### PR TITLE
Pass requesting user on delete_student_attempt

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -962,9 +962,9 @@ def send_proctoring_attempt_status_email(exam_attempt_obj, course_name):
     email.send()
 
 
-def remove_exam_attempt(attempt_id):
+def remove_exam_attempt(attempt_id, requesting_user):
     """
-    Removes an exam attempt given the attempt id.
+    Removes an exam attempt given the attempt id. requesting_user is passed through to the instructor_service.
     """
 
     log_msg = (
@@ -991,7 +991,7 @@ def remove_exam_attempt(attempt_id):
     instructor_service = get_runtime_service('instructor')
 
     if instructor_service:
-        instructor_service.delete_student_attempt(username, course_id, content_id)
+        instructor_service.delete_student_attempt(username, course_id, content_id, requesting_user=requesting_user)
 
     # see if the status transition this changes credit requirement status
     if ProctoredExamStudentAttemptStatus.needs_credit_status_update(to_status):

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -649,7 +649,7 @@ class SoftwareSecureTests(TestCase):
         )
 
         # now delete the attempt, which puts it into the archive table
-        remove_exam_attempt(attempt_id)
+        remove_exam_attempt(attempt_id, requesting_user=self.user)
 
         # now process the report
         provider.on_review_callback(json.loads(test_payload))
@@ -873,7 +873,7 @@ class SoftwareSecureTests(TestCase):
         self.assertEqual(attempt['status'], attempt['status'])
 
         # now delete the attempt, which puts it into the archive table
-        remove_exam_attempt(attempt_id)
+        remove_exam_attempt(attempt_id, requesting_user=self.user)
 
         review = ProctoredExamSoftwareSecureReview.objects.get(attempt_code=attempt['attempt_code'])
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -827,13 +827,21 @@ class ProctoredExamApiTests(LoggedInTestCase):
         Calling the api remove function removes the attempt.
         """
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
-            remove_exam_attempt(9999)
+            remove_exam_attempt(9999, requesting_user=self.user)
 
         proctored_exam_student_attempt = self._create_unstarted_exam_attempt()
-        remove_exam_attempt(proctored_exam_student_attempt.id)
+        remove_exam_attempt(proctored_exam_student_attempt.id, requesting_user=self.user)
 
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
-            remove_exam_attempt(proctored_exam_student_attempt.id)
+            remove_exam_attempt(proctored_exam_student_attempt.id, requesting_user=self.user)
+
+    def test_remove_no_user(self):
+        """
+        Attempting to remove an exam attempt without providing a requesting user will fail.
+        """
+        proctored_exam_student_attempt = self._create_unstarted_exam_attempt()
+        with self.assertRaises(UserNotFoundException):
+            remove_exam_attempt(proctored_exam_student_attempt.id, requesting_user={})
 
     @ddt.data(
         (ProctoredExamStudentAttemptStatus.verified, 'satisfied'),
@@ -868,7 +876,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
 
             # now remove exam attempt which calls the credit service method 'remove_credit_requirement_status'
-            remove_exam_attempt(exam_attempt.proctored_exam_id)
+            remove_exam_attempt(exam_attempt.proctored_exam_id, requesting_user=self.user)
 
             # make sure the credit requirement status is no longer there
             credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from edx_proctoring.services import (
     ProctoringService
 )
+from edx_proctoring.exceptions import UserNotFoundException
 from edx_proctoring import api as edx_proctoring_api
 import types
 
@@ -111,10 +112,14 @@ class MockInstructorService(object):
         """
         self.is_user_course_staff = is_user_course_staff
 
-    def delete_student_attempt(self, student_identifier, course_id, content_id):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    def delete_student_attempt(self, student_identifier, course_id, content_id, requesting_user):
         """
         Mock implementation
         """
+        # Ensure that this method was called with a real user object
+        if not hasattr(requesting_user, 'id'):
+            raise UserNotFoundException
         return True
 
     def is_course_staff(self, user, course_id):

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -464,7 +464,7 @@ class StudentProctoredExamAttempt(AuthenticatedAPIView):
                 )
                 raise StudentExamAttemptDoesNotExistsException(err_msg)
 
-            remove_exam_attempt(attempt_id)
+            remove_exam_attempt(attempt_id, request.user)
             return Response()
 
         except ProctoredBaseException, ex:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-proctoring',
-    version='0.12.13',
+    version='0.12.14',
     description='Proctoring subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
The LMS implementation that will be performing this work is being changed
to require requesting user information as part of a seperate bugfix.

See TNL-4152, ARCH-18 for details. An updated version of edx-proctoring
containing this change will need to be merged into edx-platform's
github.txt