### PR TITLE
Fixed the Bug

### DIFF
--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -24,6 +24,10 @@ def get_time_remaining_for_attempt(attempt):
     Returns the remaining time (in seconds) on an attempt
     """
 
+    # returns 0 if the attempt has not been started yet.
+    if attempt['started_at'] is None:
+        return 0
+
     # need to adjust for allowances
     expires_at = attempt['started_at'] + timedelta(minutes=attempt['allowed_time_limit_mins'])
     now_utc = datetime.now(pytz.UTC)


### PR DESCRIPTION
@chrisndodge @afzaledx 

Fixed the bug when the attempt has not been started (is in ready_to_start status) and it polls for the attempt to get the remaining time on the seq_proctored_exam_instruction_page, which leads to the 500 error, when there is no start_date for the attempt.

This is related to the Pull Request https://github.com/edx/edx-proctoring/pull/89