### PR TITLE
Fix timer time difference

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1522,7 +1522,7 @@ def _calculate_allowed_mins(due_datetime, allowed_mins):
             # e.g current_datetime=09:00, due_datetime=10:00 and allowed_mins=120(2hours)
             # then allowed_mins should be 60(1hour)
 
-            actual_allowed_mins = int((due_datetime - current_datetime).seconds / 60)
+            actual_allowed_mins = int((due_datetime - current_datetime).total_seconds() / 60)
     return actual_allowed_mins, is_exam_past_due_date
 
 

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -170,7 +170,7 @@ def emit_event(exam, event_short_name, attempt=None, override_data=None):
         # This can be used to determine how far into an attempt a given
         # event occured (e.g. "time to complete exam")
         attempt_event_elapsed_time_secs = (
-            (datetime.now(pytz.UTC) - attempt['started_at']).seconds if attempt['started_at'] else
+            (datetime.now(pytz.UTC) - attempt['started_at']).total_seconds() if attempt['started_at'] else
             None
         )
 


### PR DESCRIPTION
On Timed exams, there is issue with total time to attempt if due date is 24+ hours from now and we have set 24+ hours time_limit_mins ( 27 hours ) i.e it is like 1 day and 3 hours total time left to attempt the exam but it shows only 3 hours remaining time.

**Issue**
Actually `.seconds` is used instead of `.toatal_seconds()` to calculate total time between the dates/time interval.

[TNL-4216](https://openedx.atlassian.net/browse/TNL-4216)