### PR TITLE
only declines should cascade downwards. If a previous ICRV failed, th…

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -643,11 +643,11 @@ def update_attempt_status(exam_id, user_id, to_status, raise_if_not_found=True, 
 
         # we just want other exams which are proctored and are not practice
         exams = [
-            exam
-            for exam in _exams
+            _exam
+            for _exam in _exams
             if (
-                exam.content_id != exam_attempt_obj.proctored_exam.content_id and
-                exam.is_proctored and not exam.is_practice_exam
+                _exam.content_id != exam_attempt_obj.proctored_exam.content_id and
+                _exam.is_proctored and not _exam.is_practice_exam
             )
         ]
 

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -194,10 +194,10 @@ class ProctoredExamStudentAttemptStatus(object):
     def is_a_cascadable_failure(cls, to_status):
         """
         Returns a boolean if the passed in to_status has a failure that needs to be cascaded
-        to other attempts.
+        to other unattempted exams.
         """
         return to_status in [
-            cls.rejected, cls.declined
+            cls.declined
         ]
 
     @classmethod

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1426,13 +1426,13 @@ class ProctoredExamApiTests(LoggedInTestCase):
             ProctoredExamStudentAttemptStatus.rejected,
             False,
             None,
-            ProctoredExamStudentAttemptStatus.declined
+            None
         ),
         (
             ProctoredExamStudentAttemptStatus.rejected,
             True,
             ProctoredExamStudentAttemptStatus.created,
-            ProctoredExamStudentAttemptStatus.declined
+            ProctoredExamStudentAttemptStatus.created
         ),
         (
             ProctoredExamStudentAttemptStatus.rejected,
@@ -1511,8 +1511,11 @@ class ProctoredExamApiTests(LoggedInTestCase):
 
         # make sure an attempt was made for second_exam
         second_exam_attempt = get_exam_attempt(second_exam_id, self.user_id)
-        self.assertIsNotNone(second_exam_attempt)
-        self.assertEqual(second_exam_attempt['status'], expected_second_status)
+        if expected_second_status:
+            self.assertIsNotNone(second_exam_attempt)
+            self.assertEqual(second_exam_attempt['status'], expected_second_status)
+        else:
+            self.assertIsNone(second_exam_attempt)
 
         # no auto-generated attempts for practice and timed exams
         self.assertIsNone(get_exam_attempt(practice_exam_id, self.user_id))


### PR DESCRIPTION
…en we should not auto-decline, but rather display the failed prerequisites to the user