### PR TITLE
make sure we display the allowed time, not the default time to the us…

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1022,7 +1022,8 @@ def get_student_view(user_id, course_id, content_id,
     if student_view_template:
         template = loader.get_template(student_view_template)
         django_context = Context(context)
-        total_time = humanized_time(context['default_time_limit_mins'])
+        attempt_time = attempt['allowed_time_limit_mins'] if attempt else exam['time_limit_mins']
+        total_time = humanized_time(attempt_time)
         progress_page_url = ''
         try:
             progress_page_url = reverse(
@@ -1030,6 +1031,9 @@ def get_student_view(user_id, course_id, content_id,
                 args=[course_id]
             )
         except NoReverseMatch:
+            # we are allowing a failure here since we can't guarantee
+            # that we are running in-proc with the edx-platform LMS
+            # (for example unit tests)
             pass
 
         django_context.update({

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -46,7 +46,7 @@ from .utils import AuthenticatedAPIView
 
 ATTEMPTS_PER_PAGE = 25
 
-SOFTWARE_SECURE_CLIENT_TIMEOUT = 15
+SOFTWARE_SECURE_CLIENT_TIMEOUT = settings.PROCTORING_SETTINGS.get('SOFTWARE_SECURE_CLIENT_TIMEOUT', 30)
 
 LOG = logging.getLogger("edx_proctoring_views")
 


### PR DESCRIPTION
…er. Also, extend out the 'error' timeout when waiting to hear from the proctoring software