### PR TITLE
TNL-4366 Add ability to hide timed exam after due date

### DIFF
--- a/edx_proctoring/migrations/0005_proctoredexam_hide_after_due.py
+++ b/edx_proctoring/migrations/0005_proctoredexam_hide_after_due.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edx_proctoring', '0004_auto_20160201_0523'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='proctoredexam',
+            name='hide_after_due',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -50,6 +50,9 @@ class ProctoredExam(TimeStampedModel):
     # Whether this exam will be active.
     is_active = models.BooleanField(default=False)
 
+    # Whether to hide this exam after the due date
+    hide_after_due = models.BooleanField(default=False)
+
     class Meta:
         """ Meta class for this Django model """
         unique_together = (('course_id', 'content_id'),)

--- a/edx_proctoring/serializers.py
+++ b/edx_proctoring/serializers.py
@@ -25,6 +25,7 @@ class ProctoredExamSerializer(serializers.ModelSerializer):
     is_practice_exam = serializers.BooleanField(required=True)
     is_proctored = serializers.BooleanField(required=True)
     due_date = serializers.DateTimeField(required=False, format=None)
+    hide_after_due = serializers.BooleanField(required=True)
 
     class Meta:
         """
@@ -34,7 +35,8 @@ class ProctoredExamSerializer(serializers.ModelSerializer):
 
         fields = (
             "id", "course_id", "content_id", "external_id", "exam_name",
-            "time_limit_mins", "is_proctored", "is_practice_exam", "is_active", "due_date"
+            "time_limit_mins", "is_proctored", "is_practice_exam", "is_active",
+            "due_date", "hide_after_due"
         )
 
 

--- a/edx_proctoring/templates/timed_exam/submitted.html
+++ b/edx_proctoring/templates/timed_exam/submitted.html
@@ -18,7 +18,7 @@
     {% blocktrans %}
       Your grade for this timed exam will be immediately available on the <a href="{{progress_page_url}}">Progress</a> page.
     {% endblocktrans %}
-    {% if has_due_date %}
+    {% if will_be_revealed %}
       {% blocktrans %}
         After the due date has passed, you can review the exam, but you cannot change your answers.
       {% endblocktrans %}

--- a/edx_proctoring/tests/test_serializer.py
+++ b/edx_proctoring/tests/test_serializer.py
@@ -23,7 +23,8 @@ class TestProctoredExamSerializer(unittest.TestCase):
             'external_id': '123',
             'is_proctored': 'bla',
             'is_practice_exam': 'bla',
-            'is_active': 'f'
+            'is_active': 'f',
+            'hide_after_due': 't',
         }
         serializer = ProctoredExamSerializer(data=data)
 

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -101,7 +101,8 @@ class ProctoredExamViewTests(LoggedInTestCase):
             'external_id': '123',
             'is_proctored': True,
             'is_practice_exam': False,
-            'is_active': True
+            'is_active': True,
+            'hide_after_due': False,
         }
         response = self.client.post(
             reverse('edx_proctoring.proctored_exam.exam'),
@@ -136,7 +137,8 @@ class ProctoredExamViewTests(LoggedInTestCase):
             'external_id': '123',
             'is_proctored': True,
             'is_practice_exam': False,
-            'is_active': True
+            'is_active': True,
+            'hide_after_due': False,
         }
         response = self.client.post(
             reverse('edx_proctoring.proctored_exam.exam'),

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -189,7 +189,8 @@ class ProctoredExamView(AuthenticatedAPIView):
                 is_proctored=request.data.get('is_proctored', None),
                 is_practice_exam=request.data.get('is_practice_exam', None),
                 external_id=request.data.get('external_id', None),
-                is_active=request.data.get('is_active', None)
+                is_active=request.data.get('is_active', None),
+                hide_after_due=request.data.get('hide_after_due', None),
             )
             return Response({'exam_id': exam_id})
         else:
@@ -213,6 +214,7 @@ class ProctoredExamView(AuthenticatedAPIView):
                 is_practice_exam=request.data.get('is_practice_exam', None),
                 external_id=request.data.get('external_id', None),
                 is_active=request.data.get('is_active', None),
+                hide_after_due=request.data.get('hide_after_due', None),
             )
             return Response({'exam_id': exam_id})
         except ProctoredExamNotFoundException, ex:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-proctoring',
-    version='0.12.15',
+    version='0.12.16',
     description='Proctoring subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
[TNL-4366](https://openedx.atlassian.net/browse/TNL-4366)

edx-platform PR: https://github.com/edx/edx-platform/pull/12165 - should be functionally be ready to go, but needs further test coverage and is also dependent on this PR landing.

This PR is ready to be reviewed - the functionality is up at https://efischer19.sandbox.edx.org/courses/course-v1:EricX+test+2016/courseware/8cb2b50cc12946908da02bbd42303a3f/39f8b6dc145d4fb4b89f05d601675616/.