### PR TITLE
set the left nav state when the attempt is in second_review_required

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1267,6 +1267,11 @@ STATUS_SUMMARY_MAP = {
         'suggested_icon': 'fa-spinner fa-spin',
         'in_completed_state': True
     },
+    ProctoredExamStudentAttemptStatus.second_review_required: {
+        'short_description': _('Pending Session Review'),
+        'suggested_icon': 'fa-spinner fa-spin',
+        'in_completed_state': True
+    },
     ProctoredExamStudentAttemptStatus.verified: {
         'short_description': _('Passed Proctoring'),
         'suggested_icon': 'fa-check',

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -2231,6 +2231,14 @@ class ProctoredExamApiTests(LoggedInTestCase):
             }
         ),
         (
+            ProctoredExamStudentAttemptStatus.second_review_required, {
+                'status': ProctoredExamStudentAttemptStatus.second_review_required,
+                'short_description': 'Pending Session Review',
+                'suggested_icon': 'fa-spinner fa-spin',
+                'in_completed_state': True
+            }
+        ),
+        (
             ProctoredExamStudentAttemptStatus.verified, {
                 'status': ProctoredExamStudentAttemptStatus.verified,
                 'short_description': 'Passed Proctoring',


### PR DESCRIPTION
@afzaledx @muhhshoaib just one small change that I neglected to make on the original "second_review_required" work. The left nav bar needs to still act like it is in "submitted" state.