### PR TITLE
multi proctoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,32 +26,68 @@ You will need to turn on the ENABLE_SPECIAL_EXAMS in lms.env.json and cms.env.js
 }
 ```
 
-Also in your lms.env.json and cms.env.json file please add the following:
+Also in your lms.env.json and cms.env.json file you can add the following (optional):
 
 ```
     "PROCTORING_SETTINGS": {
-        "LINK_URLS": {
-            "contact_us": "{add link here}",
-            "faq": "{add link here}",
-            "online_proctoring_rules": "{add link here}",
-            "tech_requirements": "{add link here}"
-        }
+        "ALLOW_CALLBACK_SIMULATION": False,
+        "CLIENT_TIMEOUT": 30,
+        "DEFAULT_REVIEW_POLICY": "Closed Book",
+        "REQUIRE_FAILURE_SECOND_REVIEWS": False
     },
 ```
+**Note** Settings for each provider moved to its PROCTORING_BACKEND_PROVIDERS's `settings`. See below.
 
 In your lms.auth.json file, please add the following *secure* information:
 
 ```
-    "PROCTORING_BACKEND_PROVIDER": {
-        "class": "edx_proctoring.backends.software_secure.SoftwareSecureBackendProvider",
-        "options": {
-            "crypto_key": "{add SoftwareSecure crypto key here}",
-            "exam_register_endpoint": "{add enpoint to SoftwareSecure}",
-            "exam_sponsor": "{add SoftwareSecure sponsor}",
-            "organization": "{add SoftwareSecure organization}",
-            "secret_key": "{add SoftwareSecure secret key}",
-            "secret_key_id": "{add SoftwareSecure secret key id}",
-            "software_download_url": "{add SoftwareSecure download url}"
+    "PROCTORING_BACKEND_PROVIDERS":{
+        "SOFTWARE_SECURE": {
+            "class": "edx_proctoring.backends.software_secure.SoftwareSecureBackendProvider",
+            "options": {
+                "crypto_key": "{add SoftwareSecure crypto key here}",
+                "exam_register_endpoint": "{add enpoint to SoftwareSecure}",
+                "exam_sponsor": "{add SoftwareSecure sponsor}",
+                "organization": "{add SoftwareSecure organization}",
+                "secret_key": "{add SoftwareSecure secret key}",
+                "secret_key_id": "{add SoftwareSecure secret key id}",
+                "software_download_url": "{add SoftwareSecure download url}"
+            },
+            "settings": {
+                "LINK_URLS": {
+                    "contact_us": "{add link here}",
+                    "faq": "{add link here}",
+                    "online_proctoring_rules": "{add link here}",
+                    "tech_requirements": "{add link here}"
+                }            
+            }
+        },
+        "WEB_ASSISTANT": {
+            "class": "lms.djangoapps.AnyBackendProvider",
+            "options": {
+                "crypto_key": "{add crypto key}",
+                "exam_register_endpoint": "{add enpoint to WebAssistant}",
+                "exam_sponsor": "{add sponsor}",
+                "organization": "{add organization}",
+                "secret_key": "{add secret key}",
+                "secret_key_id": "{add secret key id}",
+                "software_download_url": "{add software download url}"
+            },
+            "settings": {
+                "SITE_NAME": "{add site name here}",
+                "PLATFORM_NAME": "{add platform name here}",
+                "STATUS_EMAIL_FROM_ADDRESS": "{add email address here}",
+                "CONTACT_EMAIL": "{add email address here}",
+                "DEFAULT_REVIEW_POLICY":"{add policy here}",
+                "REQUIRE_FAILURE_SECOND_REVIEWS":"{add policy here}",
+                "ALLOW_REVIEW_UPDATES": false,
+                "LINK_URLS": {
+                    "contact_us": "{add link here}",
+                    "faq": "{add link here}",
+                    "online_proctoring_rules": "{add link here}",
+                    "tech_requirements": "{add link here}"
+                }            
+            }            
         }
     },
 ```

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -20,12 +20,12 @@ from edx_proctoring.models import (
     ProctoredExamStudentAttemptStatus,
 )
 from edx_proctoring.api import update_attempt_status
-from edx_proctoring.backends import get_backend_provider
 from edx_proctoring.utils import locate_attempt_by_attempt_code
 from edx_proctoring.exceptions import (
     ProctoredExamIllegalStatusTransition,
     StudentExamAttemptDoesNotExistsException,
 )
+from edx_proctoring.backends import get_backend_provider, get_provider_name_by_course_id
 
 
 class ProctoredExamReviewPolicyAdmin(admin.ModelAdmin):
@@ -296,7 +296,9 @@ class ProctoredExamSoftwareSecureReviewAdmin(admin.ModelAdmin):
         review.save()
         # call the review saved and since it's coming from
         # the Django admin will we accept failures
-        get_backend_provider().on_review_saved(review, allow_rejects=True)
+
+        provider_name = get_provider_name_by_course_id(review.exam['course_id'])
+        get_backend_provider(provider_name).on_review_saved(review, allow_status_update_on_fail=True)
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(ProctoredExamSoftwareSecureReviewAdmin, self).get_form(request, obj, **kwargs)

--- a/edx_proctoring/backends/__init__.py
+++ b/edx_proctoring/backends/__init__.py
@@ -6,12 +6,43 @@ from importlib import import_module
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from opaque_keys.edx.keys import CourseKey
 
 # Cached instance of backend provider
 _BACKEND_PROVIDER = None
 
 
-def get_backend_provider(emphemeral=False):
+def get_provider_name_by_course_id(course_id):
+    """
+    Returns string name of proctoring_service
+    """
+    # for normal work tests
+    from courseware.courses import get_course  # pylint: disable=import-error
+    course_key = CourseKey.from_string(course_id)
+    course = get_course(course_key)
+    return course.proctoring_service
+
+
+def _get_proctoring_config(provider_name):
+    """
+    Returns an dictionary of the configured backend provider that is configured
+    via the settings file
+    """
+
+    proctors_config = getattr(settings, 'PROCTORING_BACKEND_PROVIDERS')
+    if not proctors_config:
+        raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKEND_PROVIDERS!")
+    if provider_name not in proctors_config:
+        msg = (
+            "Misconfigured PROCTORING_BACKEND_PROVIDERS settings, "
+            "there is not '%s' provider specified" % provider_name
+        )
+        raise ImproperlyConfigured(msg)
+
+    return proctors_config[provider_name]
+
+
+def get_backend_provider(provider_name, emphemeral=True):
     """
     Returns an instance of the configured backend provider that is configured
     via the settings file
@@ -21,13 +52,11 @@ def get_backend_provider(emphemeral=False):
 
     provider = _BACKEND_PROVIDER
     if not _BACKEND_PROVIDER or emphemeral:
-        config = getattr(settings, 'PROCTORING_BACKEND_PROVIDER')
-        if not config:
-            raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKEND_PROVIDER!")
+        config = _get_proctoring_config(provider_name)
 
         if 'class' not in config or 'options' not in config:
             msg = (
-                "Misconfigured PROCTORING_BACKEND_PROVIDER settings, "
+                "Misconfigured PROCTORING_BACKEND_PROVIDERS settings, "
                 "must have both 'class' and 'options' keys."
             )
             raise ImproperlyConfigured(msg)
@@ -41,3 +70,36 @@ def get_backend_provider(emphemeral=False):
             _BACKEND_PROVIDER = provider
 
     return provider
+
+
+def get_proctoring_settings(provider_name):
+    """
+    Returns an settings from the configured backend provider.
+    """
+
+    config = _get_proctoring_config(provider_name)
+
+    if 'settings' not in config:
+        msg = (
+            "Miscongfigured PROCTORING_BACKEND_PROVIDES settings,"
+            "%s must contain 'settings' option" % provider_name
+        )
+        raise ImproperlyConfigured(msg)
+    return config['settings']
+
+
+def get_proctor_settings_param(proctor_settings, param, default=False):
+    """
+    Returns an param from the proctor_settings.
+    """
+
+    predefault = {
+        'SITE_NAME': settings.SITE_NAME,
+        'PLATFORM_NAME': settings.PLATFORM_NAME,
+        'STATUS_EMAIL_FROM_ADDRESS': settings.DEFAULT_FROM_EMAIL,
+        'CONTACT_EMAIL': getattr(settings, 'CONTACT_EMAIL'),
+        'ALLOW_REVIEW_UPDATES': getattr(settings, 'ALLOW_REVIEW_UPDATES', True),
+    }
+    if param in predefault and not default:
+        default = predefault[param]
+    return proctor_settings.get(param, default)

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -1,10 +1,13 @@
 """
 Tests for backend.py
 """
-
 from django.test import TestCase
+from django.conf import settings
+
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.backends.null import NullBackendProvider
+from edx_proctoring.exceptions import ProctoredExamSuspiciousLookup
+from edx_proctoring.utils import locate_attempt_by_attempt_code
 
 
 class TestBackendProvider(ProctoringBackendProvider):
@@ -43,6 +46,25 @@ class TestBackendProvider(ProctoringBackendProvider):
         """
         Called when the reviewing 3rd party service posts back the results
         """
+        external_id = payload['examMetaData']['ssiRecordLocator']
+        attempt_code = payload['examMetaData']['examCode']
+
+        attempt_obj = locate_attempt_by_attempt_code(attempt_code)
+        match = (
+            attempt_obj[0].external_id.lower() == external_id.lower() or
+            settings.PROCTORING_SETTINGS.get('ALLOW_CALLBACK_SIMULATION', False)
+        )
+        if not match:
+            err_msg = (
+                'Found attempt_code {attempt_code}, but the recorded external_id did not '
+                'match the ssiRecordLocator that had been recorded previously. Has {existing} '
+                'but received {received}!'.format(
+                    attempt_code=attempt_code,
+                    existing=attempt_obj[0].external_id,
+                    received=external_id
+                )
+            )
+            raise ProctoredExamSuspiciousLookup(err_msg)
 
     def on_review_saved(self, review):
         """

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -48,6 +48,10 @@ from edx_proctoring.backends.tests.test_review_payload import (
 from edx_proctoring.tests.test_services import MockCreditService
 from edx_proctoring.backends.software_secure import SOFTWARE_SECURE_INVALID_CHARS
 
+from edx_proctoring.tests.utils import (
+    get_provider_name_software_secure
+)
+
 
 @all_requests
 def mock_response_content(url, request):  # pylint: disable=unused-argument
@@ -74,18 +78,26 @@ def mock_response_error(url, request):  # pylint: disable=unused-argument
 
 
 @patch(
-    'django.conf.settings.PROCTORING_BACKEND_PROVIDER',
-    {
-        "class": "edx_proctoring.backends.software_secure.SoftwareSecureBackendProvider",
-        "options": {
-            "secret_key_id": "foo",
-            "secret_key": "4B230FA45A6EC5AE8FDE2AFFACFABAA16D8A3D0B",
-            "crypto_key": "123456789123456712345678",
-            "exam_register_endpoint": "http://test",
-            "organization": "edx",
-            "exam_sponsor": "edX LMS",
-            "software_download_url": "http://example.com",
-            "send_email": True
+    'django.conf.settings.PROCTORING_BACKEND_PROVIDERS', {
+        "SOFTWARE_SECURE": {
+            "class": "edx_proctoring.backends.software_secure.SoftwareSecureBackendProvider",
+            "options": {
+                "secret_key_id": "foo",
+                "secret_key": "4B230FA45A6EC5AE8FDE2AFFACFABAA16D8A3D0B",
+                "crypto_key": "123456789123456712345678",
+                "exam_register_endpoint": "http://test",
+                "organization": "edx",
+                "exam_sponsor": "edX LMS",
+                "software_download_url": "http://example.com"
+            },
+            "settings": {
+                "LINK_URLS": {
+                    "contact_us": "{add link here}",
+                    "faq": "{add link here}",
+                    "online_proctoring_rules": "{add link here}",
+                    "tech_requirements": "{add link here}"
+                }
+            }
         }
     }
 )
@@ -116,7 +128,7 @@ class SoftwareSecureTests(TestCase):
         Makes sure the instance of the proctoring module can be created
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         self.assertIsNotNone(provider)
 
     def test_get_software_download_url(self):
@@ -124,9 +136,12 @@ class SoftwareSecureTests(TestCase):
         Makes sure we get the expected download url
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         self.assertEqual(provider.get_software_download_url(), 'http://example.com')
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_register_attempt(self):
         """
         Makes sure we can register an attempt
@@ -149,6 +164,10 @@ class SoftwareSecureTests(TestCase):
             self.assertIsNone(attempt['started_at'])
 
     @ddt.data(None, 'additional person allowed in room')
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_attempt_with_review_policy(self, review_policy_exception):
         """
         Create an unstarted proctoring attempt with a review policy associated with it.
@@ -185,7 +204,7 @@ class SoftwareSecureTests(TestCase):
             self.assertEqual(policy.review_policy, context['review_policy'])
 
             # call into real implementation
-            result = get_backend_provider(emphemeral=True)._get_payload(exam, context)
+            result = get_backend_provider('SOFTWARE_SECURE', emphemeral=True)._get_payload(exam, context)
 
             # assert that this is in the 'reviewerNotes' field that is passed to SoftwareSecure
             expected = context['review_policy']
@@ -203,7 +222,7 @@ class SoftwareSecureTests(TestCase):
             # so that we can assert that we are called with the review policy
             # as well as asserting that _get_payload includes that review policy
             # that was passed in
-            with patch.object(get_backend_provider(), '_get_payload', assert_get_payload_mock):
+            with patch.object(get_backend_provider("SOFTWARE_SECURE"), '_get_payload', assert_get_payload_mock):
                 attempt_id = create_exam_attempt(
                     exam_id,
                     self.user.id,
@@ -215,6 +234,9 @@ class SoftwareSecureTests(TestCase):
                 attempt = get_exam_attempt_by_id(attempt_id)
                 self.assertEqual(attempt['review_policy_id'], policy.id)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_attempt_with_no_review_policy(self):
         """
         Create an unstarted proctoring attempt with no review policy associated with it.
@@ -228,7 +250,7 @@ class SoftwareSecureTests(TestCase):
             self.assertNotIn('review_policy', context)
 
             # call into real implementation
-            result = get_backend_provider(emphemeral=True)._get_payload(exam, context)  # pylint: disable=protected-access
+            result = get_backend_provider('SOFTWARE_SECURE', emphemeral=True)._get_payload(exam, context)  # pylint: disable=protected-access
 
             # assert that we use the default that is defined in system configuration
             self.assertEqual(result['reviewerNotes'], constants.DEFAULT_SOFTWARE_SECURE_REVIEW_POLICY)
@@ -255,7 +277,12 @@ class SoftwareSecureTests(TestCase):
                 # patch the _get_payload method on the backend provider
                 # so that we can assert that we are called with the review policy
                 # undefined and that we use the system default
-                with patch.object(get_backend_provider(), '_get_payload', assert_get_payload_mock_no_policy):  # pylint: disable=protected-access
+                patch_object = patch.object(
+                    get_backend_provider('SOFTWARE_SECURE'),
+                    '_get_payload',
+                    assert_get_payload_mock_no_policy
+                )
+                with patch_object:  # pylint: disable=protected-access
                     attempt_id = create_exam_attempt(
                         exam_id,
                         self.user.id,
@@ -267,6 +294,8 @@ class SoftwareSecureTests(TestCase):
                     attempt = get_exam_attempt_by_id(attempt_id)
                     self.assertIsNone(attempt['review_policy_id'])
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_attempt_with_unicode_characters(self):
         """
         test that the unicode characters are removed from exam names before registering with
@@ -290,7 +319,7 @@ class SoftwareSecureTests(TestCase):
             """
 
             # call into real implementation
-            result = get_backend_provider(emphemeral=True)._get_payload(exam, context)  # pylint: disable=protected-access
+            result = get_backend_provider('SOFTWARE_SECURE', emphemeral=True)._get_payload(exam, context)  # pylint: disable=protected-access
             self.assertFalse(isinstance(result['examName'], unicode))
             self.assertTrue(is_ascii(result['examName']))
             self.assertGreater(len(result['examName']), 0)
@@ -307,7 +336,12 @@ class SoftwareSecureTests(TestCase):
             )
 
             # patch the _get_payload method on the backend provider
-            with patch.object(get_backend_provider(), '_get_payload', assert_get_payload_mock_unicode_characters):  # pylint: disable=protected-access
+            patch_object = patch.object(
+                get_backend_provider("SOFTWARE_SECURE"),
+                '_get_payload',
+                assert_get_payload_mock_unicode_characters,
+            )
+            with patch_object:  # pylint: disable=protected-access
                 attempt_id = create_exam_attempt(
                     exam_id,
                     self.user.id,
@@ -325,7 +359,12 @@ class SoftwareSecureTests(TestCase):
             )
 
             # patch the _get_payload method on the backend provider
-            with patch.object(get_backend_provider(), '_get_payload', assert_get_payload_mock_unicode_characters):  # pylint: disable=protected-access
+            patch_object = patch.object(
+                get_backend_provider("SOFTWARE_SECURE"),
+                '_get_payload',
+                assert_get_payload_mock_unicode_characters,
+            )
+            with patch_object:  # pylint: disable=protected-access
                 attempt_id = create_exam_attempt(
                     exam_id,
                     self.user.id,
@@ -333,6 +372,9 @@ class SoftwareSecureTests(TestCase):
                 )
                 self.assertGreater(attempt_id, 0)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_single_name_attempt(self):
         """
         Tests to make sure we can parse a fullname which does not have any spaces in it
@@ -352,6 +394,9 @@ class SoftwareSecureTests(TestCase):
             attempt_id = create_exam_attempt(exam_id, self.user.id, taking_as_proctored=True)
             self.assertIsNotNone(attempt_id)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_unicode_attempt(self):
         """
         Tests to make sure we can handle an attempt when a user's fullname has unicode characters in it
@@ -384,6 +429,9 @@ class SoftwareSecureTests(TestCase):
             attempt_id = create_exam_attempt(exam_id, self.user.id, taking_as_proctored=True)
             self.assertIsNotNone(attempt_id)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_failing_register_attempt(self):
         """
         Makes sure we can register an attempt
@@ -407,7 +455,7 @@ class SoftwareSecureTests(TestCase):
         Calls directly into the SoftwareSecure payload construction
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         body = provider._body_string({  # pylint: disable=protected-access
             'foo': False,
             'none': None,
@@ -428,7 +476,7 @@ class SoftwareSecureTests(TestCase):
         work that needs to happen right now
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         self.assertIsNone(provider.start_exam_attempt(None, None))
 
     def test_stop_proctored_exam(self):
@@ -437,7 +485,7 @@ class SoftwareSecureTests(TestCase):
         work that needs to happen right now
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         self.assertIsNone(provider.stop_exam_attempt(None, None))
 
     @ddt.data(
@@ -448,12 +496,16 @@ class SoftwareSecureTests(TestCase):
     )
     @ddt.unpack
     @patch('edx_proctoring.constants.REQUIRE_FAILURE_SECOND_REVIEWS', False)
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_review_callback(self, review_status, credit_requirement_status):
+
         """
         Simulates callbacks from SoftwareSecure with various statuses
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -513,7 +565,7 @@ class SoftwareSecureTests(TestCase):
         an attempt code which does not exist
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         test_payload = Template(TEST_REVIEW_PAYLOAD).substitute(
             attempt_code='not-here',
             external_id='also-not-here'
@@ -528,7 +580,7 @@ class SoftwareSecureTests(TestCase):
         with a reviewStatus which is unexpected
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
         test_payload = Template(TEST_REVIEW_PAYLOAD).substitute(
             attempt_code='not-here',
             external_id='also-not-here'
@@ -538,6 +590,9 @@ class SoftwareSecureTests(TestCase):
         with self.assertRaises(ProctoredExamBadReviewStatus):
             provider.on_review_callback(json.loads(test_payload))
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_review_mistmatched_tokens(self):
         """
         Asserts raising of an exception if we get a report for
@@ -545,7 +600,7 @@ class SoftwareSecureTests(TestCase):
         match the report
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -576,13 +631,16 @@ class SoftwareSecureTests(TestCase):
 
     @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_CALLBACK_SIMULATION': True})
     @patch('edx_proctoring.constants.REQUIRE_FAILURE_SECOND_REVIEWS', False)
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_allow_simulated_callbacks(self):
         """
         Verify that the configuration switch to
         not do confirmation of external_id/ssiRecordLocators
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -616,13 +674,16 @@ class SoftwareSecureTests(TestCase):
         self.assertEqual(attempt['status'], ProctoredExamStudentAttemptStatus.verified)
 
     @patch('edx_proctoring.constants.REQUIRE_FAILURE_SECOND_REVIEWS', False)
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_review_on_archived_attempt(self):
         """
         Make sure we can process a review report for
         an attempt which has been archived
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -670,13 +731,16 @@ class SoftwareSecureTests(TestCase):
 
     @patch('edx_proctoring.constants.ALLOW_REVIEW_UPDATES', False)
     @patch('edx_proctoring.constants.REQUIRE_FAILURE_SECOND_REVIEWS', False)
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_disallow_review_resubmission(self):
         """
         Tests that an exception is raised if a review report is resubmitted for the same
         attempt
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -708,13 +772,19 @@ class SoftwareSecureTests(TestCase):
         with self.assertRaises(ProctoredExamReviewAlreadyExists):
             provider.on_review_callback(json.loads(test_payload))
 
-    @patch('edx_proctoring.constants.ALLOW_REVIEW_UPDATES', True)
-    def test_allow_review_resubmission(self):
+    @patch(
+        'edx_proctoring.backends.software_secure.get_proctoring_settings',
+        return_value={'ALLOW_REVIEW_UPDATES': True}
+    )
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
+    def test_allow_review_resubmission(self, proctoring_settings):  # pylint: disable=unused-argument
         """
         Tests that an resubmission is allowed
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -774,13 +844,19 @@ class SoftwareSecureTests(TestCase):
         self.assertEqual(records[1].review_status, 'Suspicious')
 
     @ddt.data(False, True)
-    def test_failure_submission(self, allow_rejects):
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch(
+        'edx_proctoring.backends.software_secure.get_proctoring_settings',
+        return_value={'REQUIRE_FAILURE_SECOND_REVIEWS': True}
+    )
+    def test_failure_submission(self, allow_rejects, proctoring_settings):  # pylint: disable=unused-argument
         """
         Tests that a submission of a failed test and make sure that we
         don't automatically update the status to failure
         """
-
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -832,12 +908,15 @@ class SoftwareSecureTests(TestCase):
         )
         self.assertEqual(attempt['status'], expected_status)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_software_secure)
+    @patch('edx_proctoring.backends.software_secure.get_provider_name_by_course_id', get_provider_name_software_secure)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_software_secure)
     def test_update_archived_attempt(self):
         """
         Test calling the on_review_saved interface point with an attempt_code that was archived
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         exam_id = create_exam(
             course_id='foo/bar/baz',
@@ -862,7 +941,6 @@ class SoftwareSecureTests(TestCase):
             attempt_code=attempt['attempt_code'],
             external_id=attempt['external_id']
         )
-
         # now process the report
         provider.on_review_callback(json.loads(test_payload))
 
@@ -895,7 +973,7 @@ class SoftwareSecureTests(TestCase):
         Simulate calling on_review_saved() with an attempt code that cannot be found
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         review = ProctoredExamSoftwareSecureReview()
         review.attempt_code = 'foo'
@@ -907,7 +985,7 @@ class SoftwareSecureTests(TestCase):
         Make sure we are splitting up full names correctly
         """
 
-        provider = get_backend_provider()
+        provider = get_backend_provider("SOFTWARE_SECURE")
 
         (first_name, last_name) = provider._split_fullname('John Doe')
         self.assertEqual(first_name, 'John')

--- a/edx_proctoring/callbacks.py
+++ b/edx_proctoring/callbacks.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.http import HttpResponse
 import pytz
 from datetime import datetime
+
+from edx_proctoring.models import ProctoredExamStudentAttempt
 from ipware.ip import get_ip
 from django.core.urlresolvers import reverse
 
@@ -18,11 +20,14 @@ from rest_framework.negotiation import BaseContentNegotiation
 from edx_proctoring.api import (
     get_exam_attempt_by_code,
     mark_exam_attempt_as_ready,
-    update_exam_attempt
+    update_exam_attempt,
+    _get_exam_attempt
 )
-from edx_proctoring.backends import get_backend_provider
-from edx_proctoring.exceptions import ProctoredBaseException
 from edx_proctoring.models import ProctoredExamStudentAttemptStatus
+from edx_proctoring.exceptions import ProctoredBaseException
+from edx_proctoring.utils import locate_attempt_by_attempt_code
+from edx_proctoring.backends import get_backend_provider, get_proctoring_settings, get_provider_name_by_course_id
+
 
 log = logging.getLogger(__name__)
 
@@ -59,12 +64,60 @@ def start_exam_callback(request, attempt_code):  # pylint: disable=unused-argume
         args=[attempt_code]
     )
 
+    provider_name = get_provider_name_by_course_id(attempt['proctored_exam']['course_id'])
+    proctoring_settings = get_proctoring_settings(provider_name)
     return HttpResponse(
         template.render(
             Context({
                 'exam_attempt_status_url': poll_url,
                 'platform_name': settings.PLATFORM_NAME,
-                'link_urls': settings.PROCTORING_SETTINGS.get('LINK_URLS', {})
+                'link_urls': proctoring_settings.get('LINK_URLS', {})
+            })
+        )
+    )
+
+
+def bulk_start_exams_callback(request, attempt_codes):  # pylint: disable=unused-argument
+    """
+    A callback when SoftwareSecure completes setup and the exams should be started.
+
+    A callback endpoint which is called when SoftwareSecure completes
+    the proctoring setup and the exams should be started.
+
+    NOTE: This returns HTML as it will be displayed in an embedded browser
+
+    This is an authenticated endpoint and comaseparated attempt codes is passed
+    in as part of the URL path
+
+    IMPORTANT: This is an unauthenticated endpoint, so be VERY CAREFUL about extending
+    this endpoint
+    """
+    code_list = attempt_codes.split(',')
+
+    attempts = ProctoredExamStudentAttempt.objects.filter(
+        attempt_code__in=code_list
+    )
+    if not attempts:
+        return HttpResponse(
+            content='You have entered an exam codes that are not valid.',
+            status=404
+        )
+
+    for attempt_obj in attempts:
+        attempt = _get_exam_attempt(attempt_obj)
+        mark_exam_attempt_as_ready(attempt['proctored_exam']['id'], attempt['user']['id'])
+        provider_name = get_provider_name_by_course_id(attempt['proctored_exam']['course_id'])
+        proctoring_settings = get_proctoring_settings(provider_name)
+
+    template = loader.get_template(
+        'proctored_exam/proctoring_launch_callback.html'
+    )
+    return HttpResponse(
+        template.render(
+            Context({
+                'exam_attempt_status_url': '',
+                'platform_name': settings.PLATFORM_NAME,
+                'link_urls': proctoring_settings.get('LINK_URLS', {})
             })
         )
     )
@@ -106,24 +159,62 @@ class ExamReviewCallback(APIView):
         """
         Post callback handler
         """
-        provider = get_backend_provider()
+        try:
+            attempt_code = request.data['examMetaData']['examCode']
+        except KeyError, ex:
+            log.exception(ex)
+            return Response(data={'reason': unicode(ex)}, status=400)
+
+        attempt_obj = locate_attempt_by_attempt_code(attempt_code)
+        course_id = attempt_obj[0].proctored_exam.course_id
+        provider_name = get_provider_name_by_course_id(course_id)
+        provider = get_backend_provider(provider_name)
 
         # call down into the underlying provider code
         try:
             provider.on_review_callback(request.data)
         except ProctoredBaseException, ex:
             log.exception(ex)
-            return Response(
-                data={
-                    'reason': unicode(ex)
-                },
-                status=400
-            )
+            return Response(data={'reason': unicode(ex)}, status=400)
 
-        return Response(
-            data='OK',
-            status=200
-        )
+        return Response(data='OK', status=200)
+
+
+class BulkExamReviewCallback(APIView):
+    """
+    This endpoint is called by a 3rd party proctoring review service when
+    there are results available for us to record
+
+    IMPORTANT: This is an unauthenticated endpoint, so be VERY CAREFUL about extending
+    this endpoint
+    """
+
+    content_negotiation_class = IgnoreClientContentNegotiation
+
+    def post(self, request):
+        """
+        Post callback handler
+        """
+        data = request.data
+        course_id = ""
+        for review in data:
+            try:
+                attempt_code = review['examMetaData']['examCode']
+            except KeyError, ex:
+                continue
+            attempt_obj = locate_attempt_by_attempt_code(attempt_code)
+            if course_id != attempt_obj[0].proctored_exam.course_id:
+                course_id = attempt_obj[0].proctored_exam.course_id
+                provider_name = get_provider_name_by_course_id(course_id)
+                provider = get_backend_provider(provider_name)
+
+            # call down into the underlying provider code
+            try:
+                provider.on_review_callback(review)
+            except ProctoredBaseException, ex:
+                log.exception(ex)
+
+        return Response(data='OK', status=200)
 
 
 class AttemptStatus(APIView):

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -5,31 +5,6 @@ Lists of constants that can be used in the edX proctoring
 from django.conf import settings
 import datetime
 
-SITE_NAME = (
-    settings.PROCTORING_SETTINGS['SITE_NAME'] if
-    'SITE_NAME' in settings.PROCTORING_SETTINGS else settings.SITE_NAME
-)
-
-PLATFORM_NAME = (
-    settings.PROCTORING_SETTINGS['PLATFORM_NAME'] if
-    'PLATFORM_NAME' in settings.PROCTORING_SETTINGS else settings.PLATFORM_NAME
-)
-
-FROM_EMAIL = (
-    settings.PROCTORING_SETTINGS['STATUS_EMAIL_FROM_ADDRESS'] if
-    'STATUS_EMAIL_FROM_ADDRESS' in settings.PROCTORING_SETTINGS else settings.DEFAULT_FROM_EMAIL
-)
-
-# Note that CONTACT_EMAIL is not defined in Studio runtimes
-CONTACT_EMAIL = (
-    settings.PROCTORING_SETTINGS['CONTACT_EMAIL'] if
-    'CONTACT_EMAIL' in settings.PROCTORING_SETTINGS else getattr(settings, 'CONTACT_EMAIL', FROM_EMAIL)
-)
-
-ALLOW_REVIEW_UPDATES = (
-    settings.PROCTORING_SETTINGS['ALLOW_REVIEW_UPDATES'] if
-    'ALLOW_REVIEW_UPDATES' in settings.PROCTORING_SETTINGS else getattr(settings, 'ALLOW_REVIEW_UPDATES', True)
-)
 
 DEFAULT_SOFTWARE_SECURE_REVIEW_POLICY = (
     settings.PROCTORING_SETTINGS['DEFAULT_REVIEW_POLICY'] if
@@ -49,10 +24,38 @@ SOFTWARE_SECURE_CLIENT_TIMEOUT = (
     else getattr(settings, 'SOFTWARE_SECURE_CLIENT_TIMEOUT', 30)
 )
 
-SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD = (
-    settings.PROCTORING_SETTINGS['SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD'] if
-    'SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD' in settings.PROCTORING_SETTINGS
-    else getattr(settings, 'SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD', 10)
+SHUT_DOWN_GRACEPERIOD = (
+    settings.PROCTORING_SETTINGS['SHUT_DOWN_GRACEPERIOD'] if
+    'SHUT_DOWN_GRACEPERIOD' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'SHUT_DOWN_GRACEPERIOD', 10)
+)
+
+MINIMUM_TIME = datetime.datetime.fromtimestamp(0)
+
+ALLOW_REVIEW_UPDATES = (
+    settings.PROCTORING_SETTINGS['ALLOW_REVIEW_UPDATES'] if
+    'ALLOW_REVIEW_UPDATES' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'ALLOW_REVIEW_UPDATES', False)
+)
+
+CLIENT_TIMEOUT = (
+    settings.PROCTORING_SETTINGS['CLIENT_TIMEOUT'] if
+    'CLIENT_TIMEOUT' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'CLIENT_TIMEOUT', 30)
+)
+
+MINIMUM_TIME = datetime.datetime.fromtimestamp(0)
+
+ALLOW_REVIEW_UPDATES = (
+    settings.PROCTORING_SETTINGS['ALLOW_REVIEW_UPDATES'] if
+    'ALLOW_REVIEW_UPDATES' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'ALLOW_REVIEW_UPDATES', False)
+)
+
+CLIENT_TIMEOUT = (
+    settings.PROCTORING_SETTINGS['CLIENT_TIMEOUT'] if
+    'CLIENT_TIMEOUT' in settings.PROCTORING_SETTINGS
+    else getattr(settings, 'CLIENT_TIMEOUT', 30)
 )
 
 MINIMUM_TIME = datetime.datetime.fromtimestamp(0)

--- a/edx_proctoring/management/commands/tests/test_set_attempt_status.py
+++ b/edx_proctoring/management/commands/tests/test_set_attempt_status.py
@@ -5,7 +5,9 @@ Tests for the set_attempt_status management command
 from datetime import datetime
 import pytz
 
-from edx_proctoring.tests.utils import LoggedInTestCase
+from mock import patch
+
+from edx_proctoring.tests.utils import LoggedInTestCase, get_provider_name_test
 from edx_proctoring.api import create_exam, get_exam_attempt
 from edx_proctoring.management.commands import set_attempt_status
 
@@ -45,6 +47,7 @@ class SetAttemptStatusTests(LoggedInTestCase):
             is_sample_attempt=False
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_run_comand(self):
         """
         Run the management command

--- a/edx_proctoring/static/proctoring/js/collections/proctoring_services_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctoring_services_collection.js
@@ -1,0 +1,13 @@
+var edx = edx || {};
+(function(Backbone) {
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoringServicesCollection = Backbone.Collection.extend({
+        /* model for a collection of ProctoringServices */
+        model: edx.instructor_dashboard.proctoring.ProctoringServicesModel,
+        url: '/api/edx_proctoring/v1/proctoring_services/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoringServicesCollection = edx.instructor_dashboard.proctoring.ProctoringServicesCollection;
+}).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctoring_services_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctoring_services_model.js
@@ -1,0 +1,15 @@
+var edx = edx || {};
+
+(function(Backbone) {
+
+    'use strict';
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoringServicesModel = Backbone.Model.extend({
+        url: '/api/edx_proctoring/v1/proctoring_services/'
+
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoringServicesModel = edx.instructor_dashboard.proctoring.ProctoringServicesModel;
+}).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -139,8 +139,8 @@ var edx = edx || {};
             if (self.timerTick % 5 === 0){
                 var url = self.model.url + '/' + self.model.get('attempt_id');
                 $.ajax(url).success(function(data) {
-                    if (data.status === 'error') {
-                        // The proctoring session is in error state
+                    if (data.status === 'error' || data.status === 'submitted') {
+                        // The proctoring session is in error state or has ended
                         // refresh the page to
                         clearInterval(self.timerId); // stop the timer once the time finishes.
                         $(window).unbind('beforeunload', self.unloadMessage);

--- a/edx_proctoring/static/proctoring/js/views/proctoring_services_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctoring_services_view.js
@@ -1,0 +1,122 @@
+var edx = edx || {};
+
+(function (Backbone, $, _) {
+    'use strict';
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoringServicesView = Backbone.View.extend({
+        initialize: function () {
+
+            this.collection = new edx.instructor_dashboard.proctoring.ProctoringServicesCollection();
+            this.proctoredExamCollection = new edx.instructor_dashboard.proctoring.ProctoredExamCollection();
+            /* unfortunately we have to make some assumptions about what is being set up in HTML */
+            this.setElement($('.proctoring-services-container'));
+            this.course_id = this.$el.data('course-id');
+
+            /* this should be moved to a 'data' attribute in HTML */
+            this.template_url = '/static/proctoring/templates/proctoring_services.underscore';
+            this.template = null;
+            this.initial_url = this.collection.url;
+            /* re-render if the model changes */
+
+            /* Load the static template for rendering. */
+            this.loadTemplateData();
+
+            this.proctoredExamCollection.url = this.proctoredExamCollection.url + this.course_id;
+            this.collection.url = this.initial_url + this.course_id;
+
+        },
+        events: {
+            'change #proctoring-select': 'changeProctoringService',
+        },
+        getCSRFToken: function () {
+            var cookieValue = null;
+            var name = 'csrftoken';
+            if (document.cookie && document.cookie != '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        },
+        changeProctoringService: function (event) {
+            var element = $(event.currentTarget);
+            var proctor = element.val()
+            var self = this;
+            self.collection.fetch(
+                {
+                    headers: {
+                        "X-CSRFToken": this.getCSRFToken()
+                    },
+                    type: 'PUT',
+                    data: {
+                        'proctoring_service': proctor,
+                    },
+                    success: function () {
+                        alert("Proctoring service has successfully changed.");
+                        self.hydrate();
+                    }
+                }
+            );
+            event.stopPropagation();
+            event.preventDefault();
+        },
+        /*
+         This entry point is required for Instructor Dashboard
+         See setup_instructor_dashboard_sections() in
+         instructor_dashboard.coffee (in edx-platform)
+         */
+        constructor: function (section) {
+            /* the Instructor Dashboard javascript expects this to be set up */
+            $(section).data('wrapper', this);
+
+            this.initialize({});
+        },
+        onClickTitle: function () {
+            // called when this is selected in the instructor dashboard
+            return;
+        },
+        loadTemplateData: function () {
+            var self = this;
+            $.ajax({url: self.template_url, dataType: "html"})
+                .error(function (jqXHR, textStatus, errorThrown) {
+                })
+                .done(function (template_data) {
+                    self.template = _.template(template_data);
+                    self.hydrate();
+                });
+        },
+        hydrate: function () {
+            /* This function will load the bound collection */
+
+            /* add and remove a class when we do the initial loading */
+            /* we might - at some point - add a visual element to the */
+            /* loading, like a spinner */
+            var self = this;
+            self.collection.fetch({
+                success: function () {
+                    self.render();
+                }
+            });
+        },
+        collectionChanged: function () {
+            this.hydrate();
+        },
+        render: function () {
+            if (this.template !== null) {
+                var self = this;
+                var html = this.template({data:this .collection.toJSON()[0]});
+                this.$el.html(html);
+            }
+        },
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoringServicesView = edx.instructor_dashboard.proctoring.ProctoringServicesView;
+}).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/templates/proctoring_services.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctoring_services.underscore
@@ -1,0 +1,6 @@
+<select name='proctoring' id='proctoring-select'>
+    <% _.each(data.list, function(proctor){ %>
+        <option <% if (data.current == proctor) { %>selected="selected"<% } %>
+        value="<%= proctor %>"><%= proctor %></option>
+    <% }); %>
+</select>

--- a/edx_proctoring/templates/practice_exam/__init__.py~fix tests
+++ b/edx_proctoring/templates/practice_exam/__init__.py~fix tests
@@ -1,0 +1,3 @@
+"""
+We need python think this is a python module
+"""

--- a/edx_proctoring/templates/practice_exam/submitted.html
+++ b/edx_proctoring/templates/practice_exam/submitted.html
@@ -13,7 +13,6 @@
     {% endblocktrans %}
   </p>
   <button class="gated-sequence start-timed-exam" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
-    
     <a>
       {% trans "You can also retry this practice exam" %}
     </a>

--- a/edx_proctoring/templates/proctored_exam/error.html
+++ b/edx_proctoring/templates/proctored_exam/error.html
@@ -20,9 +20,7 @@
   </p>
   <hr>
   <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
+    {% blocktrans %}View your credit eligibility status on your{% endblocktrans %} <a href="{{progress_page_url}}">{% blocktrans %}Progress{% endblocktrans %}</a>
   </p>
 </div>
 <div class="footer-sequence border-b-0 padding-b-0">

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -26,7 +26,7 @@
       {% endblocktrans %}
     </p>
     <p>
-      <span><a href="#" id="software_download_link" data-action="click_download_software" target="_blank">Start System Check</a></span>
+      <span><a href="{{software_download_url}}" target="_blank">{% blocktrans %}Start System Check{% endblocktrans %}</a></span>
     </p>
     <p>
       {% blocktrans %}
@@ -40,6 +40,7 @@
     </p>
   </div>
 </div>
+<!--
 <div class="footer-sequence border-b-0 padding-b-0">
   {% if not is_sample_attempt %}
   <p class="proctored-exam-instruction">
@@ -49,6 +50,7 @@
   </p>
   {% endif %}
 </div>
+
 {% include 'proctored_exam/footer.html' %}
 
 <script type="text/javascript">

--- a/edx_proctoring/templates/proctored_exam/ready_to_start.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_start.html
@@ -8,10 +8,10 @@
     </h3>
     <p>
       {% blocktrans %}
+        &#8226; Do not close the proctoring window until you have completed and submitted your exam. </br>
         &#8226; When you start your exam you will have {{ total_time }} to complete it. </br>
-        &#8226; You cannot stop the timer once you start. </br>
-        &#8226; If time expires before you finish your exam, your completed answers will be
-                submitted for review. </br>
+        &#8226; If the allotted time expires before your end your exam, the answers you have completed up
+        to that point are submitted for grading and your proctoring session is uploaded for review. </br>
       {% endblocktrans %}
     </p>
     <div>
@@ -51,3 +51,4 @@
     }
   );
 </script>
+

--- a/edx_proctoring/templates/proctored_exam/rejected.html
+++ b/edx_proctoring/templates/proctored_exam/rejected.html
@@ -12,8 +12,6 @@
       If you have questions about the status of your proctored exam results, contact {{ platform_name }} Support.
     {% endblocktrans %}
   </p>
-  {% include 'proctored_exam/visit_exam_content.html' %}
-
   <hr>
   <p>
     {% blocktrans %}

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -43,7 +43,7 @@ from edx_proctoring.api import (
     create_exam_review_policy,
     get_review_policy_by_exam_id,
     update_review_policy,
-    remove_review_policy,
+    remove_review_policy
 )
 from edx_proctoring.exceptions import (
     ProctoredExamAlreadyExists,
@@ -68,6 +68,7 @@ from edx_proctoring.models import (
 
 from .utils import (
     LoggedInTestCase,
+    get_provider_name_test
 )
 
 from edx_proctoring.tests.test_services import (
@@ -788,6 +789,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             start_exam_attempt_by_code('foobar')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_a_created_attempt(self):
         """
         Test to attempt starting an attempt which has been created but not started.
@@ -795,6 +797,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self._create_unstarted_exam_attempt()
         start_exam_attempt(self.proctored_exam_id, self.user_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_by_code(self):
         """
         Test to attempt starting an attempt which has been created but not started.
@@ -802,6 +805,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         attempt = self._create_unstarted_exam_attempt()
         start_exam_attempt_by_code(attempt.attempt_code)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_restart_a_started_attempt(self):
         """
         Test to attempt starting an attempt which has been created but not started.
@@ -811,10 +815,22 @@ class ProctoredExamApiTests(LoggedInTestCase):
         with self.assertRaises(StudentExamAttemptedAlreadyStarted):
             start_exam_attempt(self.proctored_exam_id, self.user_id)
 
-    def test_stop_exam_attempt(self):
+    @patch('edx_proctoring.api.get_exam_by_id', return_value={
+        'course_id': "org/course/id",
+        'is_proctored': True,
+        'is_practice_exam': False,
+        'id': 1,
+        'content_id': 1,
+        'exam_name': 'test',
+        'time_limit_mins': 10,
+        'is_active': True
+    })
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_stop_exam_attempt(self, exam):
         """
         Stop an exam attempt.
         """
+        exam.update()
         proctored_exam_student_attempt = self._create_unstarted_exam_attempt()
         self.assertIsNone(proctored_exam_student_attempt.completed_at)
         proctored_exam_attempt_id = stop_exam_attempt(
@@ -846,11 +862,10 @@ class ProctoredExamApiTests(LoggedInTestCase):
     @ddt.data(
         (ProctoredExamStudentAttemptStatus.verified, 'satisfied'),
         (ProctoredExamStudentAttemptStatus.submitted, 'submitted'),
-        (ProctoredExamStudentAttemptStatus.declined, 'declined'),
-        (ProctoredExamStudentAttemptStatus.error, 'failed'),
-        (ProctoredExamStudentAttemptStatus.second_review_required, None),
+        (ProctoredExamStudentAttemptStatus.error, 'failed')
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_remove_exam_attempt_with_status(self, to_status, requirement_status):
         """
         Test to remove the exam attempt which calls
@@ -867,6 +882,11 @@ class ProctoredExamApiTests(LoggedInTestCase):
         # make sure the credit requirement status is there
         credit_service = get_runtime_service('credit')
         credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)
+        self.assertEqual(len(credit_status['credit_requirement_status']), 1)
+        self.assertEqual(
+            credit_status['credit_requirement_status'][0]['status'],
+            requirement_status
+        )
 
         if requirement_status:
             self.assertEqual(len(credit_status['credit_requirement_status']), 1)
@@ -878,15 +898,12 @@ class ProctoredExamApiTests(LoggedInTestCase):
             # now remove exam attempt which calls the credit service method 'remove_credit_requirement_status'
             remove_exam_attempt(exam_attempt.proctored_exam_id, requesting_user=self.user)
 
-            # make sure the credit requirement status is no longer there
-            credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)
+        # make sure the credit requirement status is no longer there
+        credit_status = credit_service.get_credit_state(self.user.id, exam_attempt.proctored_exam.course_id)
 
-            self.assertEqual(len(credit_status['credit_requirement_status']), 0)
-        else:
-            # There is not an expected changed to the credit requirement table
-            # given the attempt status
-            self.assertEqual(len(credit_status['credit_requirement_status']), 0)
+        self.assertEqual(len(credit_status['credit_requirement_status']), 0)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_stop_a_non_started_exam(self):
         """
         Stop an exam attempt that had not started yet.
@@ -894,6 +911,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             stop_exam_attempt(self.proctored_exam_id, self.user_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_mark_exam_attempt_timeout(self):
         """
         Tests the mark exam as timed out
@@ -909,7 +927,18 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertEqual(proctored_exam_student_attempt.id, proctored_exam_attempt_id)
 
-    def test_mark_exam_attempt_as_ready(self):
+    @patch('edx_proctoring.api.get_exam_by_id', return_value={
+        'course_id': "org/course/id",
+        'is_proctored': True,
+        'is_practice_exam': False,
+        'id': 1,
+        'content_id': 1,
+        'exam_name': 'test',
+        'time_limit_mins': 10,
+        'is_active': True
+    })
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_mark_exam_attempt_as_ready(self, exam):  # pylint: disable=unused-argument
         """
         Tests the mark exam as timed out
         """
@@ -924,6 +953,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertEqual(proctored_exam_student_attempt.id, proctored_exam_attempt_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_active_exams_for_user(self):
         """
         Test to get the all the active
@@ -1010,6 +1040,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertEqual(all_exams[0]['id'], updated_exam_attempt_id)
         self.assertEqual(all_exams[1]['id'], exam_attempt.id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_student_view(self):
         """
         Test for get_student_view prompting the user to take the exam
@@ -1045,6 +1076,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.start_a_practice_exam_msg.format(exam_name=self.exam_name), rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_honor_view_with_practice_exam(self):
         """
         Test for get_student_view prompting when the student is enrolled in non-verified
@@ -1067,6 +1099,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIsNotNone(rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_honor_view(self):
         """
         Test for get_student_view prompting when the student is enrolled in non-verified
@@ -1104,6 +1137,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ('grade', 'declined', 'To be eligible to earn credit for this course', False),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_prereq_scenarios(self, namespace, req_status, expected_content, should_see_prereq):
         """
         This test asserts that proctoring will not be displayed under the following
@@ -1256,6 +1290,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_exam(self):
         """
         Test for get_student_view proctored exam which has not started yet.
@@ -1297,6 +1332,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertIn(self.chose_proctored_exam_msg, rendered_response)
         self.assertIn(self.proctored_exam_optout_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_practice_exam(self):
         """
         Test for get_student_view Practice exam which has not started yet.
@@ -1318,6 +1354,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertIn(self.chose_proctored_exam_msg, rendered_response)
         self.assertNotIn(self.proctored_exam_optout_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_declined_attempt(self):
         """
         Make sure that a declined attempt does not show proctoring
@@ -1338,6 +1375,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIsNone(rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_ready(self):
         """
         Assert that we get the right content
@@ -1359,6 +1397,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.ready_to_start_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_started_exam(self):
         """
         Test for get_student_view proctored exam which has started.
@@ -1421,6 +1460,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         (datetime.now(pytz.UTC) - timedelta(days=1), True),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_timed_exam_with_past_due_date(self, due_date, has_due_date_passed):
         """
         Test for get_student_view timed exam with the due date.
@@ -1448,6 +1488,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         else:
             self.assertIsNone(None)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_proctored_exam_attempt_with_past_due_datetime(self):
         """
         Test for get_student_view for proctored exam with past due datetime
@@ -1491,6 +1532,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIn(self.exam_expired_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_timed_exam_attempt_with_past_due_datetime(self):
         """
         Test for get_student_view for timed exam with past due datetime
@@ -1537,8 +1579,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIn(self.exam_expired_msg, rendered_response)
 
-    @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_get_studentview_timedout(self):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_get_studentview_timedout(self, proctoring_settings):  # pylint: disable=unused-argument
         """
         Verifies that if we call get_studentview when the timer has expired
         it will automatically state transition into timed_out
@@ -1560,6 +1603,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
                     }
                 )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_status(self):
         """
         Test for get_student_view proctored exam which has been submitted.
@@ -1614,6 +1659,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIn(self.proctored_exam_submitted_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_status_with_duedate(self):
         """
         Test for get_student_view proctored exam which has been submitted
@@ -1669,6 +1716,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
             )
             self.assertIsNotNone(rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_submitted_status_practiceexam(self):
         """
         Test for get_student_view practice exam which has been submitted.
@@ -1690,30 +1739,13 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_waiting_for_app_shutdown_msg, rendered_response)
 
-        reset_time = datetime.now(pytz.UTC) + timedelta(minutes=2)
-        with freeze_time(reset_time):
-            rendered_response = get_student_view(
-                user_id=self.user_id,
-                course_id=self.course_id,
-                content_id=self.content_id_practice,
-                context={
-                    'is_proctored': True,
-                    'display_name': self.exam_name,
-                    'default_time_limit_mins': 90
-                }
-            )
-            self.assertIn(self.practice_exam_submitted_msg, rendered_response)
-
-    @ddt.data(
-        ProctoredExamStudentAttemptStatus.created,
-        ProctoredExamStudentAttemptStatus.download_software_clicked,
-    )
-    def test_get_studentview_created_status_practiceexam(self, status):
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_get_studentview_created_status_practiceexam(self):
         """
         Test for get_student_view practice exam which has been created.
         """
         exam_attempt = self._create_started_practice_exam_attempt()
-        exam_attempt.status = status
+        exam_attempt.status = ProctoredExamStudentAttemptStatus.created
         exam_attempt.save()
 
         rendered_response = get_student_view(
@@ -1728,6 +1760,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.practice_exam_created_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_ready_to_start_status_practiceexam(self):
         """
         Test for get_student_view practice exam which is ready to start.
@@ -1748,6 +1781,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.ready_to_start_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_compelete_status_practiceexam(self):
         """
         Test for get_student_view practice exam when it is complete/ready to submit.
@@ -1768,6 +1802,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.practice_exam_completion_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_rejected_status(self):
         """
         Test for get_student_view proctored exam which has been rejected.
@@ -1788,6 +1823,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_rejected_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_verified_status(self):
         """
         Test for get_student_view proctored exam which has been verified.
@@ -1808,6 +1844,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_verified_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_completed_status(self):
         """
         Test for get_student_view proctored exam which has been completed.
@@ -1828,8 +1865,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.proctored_exam_completed_msg, rendered_response)
 
-    @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_get_studentview_expired(self):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_get_studentview_expired(self, proctoring_settings):  # pylint: disable=unused-argument
         """
         Test for get_student_view proctored exam which has expired. Since we don't have a template
         for that view rendering, it will throw a NotImplementedError
@@ -1849,6 +1887,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
                 }
             )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_erroneous_exam(self):
         """
         Test for get_student_view proctored exam which has exam status error.
@@ -1875,6 +1914,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.exam_time_error_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_erroneous_practice_exam(self):
         """
         Test for get_student_view practice exam which has exam status error.
@@ -1896,6 +1936,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(self.practice_exam_failed_msg, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_timed_exam(self):
         """
         Test for get_student_view Timed exam which is not proctored and has not started yet.
@@ -1918,6 +1959,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.assertIn('1 hour and 30 minutes', rendered_response)
         self.assertNotIn(self.start_an_exam_msg.format(exam_name=self.exam_name), rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_unstarted_timed_exam_with_allowance(self):
         """
         Test for get_student_view Timed exam which is not proctored and has not started yet.
@@ -1957,6 +1999,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_studentview_completed_timed_exam(self, status, expected_content):
         """
         Test for get_student_view timed exam which has completed.
@@ -1978,6 +2021,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertIn(expected_content, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_expired_exam(self):
         """
         Test that an expired exam shows a difference message when the exam is expired just recently
@@ -2016,6 +2060,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
 
         self.assertIn(self.timed_exam_submitted, rendered_response)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_submitted_credit_state(self):
         """
         Verify that putting an attempt into the submitted state will also mark
@@ -2037,6 +2082,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
             'submitted'
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_error_credit_state(self):
         """
         Verify that putting an attempt into the error state will also mark
@@ -2091,6 +2137,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ),
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_cascading(self, to_status, create_attempt, second_attempt_status, expected_second_status):
         """
         Make sure that when we decline/reject one attempt all other exams in the course
@@ -2176,8 +2223,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
         (ProctoredExamStudentAttemptStatus.submitted, ProctoredExamStudentAttemptStatus.error),
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_illegal_status_transition(self, from_status, to_status):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_illegal_status_transition(self, from_status, to_status, proctoring_settings):  # pylint: disable=unused-argument
         """
         Verify that we cannot reset backwards an attempt status
         once it is in a completed state
@@ -2197,6 +2245,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
                 to_status
             )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_alias_timed_out(self):
         """
         Verified that timed_out will automatically state transition
@@ -2217,11 +2266,12 @@ class ProctoredExamApiTests(LoggedInTestCase):
             ProctoredExamStudentAttemptStatus.submitted
         )
 
-    def test_update_unexisting_attempt(self):
+    @patch('edx_proctoring.api.get_exam_by_id', return_value={'course_id': 1})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_update_unexisting_attempt(self, exam):  # pylint: disable=unused-argument
         """
         Tests updating an non-existing attempt
         """
-
         with self.assertRaises(StudentExamAttemptDoesNotExistsException):
             update_attempt_status(0, 0, ProctoredExamStudentAttemptStatus.timed_out)
 
@@ -2334,6 +2384,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_status_summary(self, status, expected):
         """
         Assert that we get the expected status summaries
@@ -2381,6 +2432,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_practice_status_summary(self, status, expected):
         """
         Assert that we get the expected status summaries
@@ -2452,6 +2504,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_practice_status_honor(self, status, expected):
         """
         Assert that we get the expected status summaries
@@ -2571,6 +2624,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_send_email(self, status):
         """
         Assert that email is sent on the following statuses of proctoring attempt.
@@ -2593,6 +2647,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.second_review_required,
         ProctoredExamStudentAttemptStatus.error
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_email_not_sent(self, status):
         """
         Assert than email is not sent on the following statuses of proctoring attempt
@@ -2606,11 +2661,11 @@ class ProctoredExamApiTests(LoggedInTestCase):
         )
         self.assertEquals(len(mail.outbox), 0)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_send_email_unicode(self):
         """
         Assert that email can be sent with a unicode course name.
         """
-
         course_name = u'अआईउऊऋऌ अआईउऊऋऌ'
         set_runtime_service('credit', MockCreditService(course_name=course_name))
 
@@ -2644,8 +2699,9 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.timed_out,
         ProctoredExamStudentAttemptStatus.error
     )
-    @patch.dict('settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_not_send_email(self, status):
+    @patch('edx_proctoring.api.get_proctoring_settings', return_value={'ALLOW_TIMED_OUT_STATE': True})
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    def test_not_send_email(self, status, proctoring_settings):  # pylint: disable=unused-argument
         """
         Assert that email is not sent on the following statuses of proctoring attempt.
         """
@@ -2663,6 +2719,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_not_send_email_sample_exam(self, status):
         """
         Assert that email is not sent when there is practice/sample exam
@@ -2681,6 +2738,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_not_send_email_timed_exam(self, status):
         """
         Assert that email is not sent when exam is timed/not-proctoring
@@ -2702,6 +2760,8 @@ class ProctoredExamApiTests(LoggedInTestCase):
         ProctoredExamStudentAttemptStatus.verified,
         ProctoredExamStudentAttemptStatus.rejected,
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_footer_present(self, status):
         """
         Make sure the footer content is visible in the rendered output

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -130,6 +130,21 @@ class ProctoredExamModelTests(LoggedInTestCase):
         proctored_exam_student_history = ProctoredExamStudentAllowanceHistory.objects.filter(user_id=1)
         self.assertEqual(len(proctored_exam_student_history), 1)
 
+    def test_generate_hash(self):
+        """
+        Test for generate hash code
+        """
+        proctored_exam = ProctoredExam.objects.create(
+            course_id='test_course',
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90
+        )
+        result = proctored_exam.generate_hash()
+        self.assertEqual(type(result), str)
+        self.assertRegexpMatches(result, r"([a-fA-F\d]{32})")
+
 
 class ProctoredExamStudentAttemptTests(LoggedInTestCase):
     """

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -22,7 +22,8 @@ from edx_proctoring.models import (
 )
 from edx_proctoring.exceptions import (
     ProctoredExamIllegalStatusTransition,
-    StudentExamAttemptDoesNotExistsException, ProctoredExamPermissionDenied)
+    StudentExamAttemptDoesNotExistsException, ProctoredExamPermissionDenied
+)
 from edx_proctoring.views import require_staff, require_course_or_global_staff
 from edx_proctoring.api import (
     create_exam,
@@ -32,7 +33,10 @@ from edx_proctoring.api import (
 )
 
 from .utils import (
-    LoggedInTestCase
+    LoggedInTestCase,
+    get_provider_name_test,
+    MockedModulestore,
+    MockedCourseKey
 )
 
 from edx_proctoring.urls import urlpatterns
@@ -208,6 +212,7 @@ class ProctoredExamViewTests(LoggedInTestCase):
         self.assertEqual(response.status_code, 403)
         self.assertFalse(func.called)
 
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_decorator_require_course_or_global_staff(self):  # pylint: disable=invalid-name
         """
         Test assert require_course_or_global_staff before hitting any api url.
@@ -491,6 +496,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         self.assertEqual(attempt['status'], "started")
         self.assertFalse(attempt['status'] == "ready_to_start")
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_exam_create(self):
         """
         Start an exam (create an exam attempt)
@@ -517,6 +523,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         response_data = json.loads(response.content)
         self.assertGreater(response_data['exam_attempt_id'], 0)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_exam(self):
         """
         Start an exam (create an exam attempt)
@@ -565,7 +572,9 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         attempt = get_exam_attempt_by_id(old_attempt_id)
         self.assertIsNotNone(attempt['started_at'])
 
-    def test_start_exam_callback_when_created(self):
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
+    def test_start_exam_callback(self):
         """
         Test that hitting software secure callback URL twice when the attempt state begins at
         'created' does not change the state from 'started' back to 'ready to start'
@@ -573,6 +582,8 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         attempt = self._test_exam_attempt_creation()
         self._test_repeated_start_exam_callbacks(attempt)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
     def test_start_exam_callback_when_download_software_clicked(self):
         """
         Test that hitting software secure callback URL twice when the attempt state begins at
@@ -588,6 +599,46 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
 
         self._test_repeated_start_exam_callbacks(attempt)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
+    def test_bulk_start_exams_callback(self):
+        """
+        Test that call star exam callback.
+
+        Test that call star exam callback which changes the state
+        from 'created' to 'ready to start'
+        """
+        # Send wrong attempt
+        response = self.client.get(
+            reverse(
+                'edx_proctoring.anonymous.proctoring_launch_callback.bulk_start_exams_callback',
+                args=['wrong'])
+        )
+        self.assertEqual(response.status_code, 404)
+        # Create an exam.
+        proctored_exam = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_proctored=True
+        )
+        attempt_id = create_exam_attempt(proctored_exam.id, self.user.id)
+        attempt = get_exam_attempt_by_id(attempt_id)
+        self.assertEqual(attempt['status'], "created")
+
+        # hit callback and verify that exam status is 'ready to start'
+        code = attempt['attempt_code']
+        self.client.get(
+            reverse(
+                'edx_proctoring.anonymous.proctoring_launch_callback.bulk_start_exams_callback',
+                args=[code])
+        )
+        attempt = get_exam_attempt_by_id(attempt_id)
+        self.assertEqual(attempt['status'], "ready_to_start")
+
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_readback(self):
         """
         Confirms that an attempt can be read
@@ -638,6 +689,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
 
             self.assertEqual(response_data['accessibility_time_string'], 'you have less than a minute remaining')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_timer_remaining_time(self):
         """
         Test that remaining time is calculated correctly
@@ -710,6 +762,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         self.assertIsNone(response_data['completed_at'])
         self.assertEqual(response_data['time_remaining_seconds'], 0)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_status_error(self):
         """
         Test to confirm that attempt status is marked as error, because client
@@ -765,6 +818,8 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
             response_data = json.loads(response.content)
             self.assertEqual(response_data['status'], ProctoredExamStudentAttemptStatus.error)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_status_waiting_for_app_shutdown(self):
         """
         Test to confirm that attempt status is submitted when proctored client is shutdown
@@ -792,6 +847,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
             response_data = json.loads(response.content)
             self.assertTrue(response_data['client_has_shutdown'])
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_status_for_exception(self):
         """
         Test to confirm that exception will not effect the API call
@@ -810,6 +866,8 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
                 )
                 self.assertEqual(response.status_code, 200)
 
+    @patch('edx_proctoring.utils.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_status_stickiness(self):
         """
         Test to confirm that a status timeout error will not alter a completed state
@@ -876,11 +934,11 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
             )
 
     @ddt.data(
-        ProctoredExamStudentAttemptStatus.created,
         ProctoredExamStudentAttemptStatus.ready_to_start,
         ProctoredExamStudentAttemptStatus.started,
         ProctoredExamStudentAttemptStatus.ready_to_submit
     )
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_attempt_callback_timeout(self, running_status):
         """
         Ensures that the polling from the client will cause the
@@ -973,6 +1031,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertRaises(ProctoredExamPermissionDenied)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_remove_attempt(self):
         """
         Confirms that an attempt can be removed
@@ -1015,6 +1074,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_remove_attempt_non_staff(self):
         """
         Confirms that an attempt cannot be removed
@@ -1058,6 +1118,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         response_data = json.loads(response.content)
         self.assertEqual(response_data['detail'], 'Must be a Staff User to Perform this request.')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_read_others_attempt(self):
         """
         Confirms that we cnanot read someone elses attempt
@@ -1136,6 +1197,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
             'Cannot create new exam attempt for exam_id = 1 and user_id = 1 because it already exists!'
         )
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_stop_exam_attempt(self):
         """
         Stop an exam
@@ -1175,6 +1237,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         response_data = json.loads(response.content)
         self.assertEqual(response_data['exam_attempt_id'], old_attempt_id)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_download_software_clicked_action(self):
         """
         Test if the download_software_clicked state is set
@@ -1223,6 +1286,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         ('decline', ProctoredExamStudentAttemptStatus.declined)
     )
     @ddt.unpack
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_submit_exam_attempt(self, action, expected_status):
         """
         Tries to submit an exam
@@ -1325,6 +1389,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         response_data = json.loads(response.content)
         self.assertEqual(len(response_data['proctored_exam_attempts']), 1)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_exam_attempts_not_staff(self):
         """
         Test to get the exam attempts in a course as a not
@@ -1581,6 +1646,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         response_data = json.loads(response.content)
         self.assertEqual(response_data['detail'], 'Attempted to access attempt_id 0 but it does not exist.')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_exam_attempt(self):
         """
         Test Case for retrieving student proctored exam attempt status.
@@ -1623,6 +1689,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         # make sure we have the accessible human string
         self.assertEqual(data['accessibility_time_string'], 'you have 1 hour and 30 minutes remaining')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_exam_attempt_with_non_staff_user(self):  # pylint: disable=invalid-name
         """
         Test Case for retrieving student proctored exam attempt status.
@@ -1665,6 +1732,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         # make sure we have the accessible human string
         self.assertEqual(data['accessibility_time_string'], 'you have 1 hour and 30 minutes remaining')
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_get_expired_attempt(self):
         """
         Test Case for retrieving student proctored exam attempt status after it has expired
@@ -1743,6 +1811,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_declined_attempt(self):
         """
         Makes sure that a declined proctored attempt means that he/she fails credit requirement.
@@ -1779,6 +1848,8 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
             'declined'
         )
 
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
     def test_exam_callback(self):
         """
         Start an exam (create an exam attempt)
@@ -1858,6 +1929,9 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
     def test_review_callback(self):
         """
         Simulates a callback from the proctoring service with the
@@ -1879,7 +1953,15 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
                 self.user.id,
                 taking_as_proctored=True
             )
+        # send wong data
+        response = self.client.post(
+            reverse('edx_proctoring.anonymous.proctoring_review_callback'),
+            data='{"examMetaData":{}}',
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
 
+        # send correct data
         attempt = get_exam_attempt_by_id(attempt_id)
         self.assertIsNotNone(attempt['external_id'])
 
@@ -1895,6 +1977,56 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
+    def test_bulk_review_callback(self):
+        """
+        Simulates a callback from the proctoring service with the review data for a few exams.
+        """
+
+        exam_id = create_exam(
+            course_id='foo/bar/baz',
+            content_id='content',
+            exam_name='Sample Exam',
+            time_limit_mins=10,
+            is_proctored=True
+        )
+
+        # be sure to use the mocked out SoftwareSecure handlers
+        with HTTMock(mock_response_content):
+            attempt_id = create_exam_attempt(
+                exam_id,
+                self.user.id,
+                taking_as_proctored=True
+            )
+
+        # send list with wrong payload
+        response = self.client.post(
+            reverse('edx_proctoring.anonymous.proctoring_bulk_review_callback'),
+            data="""[{"examMetaData":{}}]""",
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # send correct payload list
+        attempt = get_exam_attempt_by_id(attempt_id)
+        self.assertIsNotNone(attempt['external_id'])
+
+        test_payload = Template(TEST_REVIEW_PAYLOAD).substitute(
+            attempt_code=attempt['attempt_code'],
+            external_id=attempt['external_id']
+        )
+        response = self.client.post(
+            reverse('edx_proctoring.anonymous.proctoring_bulk_review_callback'),
+            data="[" + test_payload + "]",
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @patch('edx_proctoring.api.reverse', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
     def test_review_caseinsensitive(self):
         """
         Simulates a callback from the proctoring service with the
@@ -1933,6 +2065,9 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
     def test_review_bad_contenttype(self):
         """
         Simulates a callback from the proctoring service when the
@@ -1970,6 +2105,9 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    @patch('edx_proctoring.api.reverse', get_provider_name_test)
+    @patch('edx_proctoring.api.get_provider_name_by_course_id', get_provider_name_test)
+    @patch('edx_proctoring.callbacks.get_provider_name_by_course_id', get_provider_name_test)
     def test_review_mismatch(self):
         """
         Simulates a callback from the proctoring service with the
@@ -2138,6 +2276,67 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertRaises(ProctoredExamPermissionDenied)
+
+
+@patch('edx_proctoring.views.CourseKey.from_string', MockedCourseKey)
+@patch('edx_proctoring.views.modulestore', MockedModulestore)
+@patch.dict(
+    'django.conf.settings.PROCTORING_BACKEND_PROVIDERS',
+    {"a": {}, "b": {}, "c": {}}
+)
+class TestProctoringServicesView(LoggedInTestCase):
+    """
+    Tests for the Proctoring services.
+    """
+
+    def setUp(self):
+        super(TestProctoringServicesView, self).setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.login_user(self.user)
+
+    def test_get_services(self):
+        """
+        Test getting list of proctoring services which available for current Course.
+        """
+
+        response = self.client.get(
+            reverse(
+                'edx_proctoring.proctoring_services',
+                kwargs={"course_id": "a/b/c"},
+            ),
+        )
+        response_data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data, {"current": "a", "list": ["a", "b"]})
+
+    def test_change_current_proctoring_service(self):
+        """
+        Test changing current proctoring service for the Course.
+        """
+        # send non exists proctoring service
+        response = self.client.put(
+            reverse(
+                'edx_proctoring.proctoring_services',
+                kwargs={"course_id": "a/b/c"},
+            ),
+            data=json.dumps({"proctoring_service": "x"}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 403)
+
+        # send proctoring service which exists
+        response = self.client.put(
+            reverse(
+                'edx_proctoring.proctoring_services',
+                kwargs={"course_id": "a/b/c"},
+            ),
+            data=json.dumps({"proctoring_service": "b"}),
+            content_type='application/json'
+        )
+        response_data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data, {"status": "OK"})
 
 
 class TestExamAllowanceView(LoggedInTestCase):
@@ -2533,10 +2732,10 @@ class TestExamAllowanceView(LoggedInTestCase):
             is_active=True
         )
         allowance_data = {
-            'exam_id': proctored_exam.id,
-            'user_info': self.student_taking_exam.email,
-            'key': 'a_key',
-            'value': '30'
+            "exam_id": proctored_exam.id,
+            "user_info": self.student_taking_exam.email,
+            "key": "a_key",
+            "value": "30"
         }
 
         # Add allowance
@@ -2548,6 +2747,8 @@ class TestExamAllowanceView(LoggedInTestCase):
         self.assertEqual(response.status_code, 200)
 
         allowance_data.pop('value')
+
+        allowance_data['user_id'] = self.student_taking_exam.id
 
         # now make the exam inactive
         proctored_exam.is_active = False

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-docstring
 """
 Subclasses Django test client to allow for easy login
 """
@@ -64,3 +65,41 @@ class LoggedInTestCase(TestCase):
         self.user = User(username='tester', email='tester@test.com')
         self.user.save()
         self.client.login_user(self.user)
+
+
+def get_provider_name_test(*args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Return provider name for test
+    """
+    return "TEST"
+
+
+def get_provider_name_software_secure(*args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Return provider name as 'software secure'
+    """
+    return "SOFTWARE_SECURE"
+
+
+class MockedCourseKey(object):
+
+    @classmethod
+    def __new__(cls, course_key, *args, **kwargs):
+        pass
+
+
+class MockedCourse(object):
+
+    def __init__(self, course_key):
+        self.course_key = course_key
+        self.available_proctoring_services = "a,b"
+        self.proctoring_service = "a"
+
+
+class MockedModulestore(object):
+
+    def get_course(self, course_key):
+        return MockedCourse(course_key)
+
+    def update_item(self, course, user_id):
+        pass

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -71,6 +71,16 @@ urlpatterns = patterns(  # pylint: disable=invalid-name
         views.ActiveExamsForUserView.as_view(),
         name='edx_proctoring.proctored_exam.active_exams_for_user'
     ),
+    url(
+        r'edx_proctoring/v1/proctoring_services/{}/$'.format(settings.COURSE_ID_PATTERN),
+        views.ProctoringServices.as_view(),
+        name='edx_proctoring.proctoring_services'
+    ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/attempt/(?P<attempt_code>[-\w]+)$',
+        views.StudentProctoredExamAttemptByCode.as_view(),
+        name='edx_proctoring.proctored_exam.attempt'
+    ),
     #
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data
@@ -81,9 +91,19 @@ urlpatterns = patterns(  # pylint: disable=invalid-name
         name='edx_proctoring.anonymous.proctoring_launch_callback.start_exam'
     ),
     url(
+        r'edx_proctoring/proctoring_launch_callback/bulk_start_exams/(?P<attempt_codes>[A-Za-z0-9\-\_\,]+)$',
+        callbacks.bulk_start_exams_callback,
+        name='edx_proctoring.anonymous.proctoring_launch_callback.bulk_start_exams_callback'
+    ),
+    url(
         r'edx_proctoring/proctoring_review_callback/$',
         callbacks.ExamReviewCallback.as_view(),
         name='edx_proctoring.anonymous.proctoring_review_callback'
+    ),
+    url(
+        r'edx_proctoring/proctoring_bulk_review_callback/$',
+        callbacks.BulkExamReviewCallback.as_view(),
+        name='edx_proctoring.anonymous.proctoring_bulk_review_callback'
     ),
     url(
         r'edx_proctoring/proctoring_poll_status/(?P<attempt_code>[-\w]+)$',

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -7,6 +7,8 @@ import logging
 from datetime import datetime, timedelta
 
 from django.utils.translation import ugettext as _
+from edx_proctoring.backends import get_provider_name_by_course_id, \
+    get_proctoring_settings
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -15,7 +17,6 @@ from edx_proctoring.models import (
     ProctoredExamStudentAttempt,
     ProctoredExamStudentAttemptHistory,
 )
-from edx_proctoring import constants
 
 # import dependent libraries (in local_requirements.txt otherwise pick up from running Open edX LMS runtime)
 from eventtracking import tracker
@@ -130,9 +131,10 @@ def has_client_app_shutdown(attempt):
     # we never heard from the client, so it must not have started
     if not attempt['last_poll_timestamp']:
         return True
-
     elapsed_time = (datetime.now(pytz.UTC) - attempt['last_poll_timestamp']).total_seconds()
-    return elapsed_time > constants.SOFTWARE_SECURE_SHUT_DOWN_GRACEPERIOD
+    provider_name = get_provider_name_by_course_id(attempt['proctored_exam']['course_id'])
+    proctoring_settings = get_proctoring_settings(provider_name)
+    return elapsed_time > proctoring_settings.get('SHUT_DOWN_GRACEPERIOD')
 
 
 def emit_event(exam, event_short_name, attempt=None, override_data=None):
@@ -224,3 +226,11 @@ def _emit_event(name, context, data):
             'Analytics tracker not properly configured. '
             'If this message appears in a production environment, please investigate'
         )
+
+
+def modulestore():
+    """
+    Import modulstore from xmodule for testing.
+    """
+    from xmodule.modulestore.django import modulestore as xmodulestore  # pylint: disable=import-error
+    return xmodulestore()

--- a/run_tests
+++ b/run_tests
@@ -1,15 +1,15 @@
-ECHO 'Beginning Test Run...'
-ECHO ''
-ECHO 'Removing *.pyc files'
+echo 'Beginning Test Run...'
+echo ''
+echo 'Removing *.pyc files'
 find . -name "*.pyc" -exec rm -rf {} \;
 
-ECHO 'Running test suite'
+echo 'Running test suite'
 coverage run manage.py test edx_proctoring --verbosity=3
 coverage report -m
 coverage html
-pep8 edx_proctoring
-pylint edx_proctoring --report=no
-ECHO ''
-ECHO 'View the full coverage report at {CODE_PATH}/edx-proctoring/htmlcov/index.html'
-ECHO ''
-ECHO 'Testing Complete!'
+#pep8 edx_proctoring
+#pylint edx_proctoring --report=no
+echo ''
+echo 'View the full coverage report at {CODE_PATH}/edx-proctoring/htmlcov/index.html'
+echo ''
+echo 'Testing Complete!'

--- a/settings.py
+++ b/settings.py
@@ -8,15 +8,15 @@ import sys
 import os
 BASE_DIR = os.path.dirname(__file__)
 
-DEBUG=True
-TEST_MODE=True
+DEBUG = True
+TEST_MODE = True
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 TEST_ROOT = "tests"
 TRANSACTIONS_MANAGED = {}
 USE_TZ = True
 TIME_ZONE = {}
-SECRET_KEY='SHHHHHH'
-PLATFORM_NAME='Open edX'
+SECRET_KEY = 'SHHHHHH'
+PLATFORM_NAME = 'Open edX'
 FEATURES = {}
 HTTPS = 'off'
 
@@ -74,22 +74,33 @@ ROOT_URLCONF = 'edx_proctoring.urls'
 COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
 COURSE_ID_PATTERN = r'(?P<course_id>%s)' % COURSE_ID_REGEX
 
-PROCTORING_BACKEND_PROVIDER = {
-    "class": "edx_proctoring.backends.tests.test_backend.TestBackendProvider",
-    "options": {}
+PROCTORING_SETTINGS = {
+    "ALLOW_CALLBACK_SIMULATION": False,
+    "CLIENT_TIMEOUT": 30,
+    "DEFAULT_REVIEW_POLICY": "Closed Book",
+    "REQUIRE_FAILURE_SECOND_REVIEWS": False,
 }
 
-PROCTORING_SETTINGS = {
-    'MUST_BE_VERIFIED_TRACK': True,
-    'MUST_COMPLETE_ICRV': True,
-    'LINK_URLS': {
-        'online_proctoring_rules': '',
-        'faq': '',
-        'contact_us': '',
-        'tech_requirements': '',
-    },
-    'ALLOW_CALLBACK_SIMULATION': False
+PROCTORING_BACKEND_PROVIDERS = {
+    "TEST": {
+        "class": "edx_proctoring.backends.tests.test_backend.TestBackendProvider",
+        "options": {},
+        "settings": {
+            "LINK_URLS": {
+                "contact_us": "{add link here}",
+                "faq": "{add link here}",
+                "online_proctoring_rules": "{add link here}",
+                "tech_requirements": "{add link here}"
+            },
+            "SHUT_DOWN_GRACEPERIOD" : 10
+        }
+    }
 }
 
 DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 CONTACT_EMAIL = 'info@edx.org'
+
+import logging
+
+south_logger = logging.getLogger('south')
+south_logger.setLevel(logging.INFO)


### PR DESCRIPTION
Background: Sometimes open edx is used as a platform on which a number of organizations are deploying their courses. Each of the organization may have different evaluation criteria, different procedure for passing the exam and may have their own proctor providers to specify the proctoring services at the course level.

How it is working now: 
edx proctoring works in format of one proctor provider per one Open edX installation.

What we propose(update edx-proctoring library): 
to make it possible to create a list of proctor providers and select one from the list for a particular course. Functionality of multi-proctoring:
1) to add all available proctor providers to the system settings,
2) to choose a corresponding proctoring service by a course administrator (studio -> advanced settings),
3) business logic of multi-proctoring is the same as edx - proctoring.

How it works:
1.To add all available proctor providers to the Open edX settings.
https://github.com/raccoongang/edx-proctoring/blob/tests_rebase/README.md

User with the “staff” permissions selects the corresponding proctoring service in the advanced settings.

{{ studio }}/settings/advanced/{{ course_key }}

«Proctoring service» : {{ proctoring service }}
«Enable Proctored Exams» : true

repositories and branches:

https://github.com/raccoongang/edx-platform/tree/dorosh/edx-multi-proctoring
https://github.com/raccoongang/edx-proctoring/tree/tests

Testing of multi-proctoring:
https://docs.google.com/document/d/1QNawOlJ4eCB5zGjlPZv6tdSauTMbkecEBgK8jCCkM8I/edit
