### PR TITLE
Fetch correct remaining seconds from proctoring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Chris Dodge <cdodge@edx.org>
 Muhammad Shoaib <mshoaib@edx.org>
 Afzal Wali <afzal@edx.org>
+Mushtaq Ali <mushtaak@gmail.com>

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
@@ -22,7 +22,7 @@
             if (secondsLeft < 0)
                 secondsLeft = 0;
 
-            var hours = parseInt(secondsLeft / 3600) % 24;
+            var hours = parseInt(secondsLeft / 3600);
             var minutes = parseInt(secondsLeft / 60) % 60;
             var seconds = Math.floor(secondsLeft % 60);
 

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -47,7 +47,7 @@ def get_time_remaining_for_attempt(attempt):
     now_utc = datetime.now(pytz.UTC)
 
     if expires_at > now_utc:
-        time_remaining_seconds = (expires_at - now_utc).seconds
+        time_remaining_seconds = (expires_at - now_utc).total_seconds()
     else:
         time_remaining_seconds = 0
 


### PR DESCRIPTION
[TNL-4175](https://openedx.atlassian.net/browse/TNL-4175)

Correctly, fetch `time_remaining_seconds` and remove `mod` operation while formatting hours in javascript so that we may show remaining time greater that 24 hours.