### PR TITLE
Correct Django Requirement

### DIFF
--- a/local_requirements.txt
+++ b/local_requirements.txt
@@ -1,5 +1,5 @@
 # Django/Framework Packages
-django>=1.8,<1.9
+django>=1.8,<1.9a
 django-model-utils==2.3.1
 djangorestframework>=3.1,<3.2
 django-ipware==1.1.0


### PR DESCRIPTION
Django 1.9a is less than 1.9 and should not be installed as a requirement since edx-platform is running 1.8 and 1.9a has a security vulnerability in it.

@douglashall @mattdrayer @mjfrey 