### PR TITLE
PHX-159 Hide the navigation tabs/pane to end users who are in the middle of a proctored (or timed?) exams.

### DIFF
--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -77,6 +77,10 @@ var edx = edx || {};
 
             this.render();
         },
+        hideCourseNavBar: function() {
+            $(".wrapper-course-material").addClass('invisible');
+            $('.course-wrapper > .course-index').addClass('hidden');
+        },
         render: function () {
             if (this.template !== null) {
                 if (
@@ -85,6 +89,7 @@ var edx = edx || {};
                     this.model.get('attempt_status') !== 'error'
                 ) {
                     // add callback on scroll event
+                    this.hideCourseNavBar();
                     $(window).bind('scroll', this.detectScroll);
 
                     var html = this.template(this.model.toJSON());


### PR DESCRIPTION
@chrisndodge Kindly review the changes for PHX-159
- Hides the courseware navigation/pane for the end user when the exam timer bar is visible/running