### PR TITLE
Improve the error message when proctoring fails

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1587,6 +1587,7 @@ def _get_proctored_exam_context(exam, attempt, course_id, is_practice_exam=False
             args=[attempt['id']]
         ) if attempt else '',
         'link_urls': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}),
+        'tech_support_email': settings.TECH_SUPPORT_EMAIL,
     }
 
 

--- a/edx_proctoring/templates/proctored_exam/error.html
+++ b/edx_proctoring/templates/proctored_exam/error.html
@@ -2,20 +2,16 @@
 <div class="failure sequence proctored-exam" data-exam-id="{{exam_id}}">
   <h3>
     {% blocktrans %}
-      There was a problem with your proctoring session
+      Error with proctored exam
     {% endblocktrans %}
   </h3>
 
-  <h4>
-    {% blocktrans %}
-      Your proctoring session results: <b class="failure"> Unsatisfactory </b>
-    {% endblocktrans %}
-  </h4>
-
   <p>
     {% blocktrans %}
-      Your proctoring session ended before you completed this exam, so your proctoring results are incomplete.
-      You will not be eligible to use this course for academic credit, even if you achieve a passing grade.
+      A technical error has occurred with your proctored exam. To resolve this problem, contact
+      <a href="mailto:{{tech_support_email}}">technical support</a>. All exam data, including answers
+      for completed problems, has been lost. When the problem is resolved you will need to restart
+      the exam and complete all problems again.
     {% endblocktrans %}
   </p>
   <hr>

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -126,7 +126,7 @@ class ProctoredExamApiTests(LoggedInTestCase):
         self.timed_exam_expired = 'The time allotted for this exam has expired.'
         self.submitted_timed_exam_msg_with_due_date = 'After the due date has passed,'
         self.exam_time_expired_msg = 'You did not complete the exam in the allotted time'
-        self.exam_time_error_msg = 'There was a problem with your proctoring session'
+        self.exam_time_error_msg = 'A technical error has occurred with your proctored exam'
         self.chose_proctored_exam_msg = 'Follow these steps to set up and start your proctored exam'
         self.proctored_exam_optout_msg = 'Take this exam as an open exam instead'
         self.proctored_exam_completed_msg = 'Are you sure you want to end your proctored exam'

--- a/settings.py
+++ b/settings.py
@@ -93,3 +93,4 @@ PROCTORING_SETTINGS = {
 
 DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 CONTACT_EMAIL = 'info@edx.org'
+TECH_SUPPORT_EMAIL = 'technical@example.com'


### PR DESCRIPTION
### Description
 
[TNL-5082](https://openedx.atlassian.net/browse/TNL-5082)

This change improves the error message shown when proctoring fails as described in TNL-5082. The new error looks as follows:

![image](https://cloud.githubusercontent.com/assets/5985072/17264509/7094ab34-55b5-11e6-94ba-4cb8d79d1f89.png)

### Sandbox
- [x] https://andy-armstrong.sandbox.edx.org

Notes:
 - Log in as verified@example.com
 - Go to the proctored exam: https://andy-armstrong.sandbox.edx.org/courses/course-v1:edX_test+PRCTR_TEST+1/courseware/9b7aeac146d54fc7a552f2feb2b00f51/be3702e5245a4d6f96194449303bdbf3/
 - If the exam has already been taken then clear the attempt:
   - log in as staff
   - switch to the Instructor Dashboard
   - switch to the "Special Exams" tab
   - click on "Student Special Exam Attempts"
   - hit the "x" next to the verified user's attempt and confirm that you wish to delete it
   - return to the exam as the verified user
 - click on the arrow next to "Continue to my proctored exam"
 - follow the steps to get verified for proctoring
 - start the exam
 - now force quit the "Remote Proctor Now" app
 - go back to the exam and wait for at least sixty seconds for it to notice that the proctoring has failed
 - the page should reload and show the expected error message

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @douglashall 
- [x] Doc Review: @catong 
- [ ] UX review: @marcotuts (optional)

FYI: @robrap 

### Post-review
- [x] Squash commits