### PR TITLE
Don't error out if the credit service returns None.

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -899,9 +899,19 @@ def update_attempt_status(exam_id, user_id, to_status, raise_if_not_found=True, 
             return_course_info=True
         )
 
+        default_name = _('your course')
+        if credit_state:
+            course_name = credit_state.get('course_name', default_name)
+        else:
+            course_name = default_name
+            log.info(
+                "Could not find credit_state for user id %r in the course %r.",
+                exam_attempt_obj.user_id,
+                exam_attempt_obj.proctored_exam.course_id
+            )
         send_proctoring_attempt_status_email(
             exam_attempt_obj,
-            credit_state.get('course_name', _('your course'))
+            course_name
         )
 
     # emit an anlytics event based on the state transition

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -72,7 +72,7 @@ from .utils import (
 
 from edx_proctoring.tests.test_services import (
     MockCreditService, MockCreditServiceWithCourseEndDate,
-    MockInstructorService,
+    MockInstructorService, MockCreditServiceNone,
 )
 from edx_proctoring.runtime import set_runtime_service, get_runtime_service
 from eventtracking import tracker
@@ -2302,6 +2302,20 @@ class ProctoredExamApiTests(LoggedInTestCase):
                 raise_if_not_found=False
             )
         )
+
+    def test_update_attempt_without_credit_state(self):
+        """
+        Test updating an attempt that does not have a corresponding credit state.
+        """
+        exam_attempt = self._create_started_exam_attempt()
+        set_runtime_service('credit', MockCreditServiceNone())
+        new_attempt = update_attempt_status(
+            exam_attempt.proctored_exam_id,
+            self.user.id,
+            ProctoredExamStudentAttemptStatus.verified
+        )
+
+        self.assertEqual(new_attempt, exam_attempt.id)
 
     @ddt.data(
         (

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -102,6 +102,18 @@ class MockCreditServiceWithCourseEndDate(MockCreditService):
         return self.status
 
 
+class MockCreditServiceNone(MockCreditService):
+    """
+    Mock Credit Service that returns None for the credit state every time.
+    """
+
+    def get_credit_state(self, user_id, course_key, return_course_info=False):  # pylint: disable=unused-argument
+        """
+        Mock implementation
+        """
+        return None
+
+
 class MockInstructorService(object):
     """
     Simple mock of the Instructor Service


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5307

Small fix. Prevents code from erroring out when a `credit_service` is not found.

Reviewers: @robrap @bjacobel 