### PR TITLE
French i18n

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,912 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-01 13:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: edx_proctoring/admin.py:86
+msgid "internally reviewed"
+msgstr ""
+
+#: edx_proctoring/admin.py:95
+msgid "All Unreviewed"
+msgstr ""
+
+#: edx_proctoring/admin.py:96
+msgid "All Unreviewed Failures"
+msgstr ""
+
+#: edx_proctoring/admin.py:117
+msgid "active proctored exams"
+msgstr ""
+
+#: edx_proctoring/admin.py:175
+msgid "courses with active proctored exams"
+msgstr ""
+
+#: edx_proctoring/admin.py:340
+msgid "Course Id"
+msgstr ""
+
+#: edx_proctoring/admin.py:378
+msgid "Created"
+msgstr ""
+
+#: edx_proctoring/admin.py:379
+msgid "Download Software Clicked"
+msgstr ""
+
+#: edx_proctoring/admin.py:380
+msgid "Ready To Start"
+msgstr ""
+
+#: edx_proctoring/admin.py:381
+msgid "Started"
+msgstr ""
+
+#: edx_proctoring/admin.py:382
+msgid "Ready To Submit"
+msgstr ""
+
+#: edx_proctoring/admin.py:383
+msgid "Declined"
+msgstr ""
+
+#: edx_proctoring/admin.py:384
+msgid "Timed Out"
+msgstr ""
+
+#: edx_proctoring/admin.py:385
+msgid "Submitted"
+msgstr ""
+
+#: edx_proctoring/admin.py:386
+msgid "Second Review Required"
+msgstr ""
+
+#: edx_proctoring/admin.py:387
+msgid "Verified"
+msgstr ""
+
+#: edx_proctoring/admin.py:388
+msgid "Rejected"
+msgstr ""
+
+#: edx_proctoring/admin.py:389
+msgid "Error"
+msgstr ""
+
+#: edx_proctoring/api.py:902
+msgid "your course"
+msgstr ""
+
+#: edx_proctoring/api.py:962
+msgid "Proctoring Session Results Update for {course_name} {exam_name}"
+msgstr ""
+
+#: edx_proctoring/api.py:1284
+msgid "Taking As Proctored Exam"
+msgstr ""
+
+#: edx_proctoring/api.py:1289
+msgid "Proctored Option Available"
+msgstr ""
+
+#: edx_proctoring/api.py:1294
+msgid "Taking As Open Exam"
+msgstr ""
+
+#: edx_proctoring/api.py:1299 edx_proctoring/api.py:1304
+msgid "Pending Session Review"
+msgstr ""
+
+#: edx_proctoring/api.py:1309
+msgid "Passed Proctoring"
+msgstr ""
+
+#: edx_proctoring/api.py:1314 edx_proctoring/api.py:1319
+msgid "Failed Proctoring"
+msgstr ""
+
+#: edx_proctoring/api.py:1324
+msgid "Proctored Option No Longer Available"
+msgstr ""
+
+#: edx_proctoring/api.py:1333
+msgid "Ungraded Practice Exam"
+msgstr ""
+
+#: edx_proctoring/api.py:1338
+msgid "Practice Exam Completed"
+msgstr ""
+
+#: edx_proctoring/api.py:1343
+msgid "Practice Exam Failed"
+msgstr ""
+
+#: edx_proctoring/api.py:1351
+msgid "Timed Exam"
+msgstr ""
+
+#: edx_proctoring/models.py:176
+msgid "pending"
+msgstr ""
+
+#: edx_proctoring/models.py:177
+msgid "satisfactory"
+msgstr ""
+
+#: edx_proctoring/models.py:178
+msgid "unsatisfactory"
+msgstr ""
+
+#: edx_proctoring/models.py:464
+msgid "Taking as Proctored"
+msgstr ""
+
+#: edx_proctoring/models.py:468
+msgid "Is Sample Attempt"
+msgstr ""
+
+#: edx_proctoring/models.py:681
+msgid "Additional Time (minutes)"
+msgstr ""
+
+#: edx_proctoring/models.py:682
+msgid "Review Policy Exception"
+msgstr ""
+
+#: edx_proctoring/templates/emails/proctoring_attempt_status_email.html:3
+#, python-format
+msgid ""
+"\n"
+"\n"
+"This email is to let you know that the status of your proctoring session "
+"review for %(exam_name)s in\n"
+"<a href=\"%(course_url)s\">%(course_name)s </a> is %(status)s. If you have "
+"any questions about proctoring,\n"
+"contact %(platform)s support at %(contact_email)s.\n"
+"\n"
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/entrance.html:4
+msgid ""
+"\n"
+"      Try a proctored exam\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/entrance.html:9
+msgid ""
+"\n"
+"      Get familiar with proctoring for real exams later in the course. This "
+"practice exam has no impact\n"
+"      on your grade in the course.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/entrance.html:15
+msgid "Continue to my practice exam"
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/entrance.html:17
+msgid ""
+"\n"
+"        You will be guided through steps to set up online proctoring "
+"software and to perform various checks.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/error.html:4
+msgid ""
+"\n"
+"      There was a problem with your practice proctoring session\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/error.html:10
+msgid ""
+"\n"
+"      Your practice proctoring results: <b class=\"failure\"> Unsatisfactory "
+"</b>\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/error.html:16
+msgid ""
+"\n"
+"      Your proctoring session ended before you completed this practice "
+"exam.\n"
+"      You can retry this practice exam if you had problems setting up the "
+"online proctoring software.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/error.html:25
+msgid "Try this practice exam again"
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/submitted.html:4
+msgid ""
+"\n"
+"      You have submitted this practice proctored exam\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/submitted.html:10
+msgid ""
+"\n"
+"      Practice exams do not affect your grade or your credit eligibility.\n"
+"      You have completed this practice exam and can continue with your "
+"course work.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/practice_exam/submitted.html:18
+msgid "You can also retry this practice exam"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/confirm-decline.html:5
+msgid ""
+"\n"
+"        Are you sure you want to take this exam without proctoring?\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/confirm-decline.html:10
+msgid ""
+"\n"
+"        If you take this exam without proctoring, you will <strong> no "
+"longer be eligible for academic credit. </strong>\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/confirm-decline.html:16
+msgid "Continue Exam Without Proctoring"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/confirm-decline.html:19
+msgid "Go Back"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/entrance.html:4
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:4
+#: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:4
+msgid ""
+"\n"
+"      This exam is proctored\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/entrance.html:9
+msgid ""
+"\n"
+"      To be eligible to earn credit for this course, you must take and pass "
+"the proctoring review for this exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/entrance.html:14
+msgid "Continue to my proctored exam. I want to be eligible for credit."
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/entrance.html:16
+msgid ""
+"\n"
+"        You will be guided through steps to set up online proctoring "
+"software and to perform various checks.</br>\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/entrance.html:24
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:37
+#: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:37
+msgid "Take this exam without proctoring."
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/entrance.html:27
+#: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:41
+msgid ""
+"\n"
+"        I am not interested in academic credit.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/error.html:4
+msgid ""
+"\n"
+"      Error with proctored exam\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/error.html:10
+#, python-format
+msgid ""
+"\n"
+"      A technical error has occurred with your proctored exam. To resolve "
+"this problem, contact\n"
+"      <a href=\"mailto:%(tech_support_email)s\">technical support</a>. All "
+"exam data, including answers\n"
+"      for completed problems, has been lost. When the problem is resolved "
+"you will need to restart\n"
+"      the exam and complete all problems again.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/error.html:19
+#: edx_proctoring/templates/proctored_exam/expired.html:15
+#: edx_proctoring/templates/proctored_exam/rejected.html:19
+#: edx_proctoring/templates/proctored_exam/submitted.html:24
+#: edx_proctoring/templates/proctored_exam/verified.html:18
+#, python-format
+msgid ""
+"\n"
+"      View your credit eligibility status on your <a href="
+"\"%(progress_page_url)s\">Progress</a> page.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/error.html:26
+#: edx_proctoring/templates/proctored_exam/rejected.html:26
+msgid ""
+"\n"
+"      If you have concerns about your proctoring session results, contact "
+"your course team.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/expired.html:4
+#: edx_proctoring/templates/timed_exam/expired.html:4
+msgid ""
+"\n"
+"      The due date for this exam has passed\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/expired.html:9
+#: edx_proctoring/templates/timed_exam/expired.html:9
+msgid ""
+"\n"
+"      Because the due date has passed, you are no longer able to take this "
+"exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:9
+#, python-format
+msgid ""
+"\n"
+"    You did not satisfy the requirements for taking this exam with "
+"proctoring, and are not eligible for credit. See your <a href="
+"\"%(progress_page_url)s\">Progress</a> page for a list of requirements and "
+"your status for each.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:14
+msgid ""
+"\n"
+"    You did not satisfy the following prerequisites:\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:30
+msgid ""
+"\n"
+"    Due to unsatisfied prerequisites, you can only take this exam without "
+"proctoring.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:41
+msgid ""
+"\n"
+"        I understand that I am not eligible for academic credit.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:47
+#, python-format
+msgid ""
+"\n"
+"      If you have questions about the status of your requirements for course "
+"credit, contact %(platform_name)s Support.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/footer.html:5
+msgid ""
+"\n"
+"        About Proctored Exams\n"
+"        "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:6
+msgid ""
+"\n"
+"      Follow these steps to set up and start your proctored exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:11
+msgid ""
+"\n"
+"        1. Copy this unique exam code. You will be prompted to paste this "
+"code later before you start the exam.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:19
+msgid ""
+"\n"
+"        Select the exam code, then copy it using Command+C (Mac) or Control"
+"+C (Windows).\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:24
+msgid ""
+"\n"
+"        2. Follow the link below to set up proctoring.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:32
+msgid ""
+"\n"
+"        A new window will open. You will run a system check before "
+"downloading the proctoring application.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:37
+msgid ""
+"\n"
+"        You will be asked to verify your identity before you begin the exam. "
+"Make sure you have valid photo identification, such as a driver's license or "
+"passport, before you continue.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:42
+msgid ""
+"\n"
+"          3. When you have finished setting up proctoring, start the exam.\n"
+"        "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:48
+msgid "Start Proctored Exam"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:58
+msgid "Close"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:63
+msgid "Cannot Start Proctored Exam"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:82
+msgid "Don't want to take this exam with online proctoring?"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/instructions.html:83
+msgid "Take this exam as an open exam instead."
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:9
+#, python-format
+msgid ""
+"\n"
+"    You have not completed the prerequisites for this exam. All requirements "
+"must be satisfied before you can take this proctored exam and be eligible "
+"for credit. See your <a href=\"%(progress_page_url)s\">Progress</a> page for "
+"a list of requirements in the order that they must be completed.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:14
+msgid ""
+"\n"
+"    The following prerequisites are in a <strong>pending</strong> state and "
+"must be successfully completed before you can proceed:\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:30
+#, python-format
+msgid ""
+"\n"
+"    You can take this exam with proctoring only when all prerequisites have "
+"been successfully completed. Check your <a href=\"%(progress_page_url)s"
+"\">Progress</a>  page to see if prerequisite results have been updated. You "
+"can also take this exam now without proctoring, but you will not be eligible "
+"for credit.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:164
+msgid " Your Proctoring Session Has Started "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:165
+#, python-format
+msgid ""
+" From this point in time, you must follow the <a href="
+"\"%(link_urls.online_proctoring_rules)s\" target=\"_blank\">online "
+"proctoring rules</a> to pass the proctoring review for your exam. "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:168
+msgid ""
+"\n"
+"            Do not close this window before you finish your exam. if you "
+"close this window, your proctoring session ends, and you will not "
+"successfully complete the proctored exam.\n"
+"          "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:173
+#, python-format
+msgid ""
+"\n"
+"            Return to the %(platform_name)s course window to start your "
+"exam. When you have finished your exam and\n"
+"            have marked it as complete, you can close this window to end the "
+"proctoring session\n"
+"            and upload your proctoring session data for review.\n"
+"          "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:183
+msgid " Go to my exam "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_start.html:5
+msgid ""
+"\n"
+"      Follow these instructions\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_start.html:10
+#, python-format
+msgid ""
+"\n"
+"        &#8226; When you start your exam you will have %(total_time)s to "
+"complete it. </br>\n"
+"        &#8226; You cannot stop the timer once you start. </br>\n"
+"        &#8226; If time expires before you finish your exam, your completed "
+"answers will be\n"
+"                submitted for review. </br>\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_start.html:19
+msgid ""
+"\n"
+"          Start my exam\n"
+"        "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_submit.html:4
+msgid ""
+"\n"
+"      Are you sure you want to end your proctored exam?\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_submit.html:9
+#: edx_proctoring/templates/timed_exam/ready_to_submit.html:9
+msgid ""
+"\n"
+"      Make sure that you have selected \"Check\" or \"Final Check\" for each "
+"problem before you submit your exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_submit.html:14
+msgid ""
+"\n"
+"      After you submit your exam, your responses are graded and your "
+"proctoring session is reviewed.\n"
+"      You might be eligible to earn academic credit for this course if you "
+"complete all required exams\n"
+"      as well as achieve a final grade that meets credit requirements for "
+"the course.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_submit.html:21
+msgid ""
+"\n"
+"      Yes, end my proctored exam\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/ready_to_submit.html:27
+msgid ""
+"\n"
+"        No, I'd like to continue working\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/rejected.html:4
+msgid ""
+"\n"
+"      Your proctoring session was reviewed and did not pass requirements\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/rejected.html:10
+#, python-format
+msgid ""
+"\n"
+"      You are no longer eligible for academic credit for this course, "
+"regardless of your final grade.\n"
+"      If you have questions about the status of your proctored exam results, "
+"contact %(platform_name)s Support.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/submitted.html:4
+msgid ""
+"\n"
+"      You have submitted this proctored exam for review\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/submitted.html:9
+msgid ""
+"\n"
+"      &#8226; After you quit the proctoring session, the recorded data is "
+"uploaded for review. </br>\n"
+"      &#8226; Proctoring results are usually available within 5 business "
+"days after you submit your exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/submitted.html:18
+#: edx_proctoring/templates/proctored_exam/waiting_for_app_shutdown.html:16
+#, python-format
+msgid ""
+"\n"
+"      If you have questions about the status of your proctored exam results, "
+"contact %(platform_name)s Support.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/verified.html:4
+msgid ""
+"\n"
+"      Your proctoring session was reviewed and passed all requirements\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/verified.html:10
+msgid ""
+"\n"
+"      You are eligible to purchase academic credit for this course if you "
+"complete all required exams\n"
+"      and also achieve a final grade that meets the credit requirements for "
+"the course.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/visit_exam_content.html:5
+msgid ""
+"\n"
+"      To view your exam questions and responses, select <strong>View my "
+"exam</strong>. The exam's review status is shown in the left navigation "
+"pane.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/visit_exam_content.html:11
+msgid "View my exam"
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/visit_exam_content.html:40
+msgid ""
+"\n"
+"      After the due date for this exam has passed, you will be able to "
+"review your answers on this page.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/waiting_for_app_shutdown.html:4
+msgid ""
+"\n"
+"      You are about to complete your proctored exam\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/proctored_exam/waiting_for_app_shutdown.html:9
+msgid ""
+"\n"
+"      Make sure you return to the proctoring software and select <strong> "
+"Quit </strong> to end proctoring\n"
+"      and submit your exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:4
+#, python-format
+msgid ""
+"\n"
+"    %(exam_name)s is a Timed Exam (%(total_time)s)\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:9
+msgid "This exam has a time limit associated with it."
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:11
+msgid "To pass this exam, you must complete the problems in the time allowed."
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:13
+msgid "After you select "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:15
+msgid "I am ready to start this timed exam,"
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:17
+msgid "you will have "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:17
+msgid " to complete and submit the exam."
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/entrance.html:21
+msgid ""
+"\n"
+"        I am ready to start this timed exam.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/footer.html:3
+msgid "Can I request additional time to complete my exam?"
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/footer.html:4
+msgid ""
+"\n"
+"      If you have disabilities,\n"
+"      you might be eligible for an additional time allowance on timed "
+"exams.\n"
+"      Ask your course team for information about additional time "
+"allowances.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/ready_to_submit.html:4
+msgid ""
+"\n"
+"      Are you sure that you want to submit your timed exam?\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/ready_to_submit.html:14
+msgid ""
+"\n"
+"      After you submit your exam, your exam will be graded.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/ready_to_submit.html:19
+msgid ""
+"\n"
+"      Yes, submit my timed exam.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/ready_to_submit.html:25
+msgid ""
+"\n"
+"        No, I want to continue working.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/submitted.html:6
+msgid ""
+"\n"
+"        The time allotted for this exam has expired. Your exam has been "
+"submitted and any work you completed will be graded.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/submitted.html:10
+msgid ""
+"\n"
+"        You have submitted your timed exam.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/submitted.html:18
+#, python-format
+msgid ""
+"\n"
+"      Your grade for this timed exam will be immediately available on the <a "
+"href=\"%(progress_page_url)s\">Progress</a> page.\n"
+"    "
+msgstr ""
+
+#: edx_proctoring/templates/timed_exam/submitted.html:22
+msgid ""
+"\n"
+"        After the due date has passed, you can review the exam, but you "
+"cannot change your answers.\n"
+"      "
+msgstr ""
+
+#: edx_proctoring/utils.py:74
+msgid "{num_of_hours} hour"
+msgstr ""
+
+#: edx_proctoring/utils.py:77
+msgid "{num_of_hours} hours"
+msgstr ""
+
+#: edx_proctoring/utils.py:85 edx_proctoring/utils.py:95
+msgid "{num_of_minutes} minutes"
+msgstr ""
+
+#: edx_proctoring/utils.py:88
+msgid " and {num_of_minutes} minute"
+msgstr ""
+
+#: edx_proctoring/utils.py:90
+msgid "{num_of_minutes} minute"
+msgstr ""
+
+#: edx_proctoring/utils.py:93
+msgid " and {num_of_minutes} minutes"
+msgstr ""
+
+#: edx_proctoring/views.py:94
+msgid "could not determine the course_id"
+msgstr ""
+
+#: edx_proctoring/views.py:104
+msgid "Must be a Staff User to Perform this request."
+msgstr ""
+
+#: edx_proctoring/views.py:365 edx_proctoring/views.py:577
+msgid "you have {remaining_time} remaining"
+msgstr ""
+
+#: edx_proctoring/views.py:371
+msgid "you have less than a minute remaining"
+msgstr ""
+
+#: edx_proctoring/views.py:567
+msgid "timed"
+msgstr ""
+
+#: edx_proctoring/views.py:568
+msgid "practice"
+msgstr ""
+
+#: edx_proctoring/views.py:568
+msgid "proctored"
+msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -3,172 +3,172 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-01 13:05+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2016-09-01 16:28+0100\n"
+"Last-Translator: Laurent David <laurent.at.fun@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.5.4\n"
 
 #: edx_proctoring/admin.py:86
 msgid "internally reviewed"
