### PR TITLE
According pane content display Section

### DIFF
--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
@@ -123,7 +123,6 @@ var edx = edx || {};
             if (this.template !== null) {
                 var html = this.template({proctored_exam_allowances: this.collection.toJSON()});
                 this.$el.html(html);
-                this.$el.show();
             }
         },
         showAddModal: function (event) {

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
@@ -125,7 +125,6 @@ var edx = edx || {};
                 _.extend(data, viewHelper);
                 var html = this.template(data);
                 this.$el.html(html);
-                this.$el.show();
             }
         },
         onRemoveAttempt: function (event) {

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
@@ -123,6 +123,4 @@
     <% } else { %>
         <p> No exam results found.
     <% } %>
-
-
 </div>

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
@@ -75,47 +75,50 @@
             </ul>
             <div class="clearfix"></div>
         </div>
-        <table class="exam-attempts-table">
-            <thead>
-                <tr class="exam-attempt-headings">
-                    <th class="username"><%- gettext("Username") %></th>
-                    <th class="exam-name"><%- gettext("Exam Name") %></th>
-                    <th class="attempt-allowed-time"><%- gettext("Allowed Time (Minutes)") %> </th>
-                    <th class="attempt-started-at"><%- gettext("Started At") %></th>
-                    <th class="attempt-completed-at"><%- gettext("Completed At") %> </th>
-                    <th class="attempt-status"><%- gettext("Status") %> </th>
-                    <th class="c_action"><%- gettext("Action") %> </th>
-                </tr>
-            </thead>
-            <tbody>
-                <% _.each(proctored_exam_attempts, function(proctored_exam_attempt){ %>
-                    <tr class="allowance-items">
-                        <td>
-                            <%- interpolate(gettext(' %(username)s '), { username: proctored_exam_attempt.user.username }, true) %>
-                        </td>
-                        <td>
-                            <%- interpolate(gettext(' %(exam_display_name)s '), { exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>
-                        </td>
-                        <td> <%= proctored_exam_attempt.allowed_time_limit_mins %></td>
-                        <td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>
-                        <td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>
-                         <td>
-                         <% if (proctored_exam_attempt.status){ %>
-                            <%= proctored_exam_attempt.status %>
-                        <% } else { %>
-                            N/A
-                        <% } %>
-                        </td>
-                        <td>
-                         <% if (proctored_exam_attempt.status){ %>
-                            <a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>
-                        </td>
-                        <% } else { %>
-                            N/A
-                        <% } %>
+        <% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>
+        <% if (is_proctored_attempts) { %>
+            <table class="exam-attempts-table">
+                <thead>
+                    <tr class="exam-attempt-headings">
+                        <th class="username"><%- gettext("Username") %></th>
+                        <th class="exam-name"><%- gettext("Exam Name") %></th>
+                        <th class="attempt-allowed-time"><%- gettext("Allowed Time (Minutes)") %> </th>
+                        <th class="attempt-started-at"><%- gettext("Started At") %></th>
+                        <th class="attempt-completed-at"><%- gettext("Completed At") %> </th>
+                        <th class="attempt-status"><%- gettext("Status") %> </th>
+                        <th class="c_action"><%- gettext("Action") %> </th>
                     </tr>
-                <% }); %>
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    <% _.each(proctored_exam_attempts, function(proctored_exam_attempt){ %>
+                        <tr class="allowance-items">
+                            <td>
+                                <%- interpolate(gettext(' %(username)s '), { username: proctored_exam_attempt.user.username }, true) %>
+                            </td>
+                            <td>
+                                <%- interpolate(gettext(' %(exam_display_name)s '), { exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>
+                            </td>
+                            <td> <%= proctored_exam_attempt.allowed_time_limit_mins %></td>
+                            <td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>
+                            <td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>
+                             <td>
+                             <% if (proctored_exam_attempt.status){ %>
+                                <%= proctored_exam_attempt.status %>
+                            <% } else { %>
+                                N/A
+                            <% } %>
+                            </td>
+                            <td>
+                             <% if (proctored_exam_attempt.status){ %>
+                                <a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>
+                            </td>
+                            <% } else { %>
+                                N/A
+                            <% } %>
+                        </tr>
+                    <% }); %>
+                </tbody>
+            </table>
+        <%} %>
     </section>
 </div>

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
@@ -1,82 +1,82 @@
 <div class="wrapper-content wrapper">
-    <section class="content">
-        <div class="top-header">
-            <div class='search-attempts'>
-                <input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"
-                <% if (inSearchMode) { %>
-                    value="<%= searchText %>"
-                <%} %>
-                />
-                <span class="search"><i class="fa fa-search"></i></span>
-                <span class="clear-search"><i class="fa fa-remove"></i></i></span>
-            </div>
-            <ul class="pagination">
-                <% if (!pagination_info.has_previous){ %>
-                <li class="disabled">
-                <a aria-label="Previous">
-                    <span aria-hidden="true">&laquo;</span>
-                    </a>
-                </li>
-                <% } else { %>
-                <li>
-                    <a class="target-link " data-target-url="
-                     <%- interpolate(
-                    '%(attempt_url)s?page=%(count)s ',
-                        {
-                            attempt_url: attempt_url,
-                            count: pagination_info.current_page - 1
-                        },
-                        true
-                    ) %> "
-                    href="#" aria-label="Previous">
-                    <span aria-hidden="true">&laquo;</span>
-                    </a>
-                </li>
-                <% }%>
-                <% for(var n = 1; n <= pagination_info.total_pages; n++) { %>
-                    <li>
-                        <a class="target-link <% if (pagination_info.current_page == n){ %> active <% } %>"
-                        data-target-url="
-                            <%- interpolate(
-                                '%(attempt_url)s?page=%(count)s ',
-                                    {
-                                        attempt_url: attempt_url,
-                                        count: n
-                                    },
-                                true
-                            ) %>
-                            "
-                        href="#"><%= n %>
+    <% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>
+    <% if (is_proctored_attempts) { %>
+        <section class="content">
+            <div class="top-header">
+                <div class='search-attempts'>
+                    <input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"
+                    <% if (inSearchMode) { %>
+                        value="<%= searchText %>"
+                    <%} %>
+                    />
+                    <span class="search"><i class="fa fa-search"></i></span>
+                    <span class="clear-search"><i class="fa fa-remove"></i></i></span>
+                </div>
+                <ul class="pagination">
+                    <% if (!pagination_info.has_previous){ %>
+                    <li class="disabled">
+                    <a aria-label="Previous">
+                        <span aria-hidden="true">&laquo;</span>
                         </a>
                     </li>
-                <% } %>
-                <% if (!pagination_info.has_next){ %>
-                <li class="disabled">
-                <a aria-label="Next">
-                    <span aria-hidden="true">&raquo;</span>
-                  </a>
-                </li>
-                <% } else { %>
-                <li>
-                <a class="target-link" href="#" aria-label="Next" data-target-url="
-                <%- interpolate(
-                    '%(attempt_url)s?page=%(count)s ',
-                        {
-                            attempt_url: attempt_url,
-                            count: pagination_info.current_page + 1
-                        },
-                    true
-                ) %> "
-                >
-                  <span aria-hidden="true">&raquo;</span>
-                </a>
-                </li>
-                <% }%>
-            </ul>
-            <div class="clearfix"></div>
-        </div>
-        <% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>
-        <% if (is_proctored_attempts) { %>
+                    <% } else { %>
+                    <li>
+                        <a class="target-link " data-target-url="
+                         <%- interpolate(
+                        '%(attempt_url)s?page=%(count)s ',
+                            {
+                                attempt_url: attempt_url,
+                                count: pagination_info.current_page - 1
+                            },
+                            true
+                        ) %> "
+                        href="#" aria-label="Previous">
+                        <span aria-hidden="true">&laquo;</span>
+                        </a>
+                    </li>
+                    <% }%>
+                    <% for(var n = 1; n <= pagination_info.total_pages; n++) { %>
+                        <li>
+                            <a class="target-link <% if (pagination_info.current_page == n){ %> active <% } %>"
+                            data-target-url="
+                                <%- interpolate(
+                                    '%(attempt_url)s?page=%(count)s ',
+                                        {
+                                            attempt_url: attempt_url,
+                                            count: n
+                                        },
+                                    true
+                                ) %>
+                                "
+                            href="#"><%= n %>
+                            </a>
+                        </li>
+                    <% } %>
+                    <% if (!pagination_info.has_next){ %>
+                    <li class="disabled">
+                    <a aria-label="Next">
+                        <span aria-hidden="true">&raquo;</span>
+                      </a>
+                    </li>
+                    <% } else { %>
+                    <li>
+                    <a class="target-link" href="#" aria-label="Next" data-target-url="
+                    <%- interpolate(
+                        '%(attempt_url)s?page=%(count)s ',
+                            {
+                                attempt_url: attempt_url,
+                                count: pagination_info.current_page + 1
+                            },
+                        true
+                    ) %> "
+                    >
+                      <span aria-hidden="true">&raquo;</span>
+                    </a>
+                    </li>
+                    <% }%>
+                </ul>
+                <div class="clearfix"></div>
+            </div>
             <table class="exam-attempts-table">
                 <thead>
                     <tr class="exam-attempt-headings">
@@ -119,6 +119,10 @@
                     <% }); %>
                 </tbody>
             </table>
-        <%} %>
-    </section>
+        </section>
+    <% } else { %>
+        <p> No exam results found.
+    <% } %>
+
+
 </div>


### PR DESCRIPTION
@chrisndodge Kindly review the changes.

1) expand/collapse regions of the proctoring section of Instructor Dashboard.
2) The HTTP delete works fine for me and @afzaledx . I have tried it on my local and also in the sandbox and it seems working fine. Although if we delete a single attempt listed on the page, then only the header displays on the page. I have hide the header and the search, when there is no exam attempt on the page.

Thanks