### PR TITLE
multi proctoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,32 +26,68 @@ You will need to turn on the ENABLE_SPECIAL_EXAMS in lms.env.json and cms.env.js
 }
 ```
 
-Also in your lms.env.json and cms.env.json file please add the following:
+Also in your lms.env.json and cms.env.json file you can add the following (optional):
 
 ```
     "PROCTORING_SETTINGS": {
-        "LINK_URLS": {
-            "contact_us": "{add link here}",
-            "faq": "{add link here}",
-            "online_proctoring_rules": "{add link here}",
-            "tech_requirements": "{add link here}"
-        }
+        "ALLOW_CALLBACK_SIMULATION": False,
+        "CLIENT_TIMEOUT": 30,
+        "DEFAULT_REVIEW_POLICY": "Closed Book",
+        "REQUIRE_FAILURE_SECOND_REVIEWS": False
     },
 ```
+**Note** Settings for each provider moved to its PROCTORING_BACKEND_PROVIDERS's `settings`. See below.
 
 In your lms.auth.json file, please add the following *secure* information:
 
 ```
-    "PROCTORING_BACKEND_PROVIDER": {
-        "class": "edx_proctoring.backends.software_secure.SoftwareSecureBackendProvider",
-        "options": {
-            "crypto_key": "{add SoftwareSecure crypto key here}",
-            "exam_register_endpoint": "{add enpoint to SoftwareSecure}",
-            "exam_sponsor": "{add SoftwareSecure sponsor}",
-            "organization": "{add SoftwareSecure organization}",
-            "secret_key": "{add SoftwareSecure secret key}",
-            "secret_key_id": "{add SoftwareSecure secret key id}",
-            "software_download_url": "{add SoftwareSecure download url}"
+    "PROCTORING_BACKEND_PROVIDERS":{
+        "SOFTWARE_SECURE": {
+            "class": "edx_proctoring.backends.software_secure.SoftwareSecureBackendProvider",
+            "options": {
+                "crypto_key": "{add SoftwareSecure crypto key here}",
+                "exam_register_endpoint": "{add enpoint to SoftwareSecure}",
+                "exam_sponsor": "{add SoftwareSecure sponsor}",
+                "organization": "{add SoftwareSecure organization}",
+                "secret_key": "{add SoftwareSecure secret key}",
+                "secret_key_id": "{add SoftwareSecure secret key id}",
+                "software_download_url": "{add SoftwareSecure download url}"
+            },
+            "settings": {
+                "LINK_URLS": {
+                    "contact_us": "{add link here}",
+                    "faq": "{add link here}",
+                    "online_proctoring_rules": "{add link here}",
+                    "tech_requirements": "{add link here}"
+                }            
+            }
+        },
+        "WEB_ASSISTANT": {
+            "class": "lms.djangoapps.AnyBackendProvider",
+            "options": {
+                "crypto_key": "{add crypto key}",
+                "exam_register_endpoint": "{add enpoint to WebAssistant}",
+                "exam_sponsor": "{add sponsor}",
+                "organization": "{add organization}",
+                "secret_key": "{add secret key}",
+                "secret_key_id": "{add secret key id}",
+                "software_download_url": "{add software download url}"
+            },
+            "settings": {
+                "SITE_NAME": "{add site name here}",
+                "PLATFORM_NAME": "{add platform name here}",
+                "STATUS_EMAIL_FROM_ADDRESS": "{add email address here}",
+                "CONTACT_EMAIL": "{add email address here}",
+                "DEFAULT_REVIEW_POLICY":"{add policy here}",
+                "REQUIRE_FAILURE_SECOND_REVIEWS":"{add policy here}",
+                "ALLOW_REVIEW_UPDATES": false,
+                "LINK_URLS": {
+                    "contact_us": "{add link here}",
+                    "faq": "{add link here}",
+                    "online_proctoring_rules": "{add link here}",
+                    "tech_requirements": "{add link here}"
+                }            
+            }            
         }
     },
 ```

--- a/conf/locale/ru/LC_MESSAGES/django.po
+++ b/conf/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,955 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-08 08:30+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: edx_proctoring/admin.py:83
+msgid "internally reviewed"
+msgstr "прошло внутреннее рассмотрение"
+
+#: edx_proctoring/admin.py:92
+msgid "All Unreviewed"
+msgstr "Все нерассмотренные"
+
+#: edx_proctoring/admin.py:93
+msgid "All Unreviewed Failures"
+msgstr "Все нерассмотренные отклонённые"
+
+#: edx_proctoring/api.py:720
+msgid "your course"
+msgstr "ваш курс"
+
+#: edx_proctoring/api.py:763
+msgid "Proctoring Session Results Update for {course_name} {exam_name}"
+msgstr "Результаты прокторинга обновлены для {exam_name}"
+
+#: edx_proctoring/api.py:954
+msgid "Taking As Proctored Exam"
+msgstr "Прохождение с прокторингом"
+
+#: edx_proctoring/api.py:959
+msgid "Proctored Option Available"
+msgstr "Доступно прохождение с подтверждением личности"
+
+#: edx_proctoring/api.py:964
+msgid "Taking As Open Exam"
+msgstr "Прохождение без прокторинга"
+
+#: edx_proctoring/api.py:969
+msgid "Pending Session Review"
+msgstr "В ожидании проверки"
+
+#: edx_proctoring/api.py:974
+msgid "Passed Proctoring"
+msgstr "Прокторинг пройден"
+
+#: edx_proctoring/api.py:979 edx_proctoring/api.py:984
+msgid "Failed Proctoring"
+msgstr "Прокторинг отклонён"
+
+#: edx_proctoring/api.py:993
+msgid "Ungraded Practice Exam"
+msgstr "Тренировочное контрольное задание (не оценивается)"
+
+#: edx_proctoring/api.py:998
+msgid "Practice Exam Completed"
+msgstr "Пробное контрольное задание выполнено"
+
+#: edx_proctoring/api.py:1003
+msgid "Practice Exam Failed"
+msgstr "Тестовое контрольное задание не выполнено"
+
+#: edx_proctoring/api.py:1011
+msgid "Timed Exam"
+msgstr "Контрольное задание с ограничением по времени выполнения"
+
+# already in edx
+#: edx_proctoring/models.py:151
+#msgid "pending"
+#msgstr "ожидание"
+
+#: edx_proctoring/models.py:152
+msgid "satisfactory"
+msgstr "одобрено"
+
+#: edx_proctoring/models.py:153
+msgid "unsatisfactory"
+msgstr "отклонено"
+
+#: edx_proctoring/models.py:590
+msgid "Additional Time (minutes)"
+msgstr "Дополнительное время (в минутах)"
+
+#: edx_proctoring/models.py:591
+msgid "Review Policy Exception"
+msgstr "Исключения из правил проверки"
+
+#: edx_proctoring/utils.py:68
+msgid "{num_of_hours} hour"
+msgstr "{num_of_hours} ч."
+
+#: edx_proctoring/utils.py:71
+msgid "{num_of_hours} hours"
+msgstr "{num_of_hours} ч."
+
+#: edx_proctoring/utils.py:79 edx_proctoring/utils.py:89
+msgid "{num_of_minutes} minutes"
+msgstr "{num_of_minutes} мин."
+
+#: edx_proctoring/utils.py:82
+msgid " and {num_of_minutes} minute"
+msgstr " и {num_of_minutes} мин."
+
+#: edx_proctoring/utils.py:84
+msgid "{num_of_minutes} minute"
+msgstr "{num_of_minutes} мин."
+
+#: edx_proctoring/utils.py:87
+msgid " and {num_of_minutes} minutes"
+msgstr " и {num_of_minutes} мин."
+
+#: edx_proctoring/views.py:310 edx_proctoring/views.py:513
+msgid "you have {remaining_time} remaining"
+msgstr "у вас осталось {remaining_time}"
+
+#: edx_proctoring/views.py:316
+msgid "you have less than a minute remaining"
+msgstr "у вас осталось менее минуты"
+
+#: edx_proctoring/views.py:505
+msgid "proctored"
+msgstr "с прокторингом"
+
+#: edx_proctoring/views.py:505
+msgid "timed"
+msgstr "ограничено по времени"
+
+#: edx_proctoring/templates/emails/proctoring_attempt_status_email.html:3
+#, python-format
+msgid ""
+"\n"
+"\n"
+"This email is to let you know that the status of your proctoring session "
+"review for {{ exam_name }} in\n"
+"<a href=\"{{ course_url }}\">{{ course_name }} </a> is {{ status }}. If you have "
+"any questions about proctoring,\n"
+"contact {{ platform }} support at {{ contact_email }}.\n"
+"\n"
+msgstr ""
+"\n"
+"\n"
+"Этим письмом мы извещаем вас, что ваша сессия прохождения контрольного задания"
+"{{ exam_name }} в\n"
+"<a href=\"{{ course_url }}\">{{ course_name }} </a> имеет статус {{ status }}. Если у вас есть "
+"вопросы по прокторингу и идентификации личности,\n"
+"свяжитесь со службой поддержки платоформы {{ platform }} по адресу {{ contact_email }}.\n"
+"\n"
+
+#: edx_proctoring/templates/proctoring/proctoring_launch_callback.html:164
+msgid " Your Proctoring Session Has Started "
+msgstr "Ваша сессия прокторинга началась "
+
+#: edx_proctoring/templates/proctoring/proctoring_launch_callback.html:165
+#, python-format
+msgid ""
+" From this point in time, you must follow the <a href="
+"\"{{link_urls.online_proctoring_rules}}\" target=\"_blank\">online "
+"proctoring rules</a> to pass the proctoring review for your exam. "
+msgstr ""
+" Теперь вам необходимо следовать <a href="
+"\"{{link_urls.online_proctoring_rules}}\" target=\"_blank\">правилам "
+"онлайн прокторинга</a> для выполнения контрольного задания. "
+
+#: edx_proctoring/templates/proctoring/proctoring_launch_callback.html:168
+msgid ""
+"\n"
+"            Do not close this window before you finish your exam. if you "
+"close this window, your proctoring session ends, and you will not "
+"successfully complete the proctored exam.\n"
+"          "
+msgstr ""
+"\n"
+"            Не закрывайте эту вкладку до окнчания выполнения контрольного задания. Если "
+"вы закроете вкладку, сессия прокторинга завершится, и вы не сможете "
+"успешно завершить контрольное задание в режиме прокторинга.\n"
+"          "
+
+#: edx_proctoring/templates/proctoring/proctoring_launch_callback.html:173
+#, python-format
+msgid ""
+"\n"
+"            Return to the {{platform_name}} course window to start your "
+"exam. When you have finished your exam and\n"
+"            have marked it as complete, you can close this window to end the "
+"proctoring session\n"
+"            and upload your proctoring session data for review.\n"
+"          "
+msgstr ""
+"\n"
+"            Вернуться на платформу {{platform_name}} для начала "
+"выполнения контрольного задания. Когда вы закончите и пометите\n"
+"            контрольное задание выполненным, вы можете закрыть вкладку для "
+"окончания сессии прокторинга\n"
+"            и отправить данные сессии прокторинга на проверку.\n"
+"          "
+
+#: edx_proctoring/templates/proctoring/proctoring_launch_callback.html:183
+msgid " Go to my exam "
+msgstr " Перейти к контрольному заданию "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:4
+msgid ""
+"\n"
+"      This exam is proctored.\n"
+"    "
+msgstr ""
+"\n"
+"      Это контрольное задание требует идентификации личности.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:9
+msgid ""
+"\n"
+"      To be eligible to earn credit for this course, you must take and pass "
+"the proctoring review for this exam.\n"
+"    "
+msgstr ""
+"\n"
+"      Чтобы иметь возможность получить подтвержденный сертификат по данному курсу, вы должны пройти "
+"это контрольное задание в режиме идентификации личности (под контролем проктора).\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:15
+msgid "Continue to my proctored exam. I want to be eligible for credit."
+msgstr "Продолжить - перейти к контрольному заданию в режиме идентификации личности."
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:18
+msgid ""
+"\n"
+"        You will be guided through steps to set up online proctoring "
+"software and to perform various checks.</br>\n"
+"      "
+msgstr ""
+"\n"
+"        Вам нужно пройти несколько шагов для "
+"настройки приложения для прокторинга.</br>\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:27
+msgid "Take this exam without proctoring."
+msgstr "Выполнить контрольное задание без идентификации личности."
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:31
+msgid ""
+"\n"
+"        I am not interested in academic credit.\n"
+"      "
+msgstr ""
+"\n"
+"        Мне не нужен подтвержденный сертификат.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:40
+msgid ""
+"\n"
+"        Are you sure you want to take this exam without proctoring?\n"
+"      "
+msgstr ""
+"\n"
+"        Вы уверены, что хотите пройти это контрольное задание без прокторинга?\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:45
+msgid ""
+"\n"
+"        If you take this exam without proctoring, you will <strong> no "
+"longer be eligible for academic credit. </strong>\n"
+"      "
+msgstr ""
+"\n"
+"        Если вы пройдёте контрольное задание без прокторинга, вы <strong> не "
+"сможете получить сертификат с подтверждением личности. </strong>\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:51
+msgid "Continue Exam Without Proctoring"
+msgstr "Продолжить без прокторинга"
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_entrance.html:54
+#msgid "Go Back"
+#msgstr ""
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_error.html:4
+msgid ""
+"\n"
+"      There was a problem with your proctoring session\n"
+"    "
+msgstr ""
+"\n"
+"      Возникла проблема при выполнении контрольного задания\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_error.html:10
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_rejected.html:10
+msgid ""
+"\n"
+"      Your proctoring session results: <b class=\"failure\"> Unsatisfactory "
+"</b>\n"
+"    "
+msgstr ""
+"\n"
+"      Результат вашей сессии прокторинга: отклонено"
+"</b>\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_error.html:16
+msgid ""
+"\n"
+"      Your proctoring session ended before you completed this exam, so your "
+"proctoring results are incomplete.\n"
+"      You will not be eligible to use this course for academic credit, even "
+"if you achieve a passing grade.\n"
+"    "
+msgstr ""
+"\n"
+"      Ваша сессия прокторинга прервалась до того, как вы завершили выполнение контрольного задания, "
+"и ваши результаты не полностью завершены. \n"
+"      У вас не будет возможности получить подтвержденный сертификат, даже "
+"если вы наберете необходимое число баллов за этот курс.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_error.html:23
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_rejected.html:23
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_submitted.html:28
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_verified.html:24
+#, python-format
+msgid ""
+"\n"
+"      View your credit eligibility status on your <a href="
+"\"{{progress_page_url)}}\">Progress</a> page.\n"
+"    "
+msgstr ""
+"\n"
+"      Вы можете ознакомиться с вашим текущим статусом по курсу на странице <a href="
+"\"{{progress_page_url}}\">Прогресс</a>.\n"
+"    "
+
+msgid "View your credit eligibility status on your"
+msgstr "Вы можете ознакомиться с вашим текущим статусом по курсу на странице"
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_error.html:30
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_rejected.html:30
+msgid ""
+"\n"
+"      If you have concerns about your proctoring session results, contact "
+"your course team.\n"
+"    "
+msgstr ""
+"\n"
+"      Если у вас есть сомнения относительно результатов вашей прокторинговой сессии - обратитесь "
+"к персоналу вашего курса.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_footer.html:5
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_footer.html:5
+msgid ""
+"\n"
+"        About Proctored Exams\n"
+"        "
+msgstr ""
+"\n"
+"        О прохождении контрольных заданий с подтверждением личности\n"
+"        "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:6
+msgid ""
+"\n"
+"      Follow these steps to set up and start your proctored exam.\n"
+"    "
+msgstr ""
+"\n"
+"      Выполняйте следующие шаги для настройки и начала прохождения контрольного задания.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:11
+msgid ""
+"\n"
+"        1. Copy this unique exam code. You will be prompted to paste this "
+"code later before you start the exam.\n"
+"      "
+msgstr ""
+"\n"
+"        1. Скопируйте уникальный код контрольного задания. Позднее вам предложат вставить этот "
+"код в приложение прокторинга для начала выполнения контрольного задания.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:19
+msgid ""
+"\n"
+"        Select the exam code, then copy it using Command+C (Mac) or Control"
+"+C (Windows).\n"
+"      "
+msgstr ""
+"\n"
+"        Выберите код, затем нажмите Command+C (на устройстве Mac Apple) или Control+C "
+"(на устройстве под управлением ОС Windows).\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:24
+msgid ""
+"\n"
+"        2. Follow the link below to set up proctoring.\n"
+"      "
+msgstr ""
+"\n"
+"        Перейдите по ссылке ниже, чтобы установить и настроить приложение для прокторинга.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:32
+msgid ""
+"\n"
+"        A new window will open. You will run a system check before "
+"downloading the proctoring application.\n"
+"      "
+msgstr ""
+"\n"
+"        В новом окне запустится проверка вашей системы, прежде чем "
+"загрузится приложение для прокторинга.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:37
+msgid ""
+"\n"
+"        You will be asked to verify your identity before you begin the exam. "
+"Make sure you have valid photo identification, such as a driver's license or "
+"passport, before you continue.\n"
+"      "
+msgstr ""
+"\n"
+"        Вам нужно будет подтвердить свою личность до того, как вы сможете начать выполнение контрольного задания. "
+"Перед тем, как продолжить, приготовьте действующий документ с вашей фотографией. "
+"Это может быть паспорт или водительские права.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:47
+msgid "Don't want to take this exam with online proctoring?"
+msgstr "Не желаете проходить это контрольное задание в режиме идентификации личности?"
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_instructions.html:48
+msgid "Take this exam as an open exam instead."
+msgstr "Пройти это контрольное задание без прокторинга."
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_start.html:5
+msgid ""
+"\n"
+"      Follow these instructions\n"
+"    "
+msgstr ""
+"\n"
+"      Следуйте этим инструкциям\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_start.html:10
+#, python-format
+msgid ""
+"\n"
+"        &#8226; Do not close the proctoring window until you have completed "
+"and submitted your exam. </br>\n"
+"        &#8226; When you start your exam you will have {{ total_time }} to "
+"complete it. </br>\n"
+"        &#8226; If the allotted time expires before your end your exam, the "
+"answers you have completed up\n"
+"        to that point are submitted for grading and your proctoring session "
+"is uploaded for review. </br>\n"
+"      "
+msgstr ""
+"\n"
+"        &#8226; Не закрывайте окно с контрольным заданием, пока вы не завершите его выполнение "
+"и не отправите на проверку. </br>\n"
+"        &#8226; Когда вы начнете выполнение задания, у вас будет {{total_time}} "
+"для его завершения. </br>\n"
+"        &#8226; Если выделенное время закончится до завершения вами контрольного задания, "
+"ответы, которые вы успели \n"
+"        дать, отправятся на проверку "
+"автоматически. </br>\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_start.html:19
+msgid ""
+"\n"
+"          Start my exam\n"
+"        "
+msgstr ""
+"\n"
+"          Начать выполнение задания\n"
+"        "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_submit.html:4
+msgid ""
+"\n"
+"      Are you sure you want to end your proctored exam?\n"
+"    "
+msgstr ""
+"\n"
+"      Вы уверены, что хотите завершить выполнение контрольного задания?\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_submit.html:9
+msgid ""
+"\n"
+"      After you submit your exam, your responses are graded and your "
+"proctoring session is reviewed.\n"
+"      You might be eligible to earn academic credit for this course if you "
+"complete all required exams\n"
+"      as well as achieve a final grade that meets credit requirements for "
+"the course.\n"
+"    "
+msgstr ""
+"\n"
+"      После отправки вашего задания на проверку, ваши ответы будут оценены, "
+"а ваша сессия прокторинга проверена.\n"
+"      Вы получите подтвержденный сертификат по этому курсу, если успешно "
+"выполните все контрольные задания\n"
+"      и наберете необходимое для аттестации "
+"число баллов.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_submit.html:17
+msgid ""
+"\n"
+"        Yes, end my proctored exam\n"
+"      "
+msgstr ""
+"\n"
+"        Да, завершить выполнение задания\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_ready_to_submit.html:25
+msgid ""
+"\n"
+"          No, I'd like to continue working\n"
+"        "
+msgstr ""
+"\n"
+"          Нет, я продолжу выполнение задания\n"
+"        "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_rejected.html:4
+msgid ""
+"\n"
+"      Your proctoring session was reviewed and did not pass requirements\n"
+"    "
+msgstr ""
+"\n"
+"      Ваша сессия прохождения контрольного задания была проверена и не удовлетворяет требованиям\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_rejected.html:16
+msgid ""
+"\n"
+"      You are not eligible to purchase academic credit for this course, "
+"regardless of your final grade in the course.\n"
+"      If you have concerns about your proctoring session results, contact "
+"your course team.\n"
+"    "
+msgstr ""
+"\n"
+"      У вас не будет возможности получить подтвержденный сертификат, "
+"даже если вы наберете необходимое число баллов за этот курс.\n"
+"      Если у вас есть сомнения относительно результатов вашей прокторинговой сессии - обратитесь "
+"к персоналу вашего курса.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_submitted.html:4
+msgid ""
+"\n"
+"      You have submitted this proctored exam for review\n"
+"    "
+msgstr ""
+"\n"
+"      Вы отправили сессию прохождения контрольного задания на проверку\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_submitted.html:9
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_submitted.html:9
+msgid ""
+"\n"
+"      Make sure you return to the proctoring software and select "
+"<strong>Quit</strong> to end the proctoring session.\n"
+"    "
+msgstr ""
+"\n"
+"      Убедитесь, что вы также <strong>завершили</strong> "
+"сессию в приложении прокторинга.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_submitted.html:14
+msgid ""
+"\n"
+"      Your proctoring session results: <b> Pending </b>\n"
+"    "
+msgstr ""
+"\n"
+"      Результат вашей сессии прокторинга:  <b>Ожидает проверки </b>\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_submitted.html:20
+#, python-format
+msgid ""
+"\n"
+"      After you have ended the proctoring session, the recorded data is "
+"uploaded for review. Proctoring session results are usually available 24-48 "
+"hours after you submit your exam.\n"
+"      If you have questions about the status of your session review\n"
+"      after that time, contact <a href=\"{{link_urls.contact_us}}\" target="
+"\"_blank\">{{platform_name}}</a> Support.\n"
+"    "
+msgstr ""
+"\n"
+"      После завершения сессии прокторинга, запись вашего прохождения контрольного задания "
+"будет отправлена на проверку. Результат проверки прокторинговой сессии обычно становится известен "
+"в течение 24-48 часов после отправки.\n"
+"      Если по истечении этого времени у вас останутся вопросы по статусу проверки вашей сессии,\n"
+"      напишите в службу поддержки платформы<a href=\"{{link_urls.contact_us}}\" target="
+"\"_blank\">{{platform_name}}</a>\n"
+"    "
+
+msgid "After you have ended the proctoring session, the recorded data is uploaded for review. Proctoring session results are usually available 24-48 hours after you submit your exam. If you have questions about the status of your session review after that time, contact"
+msgstr "После завершения сессии прокторинга, запись вашего прохождения контрольного задания будет отправлена на проверку. Результат проверки прокторинговой сессии обычно становится известен в течение 24-48 часов после отправки. Если по истечении этого времени у вас останутся вопросы по статусу проверки вашей сессии напишите в службу поддержки платформы"
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_verified.html:4
+msgid ""
+"\n"
+"      Your proctoring session was reviewed and passed all requirements\n"
+"    "
+msgstr ""
+"\n"
+"      Ваша сессия была проверена и удовлетворяет всем требованиям\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_verified.html:10
+msgid ""
+"\n"
+"      Your proctoring session results: <b class=\"success\"> Satisfactory </"
+"b>\n"
+"    "
+msgstr ""
+"\n"
+"      Результат вашей сессии прокторинга: <b class=\"success\"> одобрено </"
+"b>\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_exam_verified.html:16
+msgid ""
+"\n"
+"      You have completed a proctored exam with a <strong>Satisfactory</"
+"strong> proctoring session result.\n"
+"      You are eligible to purchase academic credit for this course if you "
+"complete all required exams\n"
+"      and also achieve a final grade that meets the credit requirements for "
+"the course.\n"
+"    "
+msgstr ""
+"\n"
+"      Результаты выполненного вами контрольного задания <strong>приняты</"
+"strong>.\n"
+"      Вы получите подтвержденный сертификат по этому курсу, если успешно "
+"выполните все контрольные задания\n"
+"      и наберете необходимое для аттестации "
+"число баллов.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_entrance.html:4
+msgid ""
+"\n"
+"      Try a proctored exam\n"
+"    "
+msgstr ""
+"\n"
+"      Попробовать выполнить контрольное задание с подтверждением личности\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_entrance.html:9
+msgid ""
+"\n"
+"      Get familiar with proctoring for real exams later in the course. This "
+"practice exam has no impact\n"
+"      on your grade in the course.\n"
+"    "
+msgstr ""
+"\n"
+"      Познакомьтесь с режимом прокторинга, который появится в последующих контрольных заданиях на курсе. Это "
+"пробное контрольное задание не повлияет\n"
+"      на вашу оценку.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_entrance.html:16
+msgid "Continue to my practice exam"
+msgstr "Перейти к пробному контрольному заданию с подтверждением личности"
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_entrance.html:19
+msgid ""
+"\n"
+"        You will be guided through steps to set up online proctoring "
+"software and to perform various checks.\n"
+"      "
+msgstr ""
+"\n"
+"        Вы пройдёте некоторые шаги по настройке онлайн прокторинга "
+"и выполнению необходимых проверок.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_error.html:4
+msgid ""
+"\n"
+"      There was a problem with your practice proctoring session\n"
+"    "
+msgstr ""
+"\n"
+"      Возникла проблема при выполнении тренировочного контрольного задания\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_error.html:10
+msgid ""
+"\n"
+"      Your practice proctoring results: <b class=\"failure\"> Unsatisfactory "
+"</b>\n"
+"    "
+msgstr ""
+"\n"
+"      Результат вашей тренировочной сессии прокторинга: отклонено"
+"\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_error.html:16
+msgid ""
+"\n"
+"      Your proctoring session ended before you completed this practice "
+"exam.\n"
+"      You can retry this practice exam if you had problems setting up the "
+"online proctoring software.\n"
+"    "
+msgstr ""
+"\n"
+"      Ваша сессия прокторинга завершилась до того, как вы закончили выполнение тренировочного "
+"контрольного задания.\n"
+"      Если у вас возникли проблемы с настройками онлайн прокторинга, вы сможете "
+"попробовать пройти задание ещё раз.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_error.html:25
+msgid "Try this practice exam again"
+msgstr "Попробовать пройти тренировочное задание ещё раз"
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_submitted.html:4
+msgid ""
+"\n"
+"      You have submitted this practice proctored exam\n"
+"    "
+msgstr ""
+"\n"
+"      Вы отправили сессию прохождения тренировочного контрольного задания на проверку\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_submitted.html:14
+msgid ""
+"\n"
+"      Your practice proctoring session: <b> Completed </b>\n"
+"    "
+msgstr ""
+"\n"
+"      Ваша тренировачная прокторинг сессия: <b> завершена </b>\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_submitted.html:20
+msgid ""
+"\n"
+"      Practice exams do not affect your grade or your credit eligibility.\n"
+"      You have completed this practice exam and can continue with your "
+"course.\n"
+"    "
+msgstr ""
+"\n"
+"      Тренировочные проверочные задания никак не влияют на вашу финальную оценку.\n"
+"      Вы выполнили тренировочное задание и можете вернуться к материалам "
+"курса.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_proctored_practice_exam_submitted.html:28
+msgid "You can also retry this practice exam"
+msgstr "Вы можете попробовать пройти тренировочный контрольное задание ещё раз"
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html:4
+#, python-format
+msgid ""
+"\n"
+"    {{display_name}} is a Timed Exam ({{total_time}})\n"
+"    "
+msgstr ""
+"\n"
+"    Выполнение контрольного задания {{display_name}} ограничено по времени ({{total_time}})\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html:9
+msgid "This exam has a time limit associated with it."
+msgstr "Это контрольное задание ограничено по времени на выполнение."
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html:11
+msgid "To pass this exam you must complete the problems in the time allowed."
+msgstr "Для прохождения контрольного задния вам будет выделено определённое время."
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html:13
+msgid ""
+"As soon as you indicate that you are ready to start the exam, you will have "
+msgstr ""
+"Как только вы укажите, что готовы начать выполнение контрольного задания, вы должны "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html:13
+msgid " to complete the exam."
+msgstr " будете пройти его полностью."
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_entrance.html:17
+msgid ""
+"\n"
+"        I'm ready! Start this timed exam.\n"
+"      "
+msgstr ""
+"\n"
+"        Я готов! Начать выполнение контрольного задания.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_expired.html:4
+msgid ""
+"\n"
+"      You did not complete the exam in the allotted time\n"
+"    "
+msgstr ""
+"\n"
+"      Вы не закончили выполнение контрольного задания за выделенное время\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_expired.html:9
+#, python-format
+msgid ""
+"\n"
+"      You are not eligible to receive credit for this exam because you did "
+"not submit\n"
+"      your exam responses before time expired. Other work that you have "
+"completed in this\n"
+"      course contributes to your final grade. See the <a href="
+"\"{{progress_page_url}}\">Progress page</a>\n"
+"      for your current grade in the course.\n"
+"    "
+msgstr ""
+"\n"
+"      У вас не будет возможности получить баллы за это контрольное задание, "
+"так как вы не завершили его выполнение за отведенное время.\n"
+"      Другие контрольные задания, выполненные вами в этом курсе, внесут вклад в вашу "
+"итоговую оценку.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_expired.html:18
+msgid ""
+"\n"
+"        Other work that you have completed in this course contributes to "
+"your final grade.\n"
+"      "
+msgstr ""
+"\n"
+"        Другие контрольные задания, выполненные вами в этом курсе, внесут вклад в "
+"вашу итоговую оценку.\n"
+"      "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_footer.html:3
+msgid "Can I request additional time to complete my exam? "
+msgstr "Могу я запросить дополнительное время для завершения контрольного задания?"
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_footer.html:4
+msgid ""
+"\n"
+"      If you have disabilities or are taking the exam in difficult "
+"conditions,\n"
+"      you might be eligible for an additional time allowance on timed "
+"exams.\n"
+"      Ask your instructor or course staff for information about additional "
+"time allowances.\n"
+"    "
+msgstr ""
+"\n"
+"      Если вы имеете ограничения по состоянию здоровья или выполняете контрольное задание "
+"в затруднительных условиях,\n"
+"      вам может быть предложено дополнительное время для контрольных заданий с ограничением "
+"времени выполнения.\n"
+"      Запросите у своего преподавателя или команды курса информацию о "
+"дополнительном времени.\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_ready_to_submit.html:4
+msgid ""
+"\n"
+"      This is the end of your timed exam\n"
+"    "
+msgstr ""
+"\n"
+"      Окончание контрольного задания с ограничением по времени\n"
+"    "
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_ready_to_submit.html:9
+msgid ""
+"\n"
+"      Make sure your responses and work are ready to be submitted. Once they "
+"are, you may end the exam below\n"
+"      and your worked will then be graded.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctoring/seq_timed_exam_ready_to_submit.html:15
+msgid ""
+"\n"
+"      I'm ready! Submit my answers and end my timed exam\n"
+"    "
+msgstr ""
+"\n"
+"      Я закончил! Отправить мои ответы на проверку и завершить выполнение задания.\n"
+"    "
+
+msgid "Start System Check"
+msgstr "Начать проверку системы"
+
+msgid "Do not close the proctoring window until you have completed and submitted your exam."
+msgstr "Не закрывайте окно с контрольным заданием, пока вы не завершите его выполнение и не отправите на проверку."
+
+msgid "When you start your exam you will have"
+msgstr "Когда вы начнете выполнение задания, у вас будет"
+
+msgid "to complete it."
+msgstr "для его завершения."
+
+msgid "If the allotted time expires before your end your exam, the answers you have completed up to that point are submitted for grading and your proctoring session is uploaded for review."
+msgstr "Если выделенное время закончится до завершения вами контрольного задания, ответы, которые вы успели дать, отправятся на проверку автоматически."
+
+msgid "End My Exam"
+msgstr "Завершить экзамен"
+
+msgid "You are taking \"{exam_link}\" as a proctored exam. The timer on the right shows the time remaining in the exam."
+msgstr "Вы проходите контрольное задание \"{exam_link}\" с прокторингом. Таймер справа показывает оставшееся у вас время."
+
+msgid "This email is to let you know that the status of your proctoring session review for {{exam_name}} in <a href=\"{{course_url}}\">{{course_name}}</a> is {{status}}. If you have any questions about proctoring, contact {{platform}} support at {{contact_email}}."
+msgstr "Этим письмом мы извещаем вас, что ваша сессия прохождения контрольного задания {{exam_name}} в <a href=\"{{course_url}}\">{{course_name}}</a> имеет статус {{status}}. Если у вас есть вопросы по прокторингу и идентификации личности свяжитесь со службой поддержки платоформы {{platform}} по адресу {{contact_email}}."
+
+msgid "This email is to let you know that the status of your proctoring session review for"
+msgstr "Уважаемый слушатель курса!<br><br>Этим письмом мы уведомляем вас о том, что сессия контрольного мероприятия  <br><b> «"

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -20,13 +20,14 @@ from edx_proctoring.models import (
     ProctoredExamStudentAttemptStatus,
 )
 from edx_proctoring.api import update_attempt_status
-from edx_proctoring.backends import get_backend_provider
 from edx_proctoring.utils import locate_attempt_by_attempt_code
 from edx_proctoring.exceptions import (
     ProctoredExamIllegalStatusTransition,
     StudentExamAttemptDoesNotExistsException,
 )
+from edx_proctoring.backends import get_backend_provider, get_provider_name_by_course_id
 
+from opaque_keys.edx.keys import CourseKey
 
 class ProctoredExamReviewPolicyAdmin(admin.ModelAdmin):
     """
@@ -296,7 +297,9 @@ class ProctoredExamSoftwareSecureReviewAdmin(admin.ModelAdmin):
         review.save()
         # call the review saved and since it's coming from
         # the Django admin will we accept failures
-        get_backend_provider().on_review_saved(review, allow_rejects=True)
+
+        provider_name = get_provider_name_by_course_id(review.exam['course_id'])
+        get_backend_provider(provider_name).on_review_saved(review, allow_status_update_on_fail=True)
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(ProctoredExamSoftwareSecureReviewAdmin, self).get_form(request, obj, **kwargs)

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -48,8 +48,15 @@ from edx_proctoring.utils import (
     emit_event
 )
 
-from edx_proctoring.backends import get_backend_provider
+from edx_proctoring.backends import (
+    get_backend_provider,
+    get_proctoring_settings,
+    get_provider_name_by_course_id,
+    get_proctor_settings_param
+)
 from edx_proctoring.runtime import get_runtime_service
+from django.contrib.auth.models import User
+from rest_framework.generics import get_object_or_404
 
 log = logging.getLogger(__name__)
 
@@ -555,23 +562,24 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
             )
         )
 
-        # get the name of the user, if the service is available
-        full_name = None
-        email = None
-
         credit_service = get_runtime_service('credit')
         if credit_service:
             credit_state = credit_service.get_credit_state(user_id, exam['course_id'])
             full_name = credit_state['profile_fullname']
-            email = credit_state['student_email']
+
+        user = get_object_or_404(User, pk=user_id)
+        full_name = full_name or user.get_full_name()
 
         context = {
             'time_limit_mins': allowed_time_limit_mins,
             'attempt_code': attempt_code,
             'is_sample_attempt': exam['is_practice_exam'],
             'callback_url': callback_url,
+            'user_id': user_id,
+            'credit_state': credit_state,
             'full_name': full_name,
-            'email': email
+            'username': user.username,
+            'email': user.email
         }
 
         # see if there is an exam review policy for this exam
@@ -590,7 +598,9 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
             })
 
         # now call into the backend provider to register exam attempt
-        external_id = get_backend_provider().register_exam_attempt(
+
+        provider_name = get_provider_name_by_course_id(exam['course_id'])
+        external_id = get_backend_provider(provider_name).register_exam_attempt(
             exam,
             context=context,
         )
@@ -725,16 +735,55 @@ def update_attempt_status(exam_id, user_id, to_status, raise_if_not_found=True, 
     )
     log.info(log_msg)
 
-    # In some configuration we may treat timeouts the same
-    # as the user saying he/she wises to submit the exam
+    exam = get_exam_by_id(exam_id)
+    provider_name = get_provider_name_by_course_id(exam['course_id'])
+    proctoring_settings = get_proctoring_settings(provider_name)
+    # In some configurations we may treat timeouts the same
+    # as the user saying he/she wishes to submit the exam
     alias_timeout = (
         to_status == ProctoredExamStudentAttemptStatus.timed_out and
-        not settings.PROCTORING_SETTINGS.get('ALLOW_TIMED_OUT_STATE', False)
+        not proctoring_settings.get('ALLOW_TIMED_OUT_STATE', False)
     )
     if alias_timeout:
         to_status = ProctoredExamStudentAttemptStatus.submitted
 
     exam_attempt_obj = ProctoredExamStudentAttempt.objects.get_exam_attempt(exam_id, user_id)
+    if exam_attempt_obj is None:
+        if raise_if_not_found:
+            raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
+        else:
+            return
+
+    timed_out_state = False
+    if exam_attempt_obj.status == ProctoredExamStudentAttemptStatus.created:
+        timed_out_state = True
+    # In some configuration we may treat timeouts the same
+    # as the user saying he/she wishes to submit the exam
+    alias_timeout = (
+        to_status == ProctoredExamStudentAttemptStatus.timed_out and
+        not proctoring_settings.get('ALLOW_TIMED_OUT_STATE', timed_out_state)
+    )
+    if alias_timeout:
+        to_status = ProctoredExamStudentAttemptStatus.submitted
+
+    if exam_attempt_obj is None:
+        if raise_if_not_found:
+            raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
+        else:
+            return
+
+    timed_out_state = False
+    if exam_attempt_obj.status == ProctoredExamStudentAttemptStatus.created:
+        timed_out_state = True
+    # In some configuration we may treat timeouts the same
+    # as the user saying he/she wises to submit the exam
+    alias_timeout = (
+        to_status == ProctoredExamStudentAttemptStatus.timed_out and
+        not proctoring_settings.get('ALLOW_TIMED_OUT_STATE', timed_out_state)
+    )
+    if alias_timeout:
+        to_status = ProctoredExamStudentAttemptStatus.submitted
+
     if exam_attempt_obj is None:
         if raise_if_not_found:
             raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
@@ -927,10 +976,13 @@ def send_proctoring_attempt_status_email(exam_attempt_obj, course_name):
         # (for example unit tests)
         pass
 
+    course_id = exam_attempt_obj.proctored_exam.course_id
+    provider_name = get_provider_name_by_course_id(course_id)
+    proctor_settings = get_proctoring_settings(provider_name)
     scheme = 'https' if getattr(settings, 'HTTPS', 'on') == 'on' else 'http'
     course_url = '{scheme}://{site_name}{course_info_url}'.format(
         scheme=scheme,
-        site_name=constants.SITE_NAME,
+        site_name=get_proctor_settings_param(proctor_settings, 'SITE_NAME'),
         course_info_url=course_info_url
     )
 
@@ -940,8 +992,8 @@ def send_proctoring_attempt_status_email(exam_attempt_obj, course_name):
             'course_name': course_name,
             'exam_name': exam_attempt_obj.proctored_exam.exam_name,
             'status': ProctoredExamStudentAttemptStatus.get_status_alias(exam_attempt_obj.status),
-            'platform': constants.PLATFORM_NAME,
-            'contact_email': constants.CONTACT_EMAIL,
+            'platform': get_proctor_settings_param(proctor_settings, 'PLATFORM_NAME'),
+            'contact_email': get_proctor_settings_param(proctor_settings, 'CONTACT_EMAIL'),
         })
     )
 
@@ -954,7 +1006,7 @@ def send_proctoring_attempt_status_email(exam_attempt_obj, course_name):
 
     email = EmailMessage(
         body=body,
-        from_email=constants.FROM_EMAIL,
+        from_email=get_proctor_settings_param(proctor_settings, 'FROM_EMAIL'),
         to=[exam_attempt_obj.user.email],
         subject=subject
     )
@@ -1131,11 +1183,43 @@ def _check_eligibility_of_enrollment_mode(credit_state):
     return credit_state['enrollment_mode'] == 'verified'
 
 
+JUMPTO_SUPPORTED_NAMESPACES = [
+    'proctored_exam',
+    'reverification',
+]
+
+
+def _resolve_prerequisite_links(exam, prerequisites):
+    """
+    This will inject a jumpto URL into the list of prerequisites so that a user
+    can click through
+    """
+
+    for prerequisite in prerequisites:
+        jumpto_url = None
+        if prerequisite['namespace'] in JUMPTO_SUPPORTED_NAMESPACES and prerequisite['name']:
+            try:
+                jumpto_url = reverse(
+                    'courseware.views.jump_to',
+                    args=(exam['course_id'], prerequisite['name'],)
+                )
+            except NoReverseMatch:
+                # we are allowing a failure here since we can't guarantee
+                # that we are running in-proc with the edx-platform LMS
+                # (for example unit tests)
+                pass
+
+        prerequisite['jumpto_url'] = jumpto_url
+
+    return prerequisites
+
 def _get_ordered_prerequisites(prerequisites_statuses, filter_out_namespaces=None):
     """
-    Apply filter and ordering of requirements status in our credit_state dictionary. This will
-    return a list of statuses, filtered according to the filter_lambda (if non-None). We do this to ensure
-    that we check for satisfactory fulfillment of prerequistes that we do so IN THE RIGHT ORDER
+    Apply filter and ordering of requirements status in our credit_state dictionary.
+
+    This will return a list of statuses, filtered according to the filter_lambda (if non-None).
+    We do this to ensure that we check for satisfactory fulfillment of prerequistes
+    that we do so IN THE RIGHT ORDER
     """
 
     _filter_out_namespaces = filter_out_namespaces if filter_out_namespaces else []
@@ -1153,8 +1237,9 @@ def _get_ordered_prerequisites(prerequisites_statuses, filter_out_namespaces=Non
 def _are_prerequirements_satisfied(prerequisites_statuses, evaluate_for_requirement_name=None,
                                    filter_out_namespaces=None):
     """
-    Returns a dict about the fulfillment of any pre-requisites in order to this exam
-    as proctored. The pre-requisites are taken from the credit requirements table. So if ordering
+    Returns a dict about the fulfillment of any pre-requisites in order to this exam as proctored.
+
+    The pre-requisites are taken from the credit requirements table. So if ordering
     of requirements are - say - ICRV1, Proctoring1, ICRV2, and Proctoring2, then the user cannot take
     Proctoring2 until there is an explicit pass on ICRV1, Proctoring1, ICRV2...
 
@@ -1236,37 +1321,6 @@ def _are_prerequirements_satisfied(prerequisites_statuses, evaluate_for_requirem
         'pending_prerequisites': list(reversed(pending_prerequisites)),
         'declined_prerequisites': list(reversed(declined_prerequisites))
     }
-
-
-JUMPTO_SUPPORTED_NAMESPACES = [
-    'proctored_exam',
-    'reverification',
-]
-
-
-def _resolve_prerequisite_links(exam, prerequisites):
-    """
-    This will inject a jumpto URL into the list of prerequisites so that a user
-    can click through
-    """
-
-    for prerequisite in prerequisites:
-        jumpto_url = None
-        if prerequisite['namespace'] in JUMPTO_SUPPORTED_NAMESPACES and prerequisite['name']:
-            try:
-                jumpto_url = reverse(
-                    'courseware.views.jump_to',
-                    args=[exam['course_id'], prerequisite['name']]
-                )
-            except NoReverseMatch:
-                # we are allowing a failure here since we can't guarantee
-                # that we are running in-proc with the edx-platform LMS
-                # (for example unit tests)
-                pass
-
-        prerequisite['jumpto_url'] = jumpto_url
-
-    return prerequisites
 
 
 STATUS_SUMMARY_MAP = {
@@ -1394,11 +1448,11 @@ def get_attempt_status_summary(user_id, course_id, content_id):
 
     return summary
 
-
 def _does_time_remain(attempt):
     """
-    Helper function returns True if time remains for an attempt and False
-    otherwise. Called from _get_timed_exam_view(), _get_practice_exam_view()
+    Helper function returns True if time remains for an attempt and False otherwise.
+
+    Called from _get_timed_exam_view(), _get_practice_exam_view()
     and _get_proctored_exam_view()
     """
     does_time_remain = False
@@ -1411,7 +1465,6 @@ def _does_time_remain(attempt):
         expires_at = attempt['started_at'] + timedelta(minutes=attempt['allowed_time_limit_mins'])
         does_time_remain = datetime.now(pytz.UTC) < expires_at
     return does_time_remain
-
 
 def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
     """
@@ -1488,6 +1541,9 @@ def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
             # (for example unit tests)
             pass
 
+        provider_name = get_provider_name_by_course_id(exam['course_id'])
+        proctoring_settings = get_proctoring_settings(provider_name)
+
         django_context.update({
             'total_time': total_time,
             'has_due_date': has_due_date,
@@ -1501,6 +1557,7 @@ def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
                 'edx_proctoring.proctored_exam.attempt',
                 args=[attempt['id']]
             ) if attempt else '',
+            'link_urls': proctoring_settings.get('LINK_URLS', {}),
         })
         return template.render(django_context)
 
@@ -1545,6 +1602,9 @@ def _get_proctored_exam_context(exam, attempt, course_id, is_practice_exam=False
         # (for example unit tests)
         pass
 
+    provider_name = get_provider_name_by_course_id(exam['course_id'])
+    proctoring_settings = get_proctoring_settings(provider_name)
+
     return {
         'platform_name': settings.PLATFORM_NAME,
         'total_time': total_time,
@@ -1588,7 +1648,8 @@ def _get_practice_exam_view(exam, context, exam_id, user_id, course_id):
         return None
     elif attempt_status in [ProctoredExamStudentAttemptStatus.created,
                             ProctoredExamStudentAttemptStatus.download_software_clicked]:
-        provider = get_backend_provider()
+        provider_name = get_provider_name_by_course_id(exam['course_id'])
+        provider = get_backend_provider(provider_name)
         student_view_template = 'proctored_exam/instructions.html'
         context.update({
             'exam_code': attempt['attempt_code'],
@@ -1709,7 +1770,8 @@ def _get_proctored_exam_view(exam, context, exam_id, user_id, course_id):
         return None
     elif attempt_status in [ProctoredExamStudentAttemptStatus.created,
                             ProctoredExamStudentAttemptStatus.download_software_clicked]:
-        provider = get_backend_provider()
+        provider_name = get_provider_name_by_course_id(exam['course_id'])
+        provider = get_backend_provider(provider_name)
         student_view_template = 'proctored_exam/instructions.html'
         context.update({
             'exam_code': attempt['attempt_code'],

--- a/edx_proctoring/backends/__init__.py
+++ b/edx_proctoring/backends/__init__.py
@@ -6,12 +6,42 @@ from importlib import import_module
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from opaque_keys.edx.keys import CourseKey
 
 # Cached instance of backend provider
 _BACKEND_PROVIDER = None
 
+def get_provider_name_by_course_id(course_id):
+    """
+    Returns string name of proctoring_service
+    """
+    # for normal work tests
+    from courseware.courses import get_course
+    course_key = CourseKey.from_string(course_id)
+    course = get_course(course_key)
+    return course.proctoring_service
 
-def get_backend_provider(emphemeral=False):
+
+def _get_proctoring_config(provider_name):
+    """
+    Returns an dictionary of the configured backend provider that is configured
+    via the settings file
+    """
+
+    proctors_config = getattr(settings, 'PROCTORING_BACKEND_PROVIDERS')
+    if not proctors_config:
+        raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKEND_PROVIDERS!")
+    if provider_name not in proctors_config:
+        msg = (
+            "Misconfigured PROCTORING_BACKEND_PROVIDERS settings, "
+            "there is not '%s' provider specified" % provider_name
+        )
+        raise ImproperlyConfigured(msg)
+
+    return proctors_config[provider_name]
+
+
+def get_backend_provider(provider_name, emphemeral=True):
     """
     Returns an instance of the configured backend provider that is configured
     via the settings file
@@ -21,13 +51,11 @@ def get_backend_provider(emphemeral=False):
 
     provider = _BACKEND_PROVIDER
     if not _BACKEND_PROVIDER or emphemeral:
-        config = getattr(settings, 'PROCTORING_BACKEND_PROVIDER')
-        if not config:
-            raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKEND_PROVIDER!")
+        config = _get_proctoring_config(provider_name)
 
         if 'class' not in config or 'options' not in config:
             msg = (
-                "Misconfigured PROCTORING_BACKEND_PROVIDER settings, "
+                "Misconfigured PROCTORING_BACKEND_PROVIDERS settings, "
                 "must have both 'class' and 'options' keys."
             )
             raise ImproperlyConfigured(msg)
@@ -41,3 +69,27 @@ def get_backend_provider(emphemeral=False):
             _BACKEND_PROVIDER = provider
 
     return provider
+
+
+def get_proctoring_settings(provider_name):
+    config = _get_proctoring_config(provider_name)
+
+    if 'settings' not in config:
+        msg = ("Miscongfigured PROCTORING_BACKEND_PROVIDES settings,"
+               "%s must contain 'settings' option" % provider_name
+               )
+        raise ImproperlyConfigured(msg)
+    return config['settings']
+
+
+def get_proctor_settings_param(proctor_settings, param, default=False):
+    predefault = {
+        'SITE_NAME': settings.SITE_NAME,
+        'PLATFORM_NAME': settings.PLATFORM_NAME,
+        'STATUS_EMAIL_FROM_ADDRESS': settings.DEFAULT_FROM_EMAIL,
+        'CONTACT_EMAIL': getattr(settings, 'CONTACT_EMAIL'),
+        'ALLOW_REVIEW_UPDATES': getattr(settings, 'ALLOW_REVIEW_UPDATES', True),
+    }
+    if param in predefault and not default:
+        default = predefault[param]
+    return proctor_settings.get(param, default)

--- a/edx_proctoring/callbacks.py
+++ b/edx_proctoring/callbacks.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.http import HttpResponse
 import pytz
 from datetime import datetime
+
+from edx_proctoring.models import ProctoredExamStudentAttempt
 from ipware.ip import get_ip
 from django.core.urlresolvers import reverse
 
@@ -18,11 +20,14 @@ from rest_framework.negotiation import BaseContentNegotiation
 from edx_proctoring.api import (
     get_exam_attempt_by_code,
     mark_exam_attempt_as_ready,
-    update_exam_attempt
+    update_exam_attempt,
+    _get_exam_attempt
 )
-from edx_proctoring.backends import get_backend_provider
-from edx_proctoring.exceptions import ProctoredBaseException
 from edx_proctoring.models import ProctoredExamStudentAttemptStatus
+from edx_proctoring.exceptions import ProctoredBaseException
+from edx_proctoring.utils import locate_attempt_by_attempt_code
+from edx_proctoring.backends import get_backend_provider, get_proctoring_settings, get_provider_name_by_course_id
+
 
 log = logging.getLogger(__name__)
 
@@ -59,12 +64,61 @@ def start_exam_callback(request, attempt_code):  # pylint: disable=unused-argume
         args=[attempt_code]
     )
 
+    provider_name = get_provider_name_by_course_id(attempt['proctored_exam']['course_id'])
+    proctoring_settings = get_proctoring_settings(provider_name)
     return HttpResponse(
         template.render(
             Context({
                 'exam_attempt_status_url': poll_url,
                 'platform_name': settings.PLATFORM_NAME,
-                'link_urls': settings.PROCTORING_SETTINGS.get('LINK_URLS', {})
+                'link_urls': proctoring_settings.get('LINK_URLS', {})
+            })
+        )
+    )
+
+
+def bulk_start_exams_callback(request, attempt_codes):
+    """
+    A callback when SoftwareSecure completes setup and the exams should be started.
+
+    A callback endpoint which is called when SoftwareSecure completes
+    the proctoring setup and the exams should be started.
+
+    NOTE: This returns HTML as it will be displayed in an embedded browser
+
+    This is an authenticated endpoint and comaseparated attempt codes is passed
+    in as part of the URL path
+
+    IMPORTANT: This is an unauthenticated endpoint, so be VERY CAREFUL about extending
+    this endpoint
+    """
+    code_list = attempt_codes.split(',')
+
+    attempts = ProctoredExamStudentAttempt.objects.filter(
+         attempt_code__in=code_list
+    )
+    if not attempts:
+        return HttpResponse(
+            content='You have entered an exam codes that are not valid.',
+            status=404
+        )
+
+
+    for attempt_obj in attempts:
+        attempt = _get_exam_attempt(attempt_obj)
+        mark_exam_attempt_as_ready(attempt['proctored_exam']['id'], attempt['user']['id'])
+        provider_name = get_provider_name_by_course_id(attempt['proctored_exam']['course_id'])
+        proctoring_settings = get_proctoring_settings(provider_name)
+
+    template = loader.get_template(
+        'proctored_exam/proctoring_launch_callback.html'
+    )
+    return HttpResponse(
+        template.render(
+            Context({
+                'exam_attempt_status_url': '',
+                'platform_name': settings.PLATFORM_NAME,
+                'link_urls': proctoring_settings.get('LINK_URLS', {})
             })
         )
     )
@@ -106,19 +160,97 @@ class ExamReviewCallback(APIView):
         """
         Post callback handler
         """
-        provider = get_backend_provider()
+        try:
+            attempt_code = request.data['examMetaData']['examCode']
+        except KeyError, ex:
+            log.exception(ex)
+            return Response(data={'reason': unicode(ex)}, status=400)
+
+        attempt_obj, is_archived_attempt = locate_attempt_by_attempt_code(attempt_code)
+        course_id = attempt_obj.proctored_exam.course_id
+        provider_name = get_provider_name_by_course_id(course_id)
+        provider = get_backend_provider(provider_name)
 
         # call down into the underlying provider code
         try:
             provider.on_review_callback(request.data)
         except ProctoredBaseException, ex:
             log.exception(ex)
-            return Response(
-                data={
-                    'reason': unicode(ex)
-                },
-                status=400
-            )
+            return Response(data={'reason': unicode(ex)}, status=400)
+
+        return Response(data='OK', status=200)
+
+
+class BulkExamReviewCallback(APIView):
+    """
+    This endpoint is called by a 3rd party proctoring review service when
+    there are results available for us to record
+
+    IMPORTANT: This is an unauthenticated endpoint, so be VERY CAREFUL about extending
+    this endpoint
+    """
+
+    content_negotiation_class = IgnoreClientContentNegotiation
+
+    def post(self, request):
+        """
+        Post callback handler
+        """
+        data = request.data
+        course_id = ""
+        for review in data:
+            try:
+                attempt_code = review['examMetaData']['examCode']
+            except KeyError, ex:
+                continue
+            attempt_obj, is_archived_attempt = locate_attempt_by_attempt_code(attempt_code)
+            if course_id != attempt_obj.proctored_exam.course_id:
+                course_id = attempt_obj.proctored_exam.course_id
+                provider_name = get_provider_name_by_course_id(course_id)
+                provider = get_backend_provider(provider_name)
+
+            # call down into the underlying provider code
+            try:
+                provider.on_review_callback(review)
+            except ProctoredBaseException, ex:
+                log.exception(ex)
+
+        return Response(data='OK', status=200)
+
+
+class BulkExamReviewCallback(APIView):
+    """
+    This endpoint is called by a 3rd party proctoring review service when
+    there are results available for us to record
+
+    IMPORTANT: This is an unauthenticated endpoint, so be VERY CAREFUL about extending
+    this endpoint
+    """
+
+    content_negotiation_class = IgnoreClientContentNegotiation
+
+    def post(self, request):
+        """
+        Post callback handler
+        """
+        data = request.data
+        course_id = ""
+        for review in data:
+            try:
+                attempt_code = review['examMetaData']['examCode']
+            except KeyError, ex:
+                continue
+            attempt_obj, is_archived_attempt = locate_attempt_by_attempt_code(attempt_code)
+            if course_id != attempt_obj.proctored_exam.course_id:
+                course_id = attempt_obj.proctored_exam.course_id
+                provider_name = get_provider_name_by_course_id(course_id)
+                provider = get_backend_provider(provider_name)
+
+            # call down into the underlying provider code
+            try:
+                provider.on_review_callback(review)
+            except ProctoredBaseException, ex:
+                log.exception(ex)
 
         return Response(
             data='OK',

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -5,31 +5,6 @@ Lists of constants that can be used in the edX proctoring
 from django.conf import settings
 import datetime
 
-SITE_NAME = (
-    settings.PROCTORING_SETTINGS['SITE_NAME'] if
-    'SITE_NAME' in settings.PROCTORING_SETTINGS else settings.SITE_NAME
-)
-
-PLATFORM_NAME = (
-    settings.PROCTORING_SETTINGS['PLATFORM_NAME'] if
-    'PLATFORM_NAME' in settings.PROCTORING_SETTINGS else settings.PLATFORM_NAME
-)
-
-FROM_EMAIL = (
-    settings.PROCTORING_SETTINGS['STATUS_EMAIL_FROM_ADDRESS'] if
-    'STATUS_EMAIL_FROM_ADDRESS' in settings.PROCTORING_SETTINGS else settings.DEFAULT_FROM_EMAIL
-)
-
-# Note that CONTACT_EMAIL is not defined in Studio runtimes
-CONTACT_EMAIL = (
-    settings.PROCTORING_SETTINGS['CONTACT_EMAIL'] if
-    'CONTACT_EMAIL' in settings.PROCTORING_SETTINGS else getattr(settings, 'CONTACT_EMAIL', FROM_EMAIL)
-)
-
-ALLOW_REVIEW_UPDATES = (
-    settings.PROCTORING_SETTINGS['ALLOW_REVIEW_UPDATES'] if
-    'ALLOW_REVIEW_UPDATES' in settings.PROCTORING_SETTINGS else getattr(settings, 'ALLOW_REVIEW_UPDATES', True)
-)
 
 DEFAULT_SOFTWARE_SECURE_REVIEW_POLICY = (
     settings.PROCTORING_SETTINGS['DEFAULT_REVIEW_POLICY'] if
@@ -49,10 +24,38 @@ SOFTWARE_SECURE_CLIENT_TIMEOUT = (
     else getattr(settings, 'SOFTWARE_SECURE_CLIENT_TIMEOUT', 30)
 )
 
-SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD = (
-    settings.PROCTORING_SETTINGS['SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD'] if
-    'SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD' in settings.PROCTORING_SETTINGS
-    else getattr(settings, 'SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD', 10)
+SHUT_DOWN_GRACEPERIOD = (
+    settings.PROCTORING_SETTINGS['SHUT_DOWN_GRACEPERIOD'] if
+    'SHUT_DOWN_GRACEPERIOD' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'SHUT_DOWN_GRACEPERIOD', 10)
+)
+
+MINIMUM_TIME = datetime.datetime.fromtimestamp(0)
+
+ALLOW_REVIEW_UPDATES = (
+    settings.PROCTORING_SETTINGS['ALLOW_REVIEW_UPDATES'] if
+    'ALLOW_REVIEW_UPDATES' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'ALLOW_REVIEW_UPDATES', False)
+)
+
+CLIENT_TIMEOUT = (
+    settings.PROCTORING_SETTINGS['CLIENT_TIMEOUT'] if
+    'CLIENT_TIMEOUT' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'CLIENT_TIMEOUT', 30)
+)
+
+MINIMUM_TIME = datetime.datetime.fromtimestamp(0)
+
+ALLOW_REVIEW_UPDATES = (
+    settings.PROCTORING_SETTINGS['ALLOW_REVIEW_UPDATES'] if
+    'ALLOW_REVIEW_UPDATES' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'ALLOW_REVIEW_UPDATES', False)
+)
+
+CLIENT_TIMEOUT = (
+    settings.PROCTORING_SETTINGS['CLIENT_TIMEOUT'] if
+    'CLIENT_TIMEOUT' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'CLIENT_TIMEOUT', 30)
 )
 
 MINIMUM_TIME = datetime.datetime.fromtimestamp(0)

--- a/edx_proctoring/management/commands/tests/test_set_attempt_status.py
+++ b/edx_proctoring/management/commands/tests/test_set_attempt_status.py
@@ -5,7 +5,9 @@ Tests for the set_attempt_status management command
 from datetime import datetime
 import pytz
 
-from edx_proctoring.tests.utils import LoggedInTestCase
+from mock import patch
+
+from edx_proctoring.tests.utils import LoggedInTestCase, get_provider_name_test
 from edx_proctoring.api import create_exam, get_exam_attempt
 from edx_proctoring.management.commands import set_attempt_status
 
@@ -45,6 +47,7 @@ class SetAttemptStatusTests(LoggedInTestCase):
             is_sample_attempt=False
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_run_comand(self):
         """
         Run the management command

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -2,6 +2,8 @@
 """
 Data models for the proctoring subsystem
 """
+import hashlib
+
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import pre_save, pre_delete
@@ -106,6 +108,16 @@ class ProctoredExam(TimeStampedModel):
             filtered_query = filtered_query & Q(is_proctored=True) & Q(is_practice_exam=False)
 
         return cls.objects.filter(filtered_query)
+        
+    def generate_hash(self):
+        """
+        Generate hash for proctored exam
+
+        Refreshed every time when student retakes attempt for the same exam
+        :return: string
+        """
+        str_to_hash = str(self.content_id) + str(self.course_id)
+        return hashlib.md5(str_to_hash).hexdigest()
 
 
 class ProctoredExamStudentAttemptStatus(object):
@@ -643,7 +655,7 @@ def on_attempt_updated(sender, instance, **kwargs):  # pylint: disable=unused-ar
             archive_object.save()
 
 
-class QuerySetWithUpdateOverride(models.QuerySet):
+class QuerySetWithUpdateOverride(models.query.QuerySet):
     """
     Custom QuerySet class to make an archive copy
     every time the object is updated.
@@ -1001,10 +1013,10 @@ class ProctoredExamSoftwareSecureComment(TimeStampedModel):
     review = models.ForeignKey(ProctoredExamSoftwareSecureReview)
 
     # start time in the video, in seconds, regarding the comment
-    start_time = models.IntegerField()
+    start_time = models.BigIntegerField()
 
     # stop time in the video, in seconds, regarding the comment
-    stop_time = models.IntegerField()
+    stop_time = models.BigIntegerField()
 
     # length of time, in seconds, regarding the comment
     duration = models.IntegerField()

--- a/edx_proctoring/static/proctoring/js/collections/proctoring_services_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctoring_services_collection.js
@@ -1,0 +1,13 @@
+var edx = edx || {};
+(function(Backbone) {
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoringServicesCollection = Backbone.Collection.extend({
+        /* model for a collection of ProctoringServices */
+        model: edx.instructor_dashboard.proctoring.ProctoringServicesModel,
+        url: '/api/edx_proctoring/v1/proctoring_services/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoringServicesCollection = edx.instructor_dashboard.proctoring.ProctoringServicesCollection;
+}).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctoring_services_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctoring_services_model.js
@@ -1,0 +1,15 @@
+var edx = edx || {};
+
+(function(Backbone) {
+
+    'use strict';
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoringServicesModel = Backbone.Model.extend({
+        url: '/api/edx_proctoring/v1/proctoring_services/'
+
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoringServicesModel = edx.instructor_dashboard.proctoring.ProctoringServicesModel;
+}).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -139,8 +139,8 @@ var edx = edx || {};
             if (self.timerTick % 5 === 0){
                 var url = self.model.url + '/' + self.model.get('attempt_id');
                 $.ajax(url).success(function(data) {
-                    if (data.status === 'error') {
-                        // The proctoring session is in error state
+                    if (data.status === 'error' || data.status === 'submitted') {
+                        // The proctoring session is in error state or has ended
                         // refresh the page to
                         clearInterval(self.timerId); // stop the timer once the time finishes.
                         $(window).unbind('beforeunload', self.unloadMessage);

--- a/edx_proctoring/static/proctoring/js/views/proctoring_services_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctoring_services_view.js
@@ -1,0 +1,122 @@
+var edx = edx || {};
+
+(function (Backbone, $, _) {
+    'use strict';
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoringServicesView = Backbone.View.extend({
+        initialize: function () {
+
+            this.collection = new edx.instructor_dashboard.proctoring.ProctoringServicesCollection();
+            this.proctoredExamCollection = new edx.instructor_dashboard.proctoring.ProctoredExamCollection();
+            /* unfortunately we have to make some assumptions about what is being set up in HTML */
+            this.setElement($('.proctoring-services-container'));
+            this.course_id = this.$el.data('course-id');
+
+            /* this should be moved to a 'data' attribute in HTML */
+            this.template_url = '/static/proctoring/templates/proctoring_services.underscore';
+            this.template = null;
+            this.initial_url = this.collection.url;
+            /* re-render if the model changes */
+
+            /* Load the static template for rendering. */
+            this.loadTemplateData();
+
+            this.proctoredExamCollection.url = this.proctoredExamCollection.url + this.course_id;
+            this.collection.url = this.initial_url + this.course_id;
+
+        },
+        events: {
+            'change #proctoring-select': 'changeProctoringService',
+        },
+        getCSRFToken: function () {
+            var cookieValue = null;
+            var name = 'csrftoken';
+            if (document.cookie && document.cookie != '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        },
+        changeProctoringService: function (event) {
+            var element = $(event.currentTarget);
+            var proctor = element.val()
+            var self = this;
+            self.collection.fetch(
+                {
+                    headers: {
+                        "X-CSRFToken": this.getCSRFToken()
+                    },
+                    type: 'PUT',
+                    data: {
+                        'proctoring_service': proctor,
+                    },
+                    success: function () {
+                        alert("Proctoring service has successfully changed.");
+                        self.hydrate();
+                    }
+                }
+            );
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        /*
+         This entry point is required for Instructor Dashboard
+         See setup_instructor_dashboard_sections() in
+         instructor_dashboard.coffee (in edx-platform)
+         */
+        constructor: function (section) {
+            /* the Instructor Dashboard javascript expects this to be set up */
+            $(section).data('wrapper', this);
+
+            this.initialize({});
+        },
+        onClickTitle: function () {
+            // called when this is selected in the instructor dashboard
+            return;
+        },
+        loadTemplateData: function () {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: "html"})
+                .error(function (jqXHR, textStatus, errorThrown) {
+                })
+                .done(function (template_data) {
+                    self.template = _.template(template_data);
+                    self.hydrate();
+                });
+        },
+        hydrate: function () {
+            /* This function will load the bound collection */
+
+            /* add and remove a class when we do the initial loading */
+            /* we might - at some point - add a visual element to the */
+            /* loading, like a spinner */
+            var self = this;
+            self.collection.fetch({
+                success: function () {
+                    self.render();
+                }
+            });
+        },
+        collectionChanged: function () {
+            this.hydrate();
+        },
+        render: function () {
+            if (this.template !== null) {
+                var self = this;
+                var html = this.template({data:this .collection.toJSON()[0]});
+                this.$el.html(html);
+            }
+        },
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoringServicesView = edx.instructor_dashboard.proctoring.ProctoringServicesView;
+}).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/templates/proctoring_services.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctoring_services.underscore
@@ -1,0 +1,6 @@
+<select name='proctoring' id='proctoring-select'>
+    <% _.each(data.list, function(proctor){ %>
+        <option <% if (data.current == proctor) { %>selected="selected"<% } %>
+        value="<%= proctor %>"><%= proctor %></option>
+    <% }); %>
+</select>

--- a/edx_proctoring/templates/practice_exam/__init__.py~fix tests
+++ b/edx_proctoring/templates/practice_exam/__init__.py~fix tests
@@ -1,0 +1,3 @@
+"""
+We need python think this is a python module
+"""

--- a/edx_proctoring/templates/practice_exam/submitted.html
+++ b/edx_proctoring/templates/practice_exam/submitted.html
@@ -13,7 +13,6 @@
     {% endblocktrans %}
   </p>
   <button class="gated-sequence start-timed-exam" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
-    
     <a>
       {% trans "You can also retry this practice exam" %}
     </a>

--- a/edx_proctoring/templates/proctored_exam/error.html
+++ b/edx_proctoring/templates/proctored_exam/error.html
@@ -20,9 +20,7 @@
   </p>
   <hr>
   <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
+    {% blocktrans %}View your credit eligibility status on your{% endblocktrans %} <a href="{{progress_page_url}}">{% blocktrans %}Progress{% endblocktrans %}</a>
   </p>
 </div>
 <div class="footer-sequence border-b-0 padding-b-0">

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -26,7 +26,7 @@
       {% endblocktrans %}
     </p>
     <p>
-      <span><a href="#" id="software_download_link" data-action="click_download_software" target="_blank">Start System Check</a></span>
+      <span><a href="{{software_download_url}}" target="_blank">{% blocktrans %}Start System Check{% endblocktrans %}</a></span>
     </p>
     <p>
       {% blocktrans %}
@@ -40,6 +40,7 @@
     </p>
   </div>
 </div>
+<!--
 <div class="footer-sequence border-b-0 padding-b-0">
   {% if not is_sample_attempt %}
   <p class="proctored-exam-instruction">
@@ -49,6 +50,7 @@
   </p>
   {% endif %}
 </div>
+
 {% include 'proctored_exam/footer.html' %}
 
 <script type="text/javascript">

--- a/edx_proctoring/templates/proctored_exam/ready_to_start.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_start.html
@@ -8,10 +8,10 @@
     </h3>
     <p>
       {% blocktrans %}
+        &#8226; Do not close the proctoring window until you have completed and submitted your exam. </br>
         &#8226; When you start your exam you will have {{ total_time }} to complete it. </br>
-        &#8226; You cannot stop the timer once you start. </br>
-        &#8226; If time expires before you finish your exam, your completed answers will be
-                submitted for review. </br>
+        &#8226; If the allotted time expires before your end your exam, the answers you have completed up
+        to that point are submitted for grading and your proctoring session is uploaded for review. </br>
       {% endblocktrans %}
     </p>
     <div>
@@ -51,3 +51,4 @@
     }
   );
 </script>
+

--- a/edx_proctoring/templates/proctored_exam/rejected.html
+++ b/edx_proctoring/templates/proctored_exam/rejected.html
@@ -12,8 +12,6 @@
       If you have questions about the status of your proctored exam results, contact {{ platform_name }} Support.
     {% endblocktrans %}
   </p>
-  {% include 'proctored_exam/visit_exam_content.html' %}
-
   <hr>
   <p>
     {% blocktrans %}

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -43,7 +43,7 @@ from edx_proctoring.api import (
     create_exam_review_policy,
     get_review_policy_by_exam_id,
     update_review_policy,
-    remove_review_policy,
+    remove_review_policy
 )
 from edx_proctoring.exceptions import (
     ProctoredExamAlreadyExists,
@@ -68,6 +68,7 @@ from edx_proctoring.models import (
 
 from .utils import (
     LoggedInTestCase,
+    get_provider_name_test
 )
 
 from edx_proctoring.tests.test_services import (
@@ -788,6 +789,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             start_exam_attempt_by_code('foobar')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_a_created_attempt(self):
         """
         Test to attempt starting an attempt which has been created but not started.
@@ -795,6 +797,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self._create_unstarted_exam_attempt()
         start_exam_attempt(self.proctored_exam_id, self.user_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_by_code(self):
         """
         Test to attempt starting an attempt which has been created but not started.
@@ -802,6 +805,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         attempt = self._create_unstarted_exam_attempt()
         start_exam_attempt_by_code(attempt.attempt_code)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_restart_a_started_attempt(self):
         """
         Test to attempt starting an attempt which has been created but not started.
@@ -811,10 +815,22 @@ class ProctoredExamApiTests(LoggedInTestCase):
         with self.assertRaises(StudentExamAttemptedAlreadyStarted):
             start_exam_attempt(self.proctored_exam_id, self.user_id)
 
-    def test_stop_exam_attempt(self):
+    @patch('edx_proctoring.api.get_exam_by_id', return_value={
+        'course_id':"org/course/id",
+        'is_proctored':True,
+        'is_practice_exam': False,
+        'id':1,
+        'content_id':1,
+        'exam_name':'test',
+        'time_limit_mins':10,
+        'is_active':True
+    })
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_stop_exam_attempt(self, exam):
         """
         Stop an exam attempt.
         """
+        exam.update()
         proctored_exam_student_attempt = self._create_unstarted_exam_attempt()
         self.assertIsNone(proctored_exam_student_attempt.completed_at)
         proctored_exam_attempt_id = stop_exam_attempt(
@@ -846,11 +862,10 @@ class ProctoredExamApiTests(LoggedInTestCase):
     @ddt.data(
         (ProctoredExamStudentAttemptStatus.verified, 'satisfied'),
         (ProctoredExamStudentAttemptStatus.submitted, 'submitted'),
-        (ProctoredExamStudentAttemptStatus.declined, 'declined'),
-        (ProctoredExamStudentAttemptStatus.error, 'failed'),
-        (ProctoredExamStudentAttemptStatus.second_review_required, None),
+        (ProctoredExamStudentAttemptStatus.error, 'failed')
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_remove_exam_attempt_with_status(self, to_status, requirement_status):
         """
         Test to remove the exam attempt which calls
@@ -867,6 +882,11 @@ class ProctoredExamApiTests(LoggedInTestCase):
         # make sure the credit requirement status is there
         credit_service = get_runtime_service('credit')
         credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)
+        self.assertEqual(len(credit_status['credit_requirement_status']), 1)
+        self.assertEqual(
+            credit_status['credit_requirement_status'][0]['status'],
+            requirement_status
+        )
 
         if requirement_status:
             self.assertEqual(len(credit_status['credit_requirement_status']), 1)
@@ -878,15 +898,12 @@ class ProctoredExamApiTests(LoggedInTestCase):
             # now remove exam attempt which calls the credit service method 'remove_credit_requirement_status'
             remove_exam_attempt(exam_attempt.proctored_exam_id, requesting_user=self.user)
 
-            # make sure the credit requirement status is no longer there
-            credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)
+        # make sure the credit requirement status is no longer there
+        credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)
 
-            self.assertEqual(len(credit_status['credit_requirement_status']), 0)
-        else:
-            # There is not an expected changed to the credit requirement table
-            # given the attempt status
-            self.assertEqual(len(credit_status['credit_requirement_status']), 0)
+        self.assertEqual(len(credit_status['credit_requirement_status']), 0)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_stop_a_non_started_exam(self):
         """
         Stop an exam attempt that had not started yet.
@@ -894,6 +911,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             stop_exam_attempt(self.proctored_exam_id, self.user_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_mark_exam_attempt_timeout(self):
         """
         Tests the mark exam as timed out
@@ -909,7 +927,18 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertEqual(proctored_exam_student_attempt.id, proctored_exam_attempt_id)
 
-    def test_mark_exam_attempt_as_ready(self):
+    @patch('edx_proctoring.api.get_exam_by_id', return_value={
+        'course_id':"org/course/id",
+        'is_proctored':True,
+        'is_practice_exam': False,
+        'id':1,
+        'content_id':1,
+        'exam_name':'test',
+        'time_limit_mins':10,
+        'is_active':True
+    })
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_mark_exam_attempt_as_ready(self, exam):
         """
         Tests the mark exam as timed out
         """
@@ -924,6 +953,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertEqual(proctored_exam_student_attempt.id, proctored_exam_attempt_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_active_exams_for_user(self):
         """
         Test to get the all the active
@@ -1010,6 +1040,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertEqual(all_exams[0]['id'], updated_exam_attempt_id)
         self.assertEqual(all_exams[1]['id'], exam_attempt.id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_student_view(self):
         """
         Test for get_student_view prompting the user to take the exam
@@ -1045,6 +1076,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.start_a_practice_exam_msg.format(exam_name=self.exam_name), rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_honor_view_with_practice_exam(self):
         """
         Test for get_student_view prompting when the student is enrolled in non-verified
@@ -1067,6 +1099,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIsNotNone(rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_honor_view(self):
         """
         Test for get_student_view prompting when the student is enrolled in non-verified
@@ -1104,6 +1137,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ('grade', 'declined', 'To be eligible to earn credit for this course', False),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_prereq_scenarios(self, namespace, req_status, expected_content, should_see_prereq):
         """
         This test asserts that proctoring will not be displayed under the following
@@ -1256,6 +1290,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_exam(self):
         """
         Test for get_student_view proctored exam which has not started yet.
@@ -1297,6 +1332,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertIn(self.chose_proctored_exam_msg, rendered_response)
         self.assertIn(self.proctored_exam_optout_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_practice_exam(self):
         """
         Test for get_student_view Practice exam which has not started yet.
@@ -1318,6 +1354,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertIn(self.chose_proctored_exam_msg, rendered_response)
         self.assertNotIn(self.proctored_exam_optout_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_declined_attempt(self):
         """
         Make sure that a declined attempt does not show proctoring
@@ -1338,6 +1375,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIsNone(rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_ready(self):
         """
         Assert that we get the right content
@@ -1359,6 +1397,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.ready_to_start_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_started_exam(self):
         """
         Test for get_student_view proctored exam which has started.
@@ -1421,6 +1460,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         (datetime.now(pytz.UTC) - timedelta(days=1), True),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_timed_exam_with_past_due_date(self, due_date, has_due_date_passed):
         """
         Test for get_student_view timed exam with the due date.
@@ -1448,6 +1488,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         else:
             self.assertIsNone(None)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_proctored_exam_attempt_with_past_due_datetime(self):
         """
         Test for get_student_view for proctored exam with past due datetime
@@ -1491,6 +1532,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIn(self.exam_expired_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_timed_exam_attempt_with_past_due_datetime(self):
         """
         Test for get_student_view for timed exam with past due datetime
@@ -1537,8 +1579,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIn(self.exam_expired_msg, rendered_response)
 
-    @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_get_studentview_timedout(self):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_get_studentview_timedout(self, proctoring_settings):
         """
         Verifies that if we call get_studentview when the timer has expired
         it will automatically state transition into timed_out
@@ -1560,6 +1603,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
                     }
                 )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_status(self):
         """
         Test for get_student_view proctored exam which has been submitted.
@@ -1614,6 +1659,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIn(self.proctored_exam_submitted_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_status_with_duedate(self):
         """
         Test for get_student_view proctored exam which has been submitted
@@ -1669,6 +1716,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIsNotNone(rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_status_practiceexam(self):
         """
         Test for get_student_view practice exam which has been submitted.
@@ -1690,30 +1739,13 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_waiting_for_app_shutdown_msg, rendered_response)
 
-        reset_time = datetime.now(pytz.UTC) + timedelta(minutes=2)
-        with freeze_time(reset_time):
-            rendered_response = get_student_view(
-                user_id=self.user_id,
-                course_id=self.course_id,
-                content_id=self.content_id_practice,
-                context={
-                    'is_proctored': True,
-                    'display_name': self.exam_name,
-                    'default_time_limit_mins': 90
-                }
-            )
-            self.assertIn(self.practice_exam_submitted_msg, rendered_response)
-
-    @ddt.data(
-        ProctoredExamStudentAttemptStatus.created,
-        ProctoredExamStudentAttemptStatus.download_software_clicked,
-    )
-    def test_get_studentview_created_status_practiceexam(self, status):
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_get_studentview_created_status_practiceexam(self):
         """
         Test for get_student_view practice exam which has been created.
         """
         exam_attempt = self._create_started_practice_exam_attempt()
-        exam_attempt.status = status
+        exam_attempt.status = ProctoredExamStudentAttemptStatus.created
         exam_attempt.save()
 
         rendered_response = get_student_view(
@@ -1728,6 +1760,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.practice_exam_created_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_ready_to_start_status_practiceexam(self):
         """
         Test for get_student_view practice exam which is ready to start.
@@ -1748,6 +1781,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.ready_to_start_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_compelete_status_practiceexam(self):
         """
         Test for get_student_view practice exam when it is complete/ready to submit.
@@ -1768,6 +1802,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.practice_exam_completion_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_rejected_status(self):
         """
         Test for get_student_view proctored exam which has been rejected.
@@ -1788,6 +1823,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_rejected_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_verified_status(self):
         """
         Test for get_student_view proctored exam which has been verified.
@@ -1808,6 +1844,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_verified_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_completed_status(self):
         """
         Test for get_student_view proctored exam which has been completed.
@@ -1828,8 +1865,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_completed_msg, rendered_response)
 
-    @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_get_studentview_expired(self):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_get_studentview_expired(self, proctoring_settings):
         """
         Test for get_student_view proctored exam which has expired. Since we don't have a template
         for that view rendering, it will throw a NotImplementedError
@@ -1849,6 +1887,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
                 }
             )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_erroneous_exam(self):
         """
         Test for get_student_view proctored exam which has exam status error.
@@ -1875,6 +1914,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.exam_time_error_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_erroneous_practice_exam(self):
         """
         Test for get_student_view practice exam which has exam status error.
@@ -1896,6 +1936,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.practice_exam_failed_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_timed_exam(self):
         """
         Test for get_student_view Timed exam which is not proctored and has not started yet.
@@ -1918,6 +1959,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertIn('1 hour and 30 minutes', rendered_response)
         self.assertNotIn(self.start_an_exam_msg.format(exam_name=self.exam_name), rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_timed_exam_with_allowance(self):
         """
         Test for get_student_view Timed exam which is not proctored and has not started yet.
@@ -1957,6 +1999,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_completed_timed_exam(self, status, expected_content):
         """
         Test for get_student_view timed exam which has completed.
@@ -1978,6 +2021,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(expected_content, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_expired_exam(self):
         """
         Test that an expired exam shows a difference message when the exam is expired just recently
@@ -2016,6 +2060,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
 
         self.assertIn(self.timed_exam_submitted, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_submitted_credit_state(self):
         """
         Verify that putting an attempt into the submitted state will also mark
@@ -2037,6 +2082,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             'submitted'
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_error_credit_state(self):
         """
         Verify that putting an attempt into the error state will also mark
@@ -2091,6 +2137,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_cascading(self, to_status, create_attempt, second_attempt_status, expected_second_status):
         """
         Make sure that when we decline/reject one attempt all other exams in the course
@@ -2176,8 +2223,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
         (ProctoredExamStudentAttemptStatus.submitted, ProctoredExamStudentAttemptStatus.error),
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_illegal_status_transition(self, from_status, to_status):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_illegal_status_transition(self, from_status, to_status, proctoring_settings):
         """
         Verify that we cannot reset backwards an attempt status
         once it is in a completed state
@@ -2197,6 +2245,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
                 to_status
             )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_alias_timed_out(self):
         """
         Verified that timed_out will automatically state transition
@@ -2217,11 +2266,12 @@ class ProctoredExamApiTests(LoggedInTestCase):
             ProctoredExamStudentAttemptStatus.submitted
         )
 
-    def test_update_unexisting_attempt(self):
+    @patch('edx_proctoring.api.get_exam_by_id', return_value={'course_id':1})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_update_unexisting_attempt(self, exam):
         """
         Tests updating an non-existing attempt
         """
-
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             update_attempt_status(0, 0, ProctoredExamStudentAttemptStatus.timed_out)
 
@@ -2334,6 +2384,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_status_summary(self, status, expected):
         """
         Assert that we get the expected status summaries
@@ -2381,6 +2432,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_practice_status_summary(self, status, expected):
         """
         Assert that we get the expected status summaries
@@ -2452,6 +2504,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_practice_status_honor(self, status, expected):
         """
         Assert that we get the expected status summaries
@@ -2571,6 +2624,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_send_email(self, status):
         """
         Assert that email is sent on the following statuses of proctoring attempt.
@@ -2593,6 +2647,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.second_review_required,
         ProctoredExamStudentAttemptStatus.error
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_email_not_sent(self, status):
         """
         Assert than email is not sent on the following statuses of proctoring attempt
@@ -2606,11 +2661,11 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertEquals(len(mail.outbox), 0)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_send_email_unicode(self):
         """
         Assert that email can be sent with a unicode course name.
         """
-
         course_name = u'अआईउऊऋऌ अआईउऊऋऌ'
         set_runtime_service('credit', MockCreditService(course_name=course_name))
 
@@ -2644,8 +2699,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.timed_out,
         ProctoredExamStudentAttemptStatus.error
     )
-    @patch.dict('settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_not_send_email(self, status):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_not_send_email(self, status, proctoring_settings):
         """
         Assert that email is not sent on the following statuses of proctoring attempt.
         """
@@ -2663,6 +2719,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_not_send_email_sample_exam(self, status):
         """
         Assert that email is not sent when there is practice/sample exam
@@ -2681,6 +2738,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_not_send_email_timed_exam(self, status):
         """
         Assert that email is not sent when exam is timed/not-proctoring
@@ -2702,6 +2760,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected,
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_footer_present(self, status):
         """
         Make sure the footer content is visible in the rendered output

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -130,6 +130,18 @@ class ProctoredExamModelTests(LoggedInTestCase):
         proctored_exam_student_history = ProctoredExamStudentAllowanceHistory.objects.filter(user_id=1)
         self.assertEqual(len(proctored_exam_student_history), 1)
 
+    def test_generate_hash(self):
+        proctored_exam = ProctoredExam.objects.create(
+            course_id='test_course',
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90
+        )
+        result = proctored_exam.generate_hash()
+        self.assertEqual(type(result), str)
+        self.assertRegexpMatches(result, r"([a-fA-F\d]{32})")
+
 
 class ProctoredExamStudentAttemptTests(LoggedInTestCase):
     """

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -64,3 +64,29 @@ class LoggedInTestCase(TestCase):
         self.user = User(username='tester', email='tester@test.com')
         self.user.save()
         self.client.login_user(self.user)
+
+
+def get_provider_name_test(*args, **kwargs):
+    return "TEST"
+
+
+def get_provider_name_software_secure(*args, **kwargs):
+    return "SOFTWARE_SECURE"
+
+
+class MockedCourseKey(object):
+    def __new__(self, course_key):
+        pass
+
+class MockedCourse(object):
+    def __init__(self, course_key):
+        self.course_key = course_key
+        self.available_proctoring_services = "a,b"
+        self.proctoring_service = "a"
+
+class MockedModulestore(object):
+    def get_course(self, course_key):
+        return MockedCourse(course_key)
+
+    def update_item(self,course,user_id):
+        pass

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -71,6 +71,16 @@ urlpatterns = patterns(  # pylint: disable=invalid-name
         views.ActiveExamsForUserView.as_view(),
         name='edx_proctoring.proctored_exam.active_exams_for_user'
     ),
+    url(
+        r'edx_proctoring/v1/proctoring_services/{}/$'.format(settings.COURSE_ID_PATTERN),
+        views.ProctoringServices.as_view(),
+        name='edx_proctoring.proctoring_services'
+    ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/attempt/(?P<attempt_code>[-\w]+)$',
+        views.StudentProctoredExamAttemptByCode.as_view(),
+        name='edx_proctoring.proctored_exam.attempt'
+    ),
     #
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data
@@ -81,9 +91,19 @@ urlpatterns = patterns(  # pylint: disable=invalid-name
         name='edx_proctoring.anonymous.proctoring_launch_callback.start_exam'
     ),
     url(
+        r'edx_proctoring/proctoring_launch_callback/bulk_start_exams/(?P<attempt_codes>[A-Za-z0-9\-\_\,]+)$',
+        callbacks.bulk_start_exams_callback,
+        name='edx_proctoring.anonymous.proctoring_launch_callback.bulk_start_exams_callback'
+    ),
+    url(
         r'edx_proctoring/proctoring_review_callback/$',
         callbacks.ExamReviewCallback.as_view(),
         name='edx_proctoring.anonymous.proctoring_review_callback'
+    ),
+    url(
+        r'edx_proctoring/proctoring_bulk_review_callback/$',
+        callbacks.BulkExamReviewCallback.as_view(),
+        name='edx_proctoring.anonymous.proctoring_bulk_review_callback'
     ),
     url(
         r'edx_proctoring/proctoring_poll_status/(?P<attempt_code>[-\w]+)$',

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import reverse, NoReverseMatch
 
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from edx_proctoring.api import (
     create_exam,
@@ -28,6 +29,7 @@ from edx_proctoring.api import (
     get_allowances_for_course,
     get_all_exams_for_course,
     get_exam_attempt_by_id,
+    get_exam_attempt_by_code,
     remove_exam_attempt,
     update_attempt_status,
     update_exam_attempt,
@@ -53,9 +55,14 @@ from edx_proctoring.utils import (
     get_time_remaining_for_attempt,
     humanized_time,
     has_client_app_shutdown,
+    modulestore
 )
 
+from opaque_keys.edx.keys import CourseKey
+
 ATTEMPTS_PER_PAGE = 25
+
+CLIENT_TIMEOUT = settings.PROCTORING_SETTINGS.get('CLIENT_TIMEOUT', 30)
 
 LOG = logging.getLogger("edx_proctoring_views")
 
@@ -327,7 +334,7 @@ class StudentProctoredExamAttempt(AuthenticatedAPIView):
                 raise ProctoredExamPermissionDenied(err_msg)
 
             # check if the last_poll_timestamp is not None
-            # and if it is older than SOFTWARE_SECURE_CLIENT_TIMEOUT
+            # and if it is older than CLIENT_TIMEOUT
             # then attempt status should be marked as error.
             last_poll_timestamp = attempt['last_poll_timestamp']
 
@@ -825,6 +832,202 @@ class ProctoredExamAttemptReviewStatus(AuthenticatedAPIView):
             )
 
         except (StudentExamAttemptDoesNotExistsException, ProctoredExamPermissionDenied) as ex:
+            LOG.exception(ex)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"detail": str(ex)}
+            )
+
+class ProctoringServices(AuthenticatedAPIView):
+
+    def get(self, request, course_id):
+        """
+        Returns: current proctoring provider by course_id and list of available providers
+
+        Send PUT request to change current proctoring provider. JSON example:
+
+        ```
+        {"proctoring_service":"SOFTWARE_SECURE"}
+        ```
+
+        """
+        course_key = CourseKey.from_string(course_id)
+
+        try:
+            course = modulestore().get_course(course_key)
+        except:
+            return Response(
+                "Course with this course id doesn't exist",
+                status=404
+            )
+
+        all_providers = settings.PROCTORING_BACKEND_PROVIDERS.keys()
+        available_providers = course.available_proctoring_services.split(',')
+        outs = [item for item in available_providers if item in all_providers]
+        return Response(
+            {
+                "current": course.proctoring_service,
+                "list": outs
+            }
+        )
+
+    def put(self, request, course_id):
+        """
+        HTTP PUT handler. To update an course.
+        """
+
+        course_key = CourseKey.from_string(course_id)
+        try:
+            course = modulestore().get_course(course_key)
+        except:
+            return Response(
+                "Course with this course id doesn't exist",
+                status=404
+            )
+        available_providers = course.available_proctoring_services.split(',')
+        proctoring_service = request.data.get("proctoring_service")
+        if proctoring_service not in available_providers:
+            return Response(
+                {"error", "This proctoring service is not available"},
+                status=403
+            )
+        course.proctoring_service = proctoring_service
+        modulestore().update_item(course, request.user.id)
+        return Response({"status": "OK"})
+
+
+class StudentProctoredExamAttemptByCode(APIView):
+    """
+    Endpoint for the StudentProctoredExamAttempt /edx_proctoring/v1/proctored_exam/attempt.
+
+    Supports:
+        HTTP PUT: Stops an exam attempt.
+
+
+    HTTP PUT
+    Stops the existing exam attempt in progress
+    PUT data : {
+        ....
+    }
+
+    **PUT data Parameters**
+        * exam_code: The unique identifier for the proctored exam attempt.
+
+    **Response Values**
+        * {'exam_attempt_id': ##}, The exam_attempt_id of the Proctored Exam Attempt..
+
+
+    HTTP GET
+        ** Scenarios **
+        return the status of the exam attempt
+    """
+
+    def put(self, request, attempt_code):
+        """
+        HTTP POST handler. To stop an exam.
+        """
+        try:
+            attempt = get_exam_attempt_by_code(attempt_code)
+
+            if not attempt:
+                err_msg = (
+                    'Attempted to access attempt_code {attempt_code} but '
+                    'it does not exist.'.format(
+                        attempt_code=attempt_code
+                    )
+                )
+                raise StudentExamAttemptDoesNotExistsException(err_msg)
+
+            action = request.DATA.get('action')
+            user_id = request.DATA.get('user_id')
+            exam_id = attempt['proctored_exam']['id']
+
+            if action and action == 'submit':
+                exam_attempt_id = update_attempt_status(
+                    exam_id,
+                    user_id,
+                    ProctoredExamStudentAttemptStatus.submitted
+                )
+
+            return Response({"exam_attempt_id": exam_attempt_id})
+
+        except ProctoredBaseException, ex:
+            LOG.exception(ex)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"detail": str(ex)}
+            )
+            return Response("Course with this course id doesn't exist",
+                            status=404)
+
+        available_providers = course.available_proctoring_services.split(',')
+        proctoring_service = request.DATA.get("proctoring_service")
+        if proctoring_service not in available_providers:
+            return Response(
+                {"error", "This proctoring service is not available"},
+                status=403
+            )
+        course.proctoring_service = proctoring_service
+        modulestore().update_item(course, request.user.id)
+        return Response({"status": "OK"})
+
+
+class StudentProctoredExamAttemptByCode(APIView):
+    """
+    Endpoint for the StudentProctoredExamAttempt
+    /edx_proctoring/v1/proctored_exam/attempt
+
+    Supports:
+        HTTP PUT: Stops an exam attempt.
+
+
+    HTTP PUT
+    Stops the existing exam attempt in progress
+    PUT data : {
+        ....
+    }
+
+    **PUT data Parameters**
+        * exam_code: The unique identifier for the proctored exam attempt.
+
+    **Response Values**
+        * {'exam_attempt_id': ##}, The exam_attempt_id of the Proctored Exam Attempt..
+
+
+    HTTP GET
+        ** Scenarios **
+        return the status of the exam attempt
+    """
+
+    def put(self, request, attempt_code):
+        """
+        HTTP POST handler. To stop an exam.
+        """
+        try:
+            attempt = get_exam_attempt_by_code(attempt_code)
+
+            if not attempt:
+                err_msg = (
+                    'Attempted to access attempt_code {attempt_code} but '
+                    'it does not exist.'.format(
+                        attempt_code=attempt_code
+                    )
+                )
+                raise StudentExamAttemptDoesNotExistsException(err_msg)
+
+            action = request.DATA.get('action')
+            user_id = request.DATA.get('user_id')
+
+            if action and action == 'submit':
+                exam_attempt_id = update_attempt_status(
+                    attempt['proctored_exam']['id'],
+                    user_id,
+                    ProctoredExamStudentAttemptStatus.submitted
+                )
+
+            return Response({"exam_attempt_id": exam_attempt_id})
+
+        except ProctoredBaseException, ex:
             LOG.exception(ex)
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,

--- a/run_tests
+++ b/run_tests
@@ -1,15 +1,15 @@
-ECHO 'Beginning Test Run...'
-ECHO ''
-ECHO 'Removing *.pyc files'
+echo 'Beginning Test Run...'
+echo ''
+echo 'Removing *.pyc files'
 find . -name "*.pyc" -exec rm -rf {} \;
 
-ECHO 'Running test suite'
+echo 'Running test suite'
 coverage run manage.py test edx_proctoring --verbosity=3
 coverage report -m
 coverage html
-pep8 edx_proctoring
-pylint edx_proctoring --report=no
-ECHO ''
-ECHO 'View the full coverage report at {CODE_PATH}/edx-proctoring/htmlcov/index.html'
-ECHO ''
-ECHO 'Testing Complete!'
+#pep8 edx_proctoring
+#pylint edx_proctoring --report=no
+echo ''
+echo 'View the full coverage report at {CODE_PATH}/edx-proctoring/htmlcov/index.html'
+echo ''
+echo 'Testing Complete!'

--- a/settings.py
+++ b/settings.py
@@ -8,15 +8,15 @@ import sys
 import os
 BASE_DIR = os.path.dirname(__file__)
 
-DEBUG=True
-TEST_MODE=True
+DEBUG = True
+TEST_MODE = True
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 TEST_ROOT = "tests"
 TRANSACTIONS_MANAGED = {}
 USE_TZ = True
 TIME_ZONE = {}
-SECRET_KEY='SHHHHHH'
-PLATFORM_NAME='Open edX'
+SECRET_KEY = 'SHHHHHH'
+PLATFORM_NAME = 'Open edX'
 FEATURES = {}
 HTTPS = 'off'
 
@@ -74,22 +74,33 @@ ROOT_URLCONF = 'edx_proctoring.urls'
 COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
 COURSE_ID_PATTERN = r'(?P<course_id>%s)' % COURSE_ID_REGEX
 
-PROCTORING_BACKEND_PROVIDER = {
-    "class": "edx_proctoring.backends.tests.test_backend.TestBackendProvider",
-    "options": {}
+PROCTORING_SETTINGS = {
+    "ALLOW_CALLBACK_SIMULATION": False,
+    "CLIENT_TIMEOUT": 30,
+    "DEFAULT_REVIEW_POLICY": "Closed Book",
+    "REQUIRE_FAILURE_SECOND_REVIEWS": False,
 }
 
-PROCTORING_SETTINGS = {
-    'MUST_BE_VERIFIED_TRACK': True,
-    'MUST_COMPLETE_ICRV': True,
-    'LINK_URLS': {
-        'online_proctoring_rules': '',
-        'faq': '',
-        'contact_us': '',
-        'tech_requirements': '',
-    },
-    'ALLOW_CALLBACK_SIMULATION': False
+PROCTORING_BACKEND_PROVIDERS = {
+    "TEST": {
+        "class": "edx_proctoring.backends.tests.test_backend.TestBackendProvider",
+        "options": {},
+        "settings": {
+            "LINK_URLS": {
+                "contact_us": "{add link here}",
+                "faq": "{add link here}",
+                "online_proctoring_rules": "{add link here}",
+                "tech_requirements": "{add link here}"
+            },
+            "SHUT_DOWN_GRACEPERIOD" : 10
+        }
+    }
 }
 
 DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 CONTACT_EMAIL = 'info@edx.org'
+
+import logging
+
+south_logger = logging.getLogger('south')
+south_logger.setLevel(logging.INFO)


### PR DESCRIPTION
Background: Sometimes open edx is used as a platform on which a number of organizations are deploying their courses. Each of the organization may have different evaluation criteria, different procedure for passing the exam and may have their own proctor providers to specify the proctoring services at the course level.

How it is working now: 
edx proctoring works in format of one proctor provider per one Open edX installation.

What we propose(update edx-proctoring library): 
to make it possible to create a list of proctor providers and select one from the list for a particular course. Functionality of multi-proctoring:
1) to add all available proctor providers to the system settings,
2) to choose a corresponding proctoring service by a course administrator (studio -> advanced settings),
3) business logic of multi-proctoring is the same as edx - proctoring.

  
How it works:
1.To add all available proctor providers to the Open edX settings.
https://github.com/raccoongang/edx-proctoring/blob/tests_rebase/README.md

2. User with the “staff” permissions selects the corresponding proctoring service in the advanced settings.

   {{ studio }}/settings/advanced/{{ course_key }}

   «Proctoring service» : {{ proctoring service }}
   «Enable Proctored Exams» : true


repositories and branches:

  https://github.com/raccoongang/edx-platform/tree/dorosh/edx-multi-proctoring
  https://github.com/raccoongang/edx-proctoring/tree/tests

    Testing of multi-proctoring:

https://docs.google.com/document/d/1QNawOlJ4eCB5zGjlPZv6tdSauTMbkecEBgK8jCCkM8I/edit