-msgstr ""
+msgstr "revue interne"
 
 #: edx_proctoring/admin.py:95
 msgid "All Unreviewed"
-msgstr ""
+msgstr "Pas de Compte Rendu"
 
 #: edx_proctoring/admin.py:96
 msgid "All Unreviewed Failures"
-msgstr ""
+msgstr "Les echecs non revus"
 
 #: edx_proctoring/admin.py:117
 msgid "active proctored exams"
-msgstr ""
+msgstr "les examens surveillés actifs"
 
 #: edx_proctoring/admin.py:175
 msgid "courses with active proctored exams"
-msgstr ""
+msgstr "cours avec des examen surveillés actifs"
 
 #: edx_proctoring/admin.py:340
 msgid "Course Id"
-msgstr ""
+msgstr "Identifiant du cours"
 
 #: edx_proctoring/admin.py:378
 msgid "Created"
-msgstr ""
+msgstr "Créé"
 
 #: edx_proctoring/admin.py:379
 msgid "Download Software Clicked"
-msgstr ""
+msgstr "Bouton de téléchargement cliqué"
 
 #: edx_proctoring/admin.py:380
 msgid "Ready To Start"
-msgstr ""
+msgstr "Prêt à démarrer"
 
 #: edx_proctoring/admin.py:381
 msgid "Started"
