### PR TITLE
SOL-1844 Allow for distinguishing between proctored exam and timed exam requests

### DIFF
--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -137,8 +137,9 @@ var edx = edx || {};
             self.timerTick ++;
             self.secondsLeft --;
             if (self.timerTick % 30 === 0){
-                var url = self.model.url + '/' + self.model.get('attempt_id') + '?sourceid=in_exam';
-                $.ajax(url).success(function(data) {
+                var url = self.model.url + '/' + self.model.get('attempt_id');
+                var queryString = '?sourceid=in_exam&proctored=' + this.model.get('taking_as_proctored');
+                $.ajax(url + queryString).success(function(data) {
                     if (data.status === 'error') {
                         // The proctoring session is in error state
                         // refresh the page to bring up the new Proctoring state from the backend.

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -62,7 +62,11 @@ describe('ProctoredExamView', function () {
         expect(reloadPage).toHaveBeenCalled();
     });
     it("resets the remainig exam time after the ajax response", function(){
-        this.server.respondWith("GET", "/api/edx_proctoring/v1/proctored_exam/attempt/" + this.proctored_exam_view.model.get('attempt_id') + '?sourceid=in_exam',
+        this.server.respondWith(
+            "GET",
+            "/api/edx_proctoring/v1/proctored_exam/attempt/" +
+            this.proctored_exam_view.model.get('attempt_id') +
+            '?sourceid=in_exam&proctored=true',
             [
                 200,
                 {"Content-Type": "application/json"},

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-proctoring',
-    version='0.12.19',
+    version='0.12.20',
     description='Proctoring subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
Adding a request parameter to exam attempt status polling that takes place during an exam which will allow us to distinguish between timed and proctored exams in logs.

Related PR: https://github.com/edx/edx-platform/pull/12815

@ormsbee @efischer19 