### PR TITLE
Modify Proctoring Test Instructions Behavior

### DIFF
--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -38,8 +38,44 @@
         You will be asked to verify your identity before you begin the exam. Make sure you have valid photo identification, such as a driver's license or passport, before you continue.
       {% endblocktrans %}
     </p>
+    <p>
+        {% blocktrans %}
+          3. When you have finished setting up proctoring, start the exam.
+        {% endblocktrans %}
+    </p>
+    <div>
+        <button type="button" class="exam-action-button btn-pl-primary start-proctored-exam">
+            {% trans "Start Proctored Exam" %}
+        </button>
+    </div>
   </div>
 </div>
+<div id="accessible-error-modal" class="modal" aria-hidden="true">
+  <div class="inner-wrapper" role="dialog" aria-labelledby="accessible-error-title">
+    <button class="close-modal">
+      <span class="icon fa fa-remove" aria-hidden="true"></span>
+      <span class="sr">
+          {% trans "Close" %}
+      </span>
+    </button>
+
+    <header>
+        <h2 id="acessible-error-title">{% trans "Cannot Start Proctored Exam" %}</h2>
+        <span class="sr">,
+            {% trans "modal open"}
+        </span>
+    <hr aria-hidden="true" />
+    </header>
+    <div role="alertdialog" class="status message" tabindex="-1">
+        <p class="message-title" style="text-align: center; font-size: 16px;"></p>
+    </div>
+    <div class="actions" style="text-align: center;">
+        <button class="dismiss ok-button"></button>
+    </div>
+  </div>
+  <a href="#accessible-error-modal" rel="leanModal" id="confirm_open_button" style="display:none">{% trans "open"}</a>
+</div>
+
 <div class="footer-sequence border-b-0 padding-b-0">
   {% if not is_sample_attempt %}
   <p class="proctored-exam-instruction">
@@ -53,7 +89,14 @@
 
 <script type="text/javascript">
 
-  var _waiting_for_proctored_interval = null;
+  var accessible_error = function(message) {
+
+      accessible_modal("#accessible-error-modal #confirm_open_button",
+              "#accessible-error-modal .close-modal", "#accessible-error-modal", ".content-wrapper");
+      $("#accessible-error-modal #confirm_open_button").click();
+      $("#accessible-error-modal .message-title").html(message);
+      $("#accessible-error-modal .ok-button").html(gettext("OK"));
+  };
 
   $('.proctored-decline-exam').click(
     function(e) {
@@ -87,26 +130,30 @@
     }
   );
 
-  $(document).ready(function(){
-    _waiting_for_proctored_interval = setInterval(
-      poll_exam_started,
-      5000
-    );
-  });
 
-  function poll_exam_started() {
+  function check_exam_started() {
     var url = $('.instructions').data('exam-started-poll-url') + '?sourceid=instructions';
     $.ajax(url).success(function(data){
       if (data.status === 'ready_to_start') {
-        if (_waiting_for_proctored_interval != null) {
-          clearInterval(_waiting_for_proctored_interval)
-        }
         // we've state transitioned, so refresh the page
         // to reflect the new state (which will expose the test)
         location.reload();
       }
+      else {
+          // The proctoring setup is not yet complete.
+          // Show a modal indicating that the user is not done yet.
+          accessible_error(gettext("You must complete the proctoring setup before you can start the exam."));
+      }
     });
   }
+
+  $("#accessible-error-modal .cancel-button").click(function(){
+      $("#accessible-error-modal .close-modal").click();
+  });
+  $("#accessible-error-modal .ok-button").click(function(){
+      $("#accessible-error-modal .close-modal").click();
+  });
+  $('.start-proctored-exam').click(check_exam_started);
 
   $("#software_download_link").click(function (e) {
     e.preventDefault();


### PR DESCRIPTION
### Description
 
[TNL-5087](https://openedx.atlassian.net/browse/TNL-5087)

I have modified the behavior of this page such that it no longer polls to see whether or not the learner has completed the proctoring setup.

The color updates to the instructions will need to be a different edx-platform change: https://github.com/edx/edx-platform/pull/13187/commits/d7a2aa611fc1edc2f09bb319f0d03f9e9984bfaf

Here's some screenshots of the prototype:
![New instructions](https://dl.dropboxusercontent.com/u/386585530/system-check.png)
![Error modal](https://dl.dropboxusercontent.com/u/386585530/error-message.png)

### Sandbox
1. Visit https://dianakhuang.sandbox.edx.org/courses/course-v1:Proctoring+101+Now/courseware/e38af50b24a74f079af0c202bd364baa/8ce10919375843529a68d88e56860e9a/
2. Log in with the verified@example.com user information.
3. At the bottom of the instructions, click the 'Start Proctored Exam' button to view an error modal telling you need to set up proctoring.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @bjacobel 
- [x] Doc Review: @catong 
- [ ] UX review: @chris-mike 
- [x] Product Review: @marcotuts 

### Post-review
- [ ] Squash commits