-msgstr ""
+msgstr "Démarré"
 
 #: edx_proctoring/admin.py:382
 msgid "Ready To Submit"
-msgstr ""
+msgstr "Prêt à soumettre"
 
 #: edx_proctoring/admin.py:383
 msgid "Declined"
-msgstr ""
+msgstr "Décliné"
 
 #: edx_proctoring/admin.py:384
 msgid "Timed Out"
-msgstr ""
+msgstr "Temps Expiré"
 
 #: edx_proctoring/admin.py:385
 msgid "Submitted"
-msgstr ""
+msgstr "Soumis"
 
 #: edx_proctoring/admin.py:386
 msgid "Second Review Required"
-msgstr ""
+msgstr "Seconde relecture requise"
 
 #: edx_proctoring/admin.py:387
 msgid "Verified"
-msgstr ""
+msgstr "Vérifié"
 
 #: edx_proctoring/admin.py:388
 msgid "Rejected"
-msgstr ""
+msgstr "Rejeté"
 
 #: edx_proctoring/admin.py:389
 msgid "Error"
-msgstr ""
+msgstr "Erreur"
 
 #: edx_proctoring/api.py:902
 msgid "your course"
-msgstr ""
+msgstr "votre cours"
 
 #: edx_proctoring/api.py:962
 msgid "Proctoring Session Results Update for {course_name} {exam_name}"
 msgstr ""
