### PR TITLE
SOL-1169

### DIFF
--- a/edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html
+++ b/edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html
@@ -12,14 +12,14 @@
     </strong>
     {% trans "As soon as you indicate that you are ready to start the exam, you will have "%} {{total_time|lower}} {% trans " to complete the exam." %}
   </p>
-  <div class="gated-sequence">
-    <a class='start-timed-exam' data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}">
+  <button class="gated-sequence start-timed-exam" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}">
+    <a>
       {% blocktrans %}
         I'm ready! Start this timed exam.
       {% endblocktrans %}
-        <i class="fa fa-arrow-circle-right"></i>
-      </a>
-  </div>
+      <i class="fa fa-arrow-circle-right"></i>
+    </a>
+  </button>
 </div>
 {% include 'proctoring/seq_timed_exam_footer.html' %}
 


### PR DESCRIPTION
@chrisndodge Kindly review the changes for SOL-1169

- There is only one anchor tag in the timed exam entrance page. 
- There is also another PR in edx-platform. Just moved the button saas inside the timed-exam div.
https://github.com/edx/edx-platform/pull/9716

