### PR TITLE
SOL-1360 Timed Exams should allow learners into the exam after submission

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1264,7 +1264,7 @@ def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
     attempt = get_exam_attempt(exam_id, user_id)
 
     attempt_status = attempt['status'] if attempt else None
-
+    has_due_date = True if exam['due_date'] is not None else False
     if not attempt_status:
         if _has_due_date_passed(exam['due_date']):
             _create_and_expire_attempt(exam_id, user_id)
@@ -1279,6 +1279,11 @@ def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
     elif attempt_status == ProctoredExamStudentAttemptStatus.ready_to_submit:
         student_view_template = 'timed_exam/ready_to_submit.html'
     elif attempt_status == ProctoredExamStudentAttemptStatus.submitted:
+        # check if the exam's due_date has passed then we return None
+        # so that the user can see his exam answers in read only mode.
+        if _has_due_date_passed(exam['due_date']):
+            return None
+
         student_view_template = 'timed_exam/submitted.html'
 
     if student_view_template:
@@ -1321,6 +1326,7 @@ def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
 
         django_context.update({
             'total_time': total_time,
+            'has_due_date': has_due_date,
             'exam_id': exam_id,
             'progress_page_url': progress_page_url,
             'does_time_remain': _does_time_remain(attempt),

--- a/edx_proctoring/templates/timed_exam/submitted.html
+++ b/edx_proctoring/templates/timed_exam/submitted.html
@@ -10,5 +10,10 @@
     {% blocktrans %}
       Your grade for this timed exam will be immediately available on the <a href="{{progress_page_url}}">Progress</a> page.
     {% endblocktrans %}
+    {% if has_due_date %}
+      {% blocktrans %}
+        After the due date has passed, you can review the exam, but you cannot change your answers.
+      {% endblocktrans %}
+    {% endif %}
   </p>
 </div>

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -103,6 +103,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.start_an_exam_msg = 'This exam is proctored'
         self.exam_expired_msg = 'The due date for this exam has passed'
         self.timed_exam_msg = '{exam_name} is a Timed Exam'
+        self.submitted_timed_exam_msg_with_due_date = 'After the due date has passed,'
         self.exam_time_expired_msg = 'You did not complete the exam in the allotted time'
         self.exam_time_error_msg = 'There was a problem with your proctoring session'
         self.chose_proctored_exam_msg = 'Follow these steps to set up and start your proctored exam'
@@ -251,6 +252,18 @@ class ProctoredExamApiTests(LoggedInTestCase):
             exam_name=self.exam_name,
             time_limit_mins=self.default_time_limit,
             is_active=False
+        )
+
+    def _create_exam_attempt(self, exam_id, status='created'):
+        """
+        Creates the ProctoredExamStudentAttempt object.
+        """
+        return ProctoredExamStudentAttempt.objects.create(
+            proctored_exam_id=exam_id,
+            user_id=self.user_id,
+            external_id=self.external_id,
+            allowed_time_limit_mins=10,
+            status=status
         )
 
     def _create_unstarted_exam_attempt(self, is_proctored=True, is_practice=False):
@@ -1156,6 +1169,37 @@ class ProctoredExamApiTests(LoggedInTestCase):
             }
         )
         self.assertIsNone(rendered_response)
+
+    @ddt.data(
+        (datetime.now(pytz.UTC) + timedelta(days=1), False),
+        (datetime.now(pytz.UTC) - timedelta(days=1), True),
+    )
+    @ddt.unpack
+    def test_get_studentview_submitted_timed_exam_with_past_due_date(self, due_date, has_due_date_passed):
+        """
+        Test for get_student_view timed exam with the due date.
+        """
+
+        # exam is created with due datetime which has already passed
+        exam_id = self._create_exam_with_due_time(is_proctored=False, due_date=due_date)
+
+        # now create the timed_exam attempt in the submitted state
+        self._create_exam_attempt(exam_id, status='submitted')
+
+        rendered_response = get_student_view(
+            user_id=self.user_id,
+            course_id=self.course_id,
+            content_id=self.content_id_for_exam_with_due_date,
+            context={
+                'is_proctored': False,
+                'display_name': self.exam_name,
+                'default_time_limit_mins': 10
+            }
+        )
+        if not has_due_date_passed:
+            self.assertIn(self.submitted_timed_exam_msg_with_due_date, rendered_response)
+        else:
+            self.assertIsNone(None)
 
     @ddt.data(
         (True, False),


### PR DESCRIPTION
@afzaledx can you do the initial review.

@chrisndodge 
- alter the logic on the timed exam view to allow learners into the exam after submission
- update the message when the due date is not None and it has not been passed