+"Mise à jour des résultats des session d'examen pour {course_name} {exam_name}"
 
 #: edx_proctoring/api.py:1284
 msgid "Taking As Proctored Exam"
-msgstr ""
+msgstr "Passer comme examen surveillé"
 
 #: edx_proctoring/api.py:1289
 msgid "Proctored Option Available"
-msgstr ""
+msgstr "Possibilité de le passer comme examen surveillé"
 
 #: edx_proctoring/api.py:1294
 msgid "Taking As Open Exam"
-msgstr ""
+msgstr "Passer comme examen \"ouvert\""
 
 #: edx_proctoring/api.py:1299 edx_proctoring/api.py:1304
 msgid "Pending Session Review"
-msgstr ""
+msgstr "Session en cours de revue"
 
 #: edx_proctoring/api.py:1309
 msgid "Passed Proctoring"
-msgstr ""
+msgstr "Examen passés"
 
 #: edx_proctoring/api.py:1314 edx_proctoring/api.py:1319
 msgid "Failed Proctoring"
-msgstr ""
+msgstr "Examens échoués"
 
 #: edx_proctoring/api.py:1324
 msgid "Proctored Option No Longer Available"
-msgstr ""
+msgstr "L'option examen surveillé plus disponible"
 
 #: edx_proctoring/api.py:1333
 msgid "Ungraded Practice Exam"
-msgstr ""
+msgstr "Examen blanc non noté"
 
 #: edx_proctoring/api.py:1338
 msgid "Practice Exam Completed"
-msgstr ""
+msgstr "Examen blanc complété"
 
 #: edx_proctoring/api.py:1343
 msgid "Practice Exam Failed"
-msgstr ""
+msgstr "Examen blanc échoué"
 
 #: edx_proctoring/api.py:1351
 msgid "Timed Exam"
-msgstr ""
+msgstr "Examen à temps limité"
 
 #: edx_proctoring/models.py:176
 msgid "pending"
-msgstr ""
+msgstr "en attente"
 
 #: edx_proctoring/models.py:177
 msgid "satisfactory"
-msgstr ""
+msgstr "satisfaisant"
 
 #: edx_proctoring/models.py:178
 msgid "unsatisfactory"
-msgstr ""
+msgstr "non statisfaisant"
 
 #: edx_proctoring/models.py:464
 msgid "Taking as Proctored"
-msgstr ""
+msgstr "Passer comme examen surveillé"
 
 #: edx_proctoring/models.py:468
 msgid "Is Sample Attempt"
-msgstr ""
+msgstr "Est une tentative d'exemple"
 
 #: edx_proctoring/models.py:681
 msgid "Additional Time (minutes)"
-msgstr ""
+msgstr "Temps additionnel (minutes)"
 
 #: edx_proctoring/models.py:682
 msgid "Review Policy Exception"
-msgstr ""
+msgstr "Revoir les Règles d'Exception"
 
 #: edx_proctoring/templates/emails/proctoring_attempt_status_email.html:3
 #, python-format
@@ -182,6 +182,14 @@ msgid ""
 "contact %(platform)s support at %(contact_email)s.\n"
 "\n"
 msgstr ""
+"\n"
+"\n"
+"Cet email a pour but de vous avertir que votre examen surveillé "
+"%(exam_name)s\n"
+"<a href=\"%(course_url)s\">%(course_name)s </a> est en %(status)s. Si vous "
+"avez des question à propos des examens surveillés,\n"
+"contactez le support de la plateforme %(platform)s à %(contact_email)s.\n"
+"\n"
 
 #: edx_proctoring/templates/practice_exam/entrance.html:4
 msgid ""
@@ -189,6 +197,9 @@ msgid ""
 "      Try a proctored exam\n"
 "    "
 msgstr ""
+"\n"
+"      Essayez un examen surveillé\n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/entrance.html:9
 msgid ""
@@ -198,10 +209,15 @@ msgid ""
 "      on your grade in the course.\n"
 "    "
 msgstr ""
+"\n"
+"       Se familiariser avec la surveillance d'examens pour des sessions "
+"examens réelles plus tard dans le cours. Cet examen blanc n'a pas d'impact \n"
+"       sur votre note dans le cours. \n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/entrance.html:15
 msgid "Continue to my practice exam"
-msgstr ""
+msgstr "Continuer mon examen blanc"
 
 #: edx_proctoring/templates/practice_exam/entrance.html:17
 msgid ""
@@ -210,6 +226,10 @@ msgid ""
 "software and to perform various checks.\n"
 "      "
 msgstr ""
+"\n"
+"        Vous serez guidé à travers les étapes pour mettre en place un "
+"logiciel de surveillance d'en ligne et d'effectuer différents contrôles.\n"
+"      "
 
 #: edx_proctoring/templates/practice_exam/error.html:4
 msgid ""
@@ -217,6 +237,9 @@ msgid ""
 "      There was a problem with your practice proctoring session\n"
 "    "
 msgstr ""
+"\n"
+"      Il y a eu un problème avec votre session d'examen blanc\n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/error.html:10
 msgid ""
@@ -225,6 +248,10 @@ msgid ""
 "</b>\n"
 "    "
 msgstr ""
+"\n"
+"     Les résultats de votre examen pratique: <b class=\"failure\"> Non "
+"satisfaisant </b>\n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/error.html:16
 msgid ""
@@ -235,10 +262,16 @@ msgid ""
 "online proctoring software.\n"
 "    "
 msgstr ""
+"\n"
+"      Votre session d'examen surveillé s'est terminée avant que vous n'ayez "
+"complété cet examen blanc.\n"
+"      Vous pouvez rééessayer cet examen blanc si vous avez eu des problèmes "
+"pour mettre en place le logiciel de surveillance d'examen.\n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/error.html:25
 msgid "Try this practice exam again"
-msgstr ""
+msgstr "Esssayez encore cet examen blanc"
 
 #: edx_proctoring/templates/practice_exam/submitted.html:4
 msgid ""
@@ -246,6 +279,9 @@ msgid ""
 "      You have submitted this practice proctored exam\n"
 "    "
 msgstr ""
+"\n"
+"      Vous avez soumis cet examen blanc\n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/submitted.html:10
 msgid ""
@@ -255,10 +291,16 @@ msgid ""
 "course work.\n"
 "    "
 msgstr ""
+"\n"
+"      Les examens blancs n'affectent pas votre note ou la possibilté d'avoir "
+"un crédit.\n"
+"      Vous avez complété cet examen pratique et pouvez continuer avec votre "
+"travail.\n"
+"    "
 
 #: edx_proctoring/templates/practice_exam/submitted.html:18
 msgid "You can also retry this practice exam"
-msgstr ""
+msgstr "Vous pouvez aussi réésayer cet examen blanc"
 
 #: edx_proctoring/templates/proctored_exam/confirm-decline.html:5
 msgid ""
@@ -266,6 +308,9 @@ msgid ""
 "        Are you sure you want to take this exam without proctoring?\n"
 "      "
 msgstr ""
+"\n"
+"        Êtes-vous sûr que vous voulez faire cet examen sans surveillance?\n"
+"      "
 
 #: edx_proctoring/templates/proctored_exam/confirm-decline.html:10
 msgid ""
@@ -277,11 +322,11 @@ msgstr ""
 
 #: edx_proctoring/templates/proctored_exam/confirm-decline.html:16
 msgid "Continue Exam Without Proctoring"
-msgstr ""
+msgstr "Continuer l'examen sans surveillance"
 
 #: edx_proctoring/templates/proctored_exam/confirm-decline.html:19
 msgid "Go Back"
-msgstr ""
+msgstr "Retourner"
 
 #: edx_proctoring/templates/proctored_exam/entrance.html:4
 #: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:4
@@ -291,6 +336,9 @@ msgid ""
 "      This exam is proctored\n"
 "    "
 msgstr ""
+"\n"
+"      Cet examen est surveillé\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/entrance.html:9
 msgid ""
@@ -316,7 +364,7 @@ msgstr ""
 #: edx_proctoring/templates/proctored_exam/failed-prerequisites.html:37
 #: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:37
 msgid "Take this exam without proctoring."
-msgstr ""
+msgstr "Faire cet examen sans surveillance"
 
 #: edx_proctoring/templates/proctored_exam/entrance.html:27
 #: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:41
@@ -332,6 +380,9 @@ msgid ""
 "      Error with proctored exam\n"
 "    "
 msgstr ""
+"\n"
+"      Error lors de l'examen surveillé\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/error.html:10
 #, python-format
@@ -376,6 +427,9 @@ msgid ""
 "      The due date for this exam has passed\n"
 "    "
 msgstr ""
+"\n"
+"      La date limite de passage de l'examen est dépassée\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/expired.html:9
 #: edx_proctoring/templates/timed_exam/expired.html:9
@@ -434,6 +488,9 @@ msgid ""
 "        About Proctored Exams\n"
 "        "
 msgstr ""
+"\n"
+"        A propos des examen surveillés\n"
+"        "
 
 #: edx_proctoring/templates/proctored_exam/instructions.html:6
 msgid ""
@@ -488,26 +545,31 @@ msgid ""
 "          3. When you have finished setting up proctoring, start the exam.\n"
 "        "
 msgstr ""
+"\n"
+"          3. Quand vous avez fini de mettre en place l'examen surveillé, "
+"démarrer l'examen.\n"
+"        "
 
 #: edx_proctoring/templates/proctored_exam/instructions.html:48
 msgid "Start Proctored Exam"
-msgstr ""
+msgstr "Démarrer l'examen surveillé"
 
 #: edx_proctoring/templates/proctored_exam/instructions.html:58
 msgid "Close"
-msgstr ""
+msgstr "Clore"
 
 #: edx_proctoring/templates/proctored_exam/instructions.html:63
 msgid "Cannot Start Proctored Exam"
-msgstr ""
+msgstr "Ne peut pas démarer l'examen surveillé"
 
 #: edx_proctoring/templates/proctored_exam/instructions.html:82
 msgid "Don't want to take this exam with online proctoring?"
 msgstr ""
+"Vous ne voulez pas passer cet examen avec la surveillance d'examens en ligne?"
 
 #: edx_proctoring/templates/proctored_exam/instructions.html:83
 msgid "Take this exam as an open exam instead."
-msgstr ""
+msgstr "Passez cet examen en tant qu'examen \"ouvert\" à la place"
 
 #: edx_proctoring/templates/proctored_exam/pending-prerequisites.html:9
 #, python-format
@@ -542,7 +604,7 @@ msgstr ""
 
 #: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:164
 msgid " Your Proctoring Session Has Started "
-msgstr ""
+msgstr "Votre examen surveillé a démarré"
 
 #: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:165
 #, python-format
@@ -575,7 +637,7 @@ msgstr ""
 
 #: edx_proctoring/templates/proctored_exam/proctoring_launch_callback.html:183
 msgid " Go to my exam "
-msgstr ""
+msgstr "Aller à mon examen"
 
 #: edx_proctoring/templates/proctored_exam/ready_to_start.html:5
 msgid ""
@@ -583,6 +645,9 @@ msgid ""
 "      Follow these instructions\n"
 "    "
 msgstr ""
+"\n"
+"      Suivez ces instructions\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/ready_to_start.html:10
 #, python-format
@@ -596,6 +661,15 @@ msgid ""
 "                submitted for review. </br>\n"
 "      "
 msgstr ""
+"\n"
+"        &#8226; Quand vous démarez votre examen vous aurez %(total_time)s "
+"pour le compléter. </br>\n"
+"        &#8226; Vous ne pouvez pas stopper le compteur de temps une fois "
+"démarré. </br>\n"
+"        &#8226; Si le temps expire durant votre sessions, seuls les "
+"questions validées et soumises seront\n"
+"                notées. </br>\n"
+"      "
 
 #: edx_proctoring/templates/proctored_exam/ready_to_start.html:19
 msgid ""
@@ -603,6 +677,9 @@ msgid ""
 "          Start my exam\n"
 "        "
 msgstr ""
+"\n"
+"          Démarrer mon examen\n"
+"        "
 
 #: edx_proctoring/templates/proctored_exam/ready_to_submit.html:4
 msgid ""
@@ -610,6 +687,9 @@ msgid ""
 "      Are you sure you want to end your proctored exam?\n"
 "    "
 msgstr ""
+"\n"
+"      Vous êtes sûr de vouloir finir cet examen surveillé?\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/ready_to_submit.html:9
 #: edx_proctoring/templates/timed_exam/ready_to_submit.html:9
@@ -619,6 +699,10 @@ msgid ""
 "problem before you submit your exam.\n"
 "    "
 msgstr ""
+"\n"
+"      Assurez-vous de bien avoir appuyé sur \"Vérifier\" or \"Vérification "
+"finale\" pour chaque problème avant d'avoir soumis votre examen.\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/ready_to_submit.html:14
 msgid ""
@@ -638,6 +722,9 @@ msgid ""
 "      Yes, end my proctored exam\n"
 "    "
 msgstr ""
+"\n"
+"      Oui, finir ma session d'examen surveillé\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/ready_to_submit.html:27
 msgid ""
@@ -645,6 +732,9 @@ msgid ""
 "        No, I'd like to continue working\n"
 "      "
 msgstr ""
+"\n"
+"        Non, je voudrais continuer à travailler\n"
+"      "
 
 #: edx_proctoring/templates/proctored_exam/rejected.html:4
 msgid ""
@@ -670,6 +760,9 @@ msgid ""
 "      You have submitted this proctored exam for review\n"
 "    "
 msgstr ""
+"\n"
+"      Vous avez présenté cet examen surveillé pour être revu\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/submitted.html:9
 msgid ""
@@ -697,6 +790,10 @@ msgid ""
 "      Your proctoring session was reviewed and passed all requirements\n"
 "    "
 msgstr ""
+"\n"
+"      Votre session de surveillance a été revue et correspond à toutes les "
+"exigences\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/verified.html:10
 msgid ""
@@ -707,6 +804,12 @@ msgid ""
 "the course.\n"
 "    "
 msgstr ""
+"\n"
+"      Vous êtes eligible pour bénéficier d'un UE pour ce cours si vous "
+"complétez tous les examens requis \n"
+"      et aussi avoir une note finale qui correspond au prérequis pour ce "
+"cours.\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/visit_exam_content.html:5
 msgid ""
@@ -716,10 +819,15 @@ msgid ""
 "pane.\n"
 "    "
 msgstr ""
+"\n"
+"      Pour voir les questions de votre examen et leur réponses, sélectionnez "
+"<strong>Voir mon examen</strong>. Le status du compte rendu de l'examen est "
+"indiqué dans la partie gauche du paneau de navigation.\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/visit_exam_content.html:11
 msgid "View my exam"
-msgstr ""
+msgstr "Voir mon examen"
 
 #: edx_proctoring/templates/proctored_exam/visit_exam_content.html:40
 msgid ""
@@ -728,6 +836,10 @@ msgid ""
 "review your answers on this page.\n"
 "    "
 msgstr ""
+"\n"
+"      Après la date limite de passage de l'examen, vous allez pouvoir revoir "
+"les réponses de cette page.\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/waiting_for_app_shutdown.html:4
 msgid ""
@@ -735,6 +847,9 @@ msgid ""
 "      You are about to complete your proctored exam\n"
 "    "
 msgstr ""
+"\n"
+"      Vous êtes en train de compléter votre examen surveillé\n"
+"    "
 
 #: edx_proctoring/templates/proctored_exam/waiting_for_app_shutdown.html:9
 msgid ""
@@ -744,6 +859,11 @@ msgid ""
 "      and submit your exam.\n"
 "    "
 msgstr ""
+"\n"
+"      Assurez vous que vous démarrez le logiciel de surveillance et "
+"sélectionnez<strong> Quitter </strong> pour finir la session\n"
+"      et soumettre votre examen.\n"
+"    "
 
 #: edx_proctoring/templates/timed_exam/entrance.html:4
 #, python-format
@@ -752,41 +872,40 @@ msgid ""
 "    %(exam_name)s is a Timed Exam (%(total_time)s)\n"
 "    "
 msgstr ""
+"\n"
+"    %(exam_name)s est un examen à temps limité (%(total_time)s) \n"
+" "
 
 #: edx_proctoring/templates/timed_exam/entrance.html:9
 msgid "This exam has a time limit associated with it."
-msgstr ""
+msgstr "Cet examen a une limite de temps associée."
 
 #: edx_proctoring/templates/timed_exam/entrance.html:11
 msgid "To pass this exam, you must complete the problems in the time allowed."
 msgstr ""
+"Pour passer cet examen, vous devez compléter les activités dans le temps "
+"alloué"
 
 #: edx_proctoring/templates/timed_exam/entrance.html:13
 msgid "After you select "
-msgstr ""
+msgstr "Apres avoir sélectionné"
 
 #: edx_proctoring/templates/timed_exam/entrance.html:15
 msgid "I am ready to start this timed exam,"
-msgstr ""
+msgstr "Je suis prêt(e) à démarrer cet examen,"
 
 #: edx_proctoring/templates/timed_exam/entrance.html:17
 msgid "you will have "
-msgstr ""
+msgstr "vous allez avoir"
 
 #: edx_proctoring/templates/timed_exam/entrance.html:17
 msgid " to complete and submit the exam."
-msgstr ""
+msgstr " pour compléter et soumettre l'examen"
 
 #: edx_proctoring/templates/timed_exam/entrance.html:21
-msgid ""
-"\n"
-"        I am ready to start this timed exam.\n"
-"      "
-msgstr ""
-
 #: edx_proctoring/templates/timed_exam/footer.html:3
 msgid "Can I request additional time to complete my exam?"
-msgstr ""
+msgstr "Puis-je demander un délai supplémentaire pour terminer mon examen?"
 
 #: edx_proctoring/templates/timed_exam/footer.html:4
 msgid ""
@@ -798,6 +917,13 @@ msgid ""
 "allowances.\n"
 "    "
 msgstr ""
+"\n"
+"      Si vous avez des difficultés,\n"
+"      vous pouvez éventuellement bénéficier de temps additionnel sur les "
+"examens.\n"
+"      Demandez à l'équipe pédagogique les information sur l'attribution de "
+"temps additionel.\n"
+"    "
 
 #: edx_proctoring/templates/timed_exam/ready_to_submit.html:4
 msgid ""
@@ -805,6 +931,9 @@ msgid ""
 "      Are you sure that you want to submit your timed exam?\n"
 "    "
 msgstr ""
+"\n"
+"      Etes vous sûr que vous voulez soumettre votre examn à temps limité?\n"
+"    "
 
 #: edx_proctoring/templates/timed_exam/ready_to_submit.html:14
 msgid ""
@@ -812,6 +941,9 @@ msgid ""
 "      After you submit your exam, your exam will be graded.\n"
 "    "
 msgstr ""
+"\n"
+"      Après avoir soumis votre examen, votre examen sera noté.\n"
+"    "
 
 #: edx_proctoring/templates/timed_exam/ready_to_submit.html:19
 msgid ""
@@ -819,6 +951,9 @@ msgid ""
 "      Yes, submit my timed exam.\n"
 "    "
 msgstr ""
+"\n"
+"      Oui soumettez mon examen à temps limité.\n"
+"    "
 
 #: edx_proctoring/templates/timed_exam/ready_to_submit.html:25
 msgid ""
@@ -826,6 +961,9 @@ msgid ""
 "        No, I want to continue working.\n"
 "      "
 msgstr ""
+"\n"
+"        Non je veux continuer à travailler.\n"
+"      "
 
 #: edx_proctoring/templates/timed_exam/submitted.html:6
 msgid ""
@@ -834,6 +972,10 @@ msgid ""
 "submitted and any work you completed will be graded.\n"
 "      "
 msgstr ""
+"\n"
+"        Le temps alloué pour cet examen a expiré. Votre examen a été   "
+"soumis et tout ce que vous avez complété sera noté.\n"
+"      "
 
 #: edx_proctoring/templates/timed_exam/submitted.html:10
 msgid ""
@@ -841,6 +983,9 @@ msgid ""
 "        You have submitted your timed exam.\n"
 "      "
 msgstr ""
+"\n"
+"        Vous avez soumis votre examen à temps limité.\n"
+"      "
 
 #: edx_proctoring/templates/timed_exam/submitted.html:18
 #, python-format
@@ -850,6 +995,11 @@ msgid ""
 "href=\"%(progress_page_url)s\">Progress</a> page.\n"
 "    "
 msgstr ""
+"\n"
+"      Votre note pour cet examen à temps limité sera disponible "
+"immédiatement sur la<a href=\"%(progress_page_url)s\">page de Progression</"
+"a>.\n"
+"    "
 
 #: edx_proctoring/templates/timed_exam/submitted.html:22
 msgid ""
@@ -858,55 +1008,61 @@ msgid ""
 "cannot change your answers.\n"
 "      "
 msgstr ""
+"\n"
+"       Après que la date de rendu soit dépassée, vous pouvez revoir les "
+"questions de l'examen, mais vous ne pouvez pas changer les réponses.\n"
+"      "
 
 #: edx_proctoring/utils.py:74
 msgid "{num_of_hours} hour"
-msgstr ""
+msgstr "{num_of_hours} hour"
 
 #: edx_proctoring/utils.py:77
 msgid "{num_of_hours} hours"
-msgstr ""
+msgstr "{num_of_hours} heures"
 
 #: edx_proctoring/utils.py:85 edx_proctoring/utils.py:95
 msgid "{num_of_minutes} minutes"
-msgstr ""
+msgstr "{num_of_minutes} minutes"
 
 #: edx_proctoring/utils.py:88
 msgid " and {num_of_minutes} minute"
-msgstr ""
+msgstr " et {num_of_minutes} minute"
 
 #: edx_proctoring/utils.py:90
 msgid "{num_of_minutes} minute"
-msgstr ""
+msgstr "{num_of_minutes} minute"
 
 #: edx_proctoring/utils.py:93
 msgid " and {num_of_minutes} minutes"
-msgstr ""
+msgstr " et {num_of_minutes} minutes"
 
 #: edx_proctoring/views.py:94
 msgid "could not determine the course_id"
-msgstr ""
+msgstr "ne peut déterminer l'identifiant du cours"
 
 #: edx_proctoring/views.py:104
 msgid "Must be a Staff User to Perform this request."
 msgstr ""
+"Vous devez être un utilisateur de l'équipe enseignante pour réaliser cette "
+"requête"
 
 #: edx_proctoring/views.py:365 edx_proctoring/views.py:577
 msgid "you have {remaining_time} remaining"
-msgstr ""
+msgstr "il reste {remaining_time} minute avant la fin"
 
 #: edx_proctoring/views.py:371
 msgid "you have less than a minute remaining"
-msgstr ""
+msgstr "il reste moins d'une minute avant la fin"
 
 #: edx_proctoring/views.py:567
 msgid "timed"
-msgstr ""
+msgstr "temps limité"
 
 #: edx_proctoring/views.py:568
 msgid "practice"
-msgstr ""
+msgstr "entraînement"
 
 #: edx_proctoring/views.py:568
 msgid "proctored"
-msgstr ""
+msgstr "surveillé"


### PR DESCRIPTION
Details from comment thread via @rmoch :

> This edX code, which is part of Dogwood release, is not internationalized at all. Nor in its repository, nor on Transifex. 
> We wrote french i18n files, as we need them for our release (France Université Numérique) and made a PR.
> I suppose your internationalization team should add this repository to Transifex process to allow community to translate in all the languages.

