### PR TITLE
Introduce id verification step for proctored exams

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1641,6 +1641,7 @@ def _get_proctored_exam_view(exam, context, exam_id, user_id, course_id):
     student_view_template = None
 
     credit_state = context.get('credit_state')
+    verification_status = context.get('verification_status')
 
     # see if only 'verified' track students should see this *except* if it is a practice exam
     check_mode = (
@@ -1720,6 +1721,8 @@ def _get_proctored_exam_view(exam, context, exam_id, user_id, course_id):
                     prerequisite_status['pending_prerequisites']
                 )
                 student_view_template = 'proctored_exam/pending-prerequisites.html'
+        elif verification_status is not 'approved':
+            student_view_template = 'proctored_exam/id_verification.html'
         else:
             student_view_template = 'proctored_exam/entrance.html'
             # emit an event that the user was presented with the option

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1721,8 +1721,6 @@ def _get_proctored_exam_view(exam, context, exam_id, user_id, course_id):
                     prerequisite_status['pending_prerequisites']
                 )
                 student_view_template = 'proctored_exam/pending-prerequisites.html'
-        elif verification_status is not 'approved':
-            student_view_template = 'proctored_exam/id_verification.html'
         else:
             student_view_template = 'proctored_exam/entrance.html'
             # emit an event that the user was presented with the option
@@ -1733,12 +1731,16 @@ def _get_proctored_exam_view(exam, context, exam_id, user_id, course_id):
         return None
     elif attempt_status in [ProctoredExamStudentAttemptStatus.created,
                             ProctoredExamStudentAttemptStatus.download_software_clicked]:
-        provider = get_backend_provider()
-        student_view_template = 'proctored_exam/instructions.html'
-        context.update({
-            'exam_code': attempt['attempt_code'],
-            'software_download_url': provider.get_software_download_url(),
-        })
+        if verification_status is not 'approved':
+            # if the user has not id verified yet, show them the page that requires them to do so
+            student_view_template = 'proctored_exam/id_verification.html'
+        else:
+            provider = get_backend_provider()
+            student_view_template = 'proctored_exam/instructions.html'
+            context.update({
+                'exam_code': attempt['attempt_code'],
+                'software_download_url': provider.get_software_download_url(),
+            })
     elif attempt_status == ProctoredExamStudentAttemptStatus.ready_to_start:
         student_view_template = 'proctored_exam/ready_to_start.html'
     elif attempt_status == ProctoredExamStudentAttemptStatus.error:

--- a/edx_proctoring/templates/proctored_exam/id_verification.html
+++ b/edx_proctoring/templates/proctored_exam/id_verification.html
@@ -1,0 +1,62 @@
+{% load i18n %}
+<div class="sequence proctored-exam instructions message-left-bar" data-exam-id="{{exam_id}}" data-exam-started-poll-url="{{exam_started_poll_url}}">
+
+    <div class="">
+        <h3>
+            {% blocktrans %}
+                Complete your verification before starting the proctored exam.
+            {% endblocktrans %}
+        </h3>
+        <p>
+            {% blocktrans %}
+                You must successfully complete identity verification before you can start the proctored exam.
+            {% endblocktrans %}
+        </p>
+        {% if verification_status == 'pending' %}
+            <p>
+                {% blocktrans %}
+                    Your verification is pending. Results should be available 2-3 days after you
+                    submit your verification.
+                {% endblocktrans %}
+            </p>
+        {% elif verification_status == 'must_reverify' %}
+            <p>
+                {% blocktrans %}
+                    Your verification attempt failed. Please read our guidelines to make
+                    sure you understand the requirements for successfully completing verification,
+                    then try again.
+                {% endblocktrans %}
+            </p>
+            <div>
+                <a href="{{ reverify_url }}" class="reverify-url btn-pl-primary">
+                    {% trans "Retry Verification" %}
+                </a>
+            </div>
+        {% elif verification_status == 'expired' %}
+            <p>
+                {% blocktrans %}
+                    Your verification has expired. You must successfully complete a new identity verification
+                    before you can start the proctored exam.
+                {% endblocktrans %}
+            </p>
+            <div>
+                <a href="{{ reverify_url }}" class="reverify-url btn-pl-primary">
+                    {% trans "Continue to Verification" %}
+                </a>
+            </div>
+        {% else %}
+            <p>
+                {% blocktrans %}
+                    Make sure you are on a computer with a webcam, and that you have valid photo identification
+                    such as a driver's license or passport, before you continue.
+                {% endblocktrans %}
+            </p>
+            <div>
+                <a href="{{ reverify_url }}" class="reverify-url btn-pl-primary">
+                    {% trans "Continue to Verification" %}
+                </a>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% include 'proctored_exam/footer.html' %}

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -35,7 +35,9 @@
     </p>
     <p>
       {% blocktrans %}
-        You will be asked to verify your identity before you begin the exam. Make sure you have valid photo identification, such as a driver's license or passport, before you continue.
+        You will be asked to verify your identity as part of the proctoring exam set up.
+        Make sure you are on a computer with a webcam, and that you have valid photo identification
+        such as a driver's license or passport, before you continue.
       {% endblocktrans %}
     </p>
     <p>

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -160,15 +160,15 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
     def test_verification_status(self, verification_status, expected_message):
         """
         This test asserts that the correct id verification message is shown
-        to the user for their current status.
+        to the user when they choose to take a proctored exam.
         """
 
-        exam = get_exam_by_id(self.proctored_exam_id)
+        self._create_unstarted_exam_attempt()
 
         rendered_response = get_student_view(
             user_id=self.user_id,
-            course_id=exam['course_id'],
-            content_id=exam['content_id'],
+            course_id=self.course_id,
+            content_id=self.content_id,
             context={
                 'is_proctored': True,
                 'display_name': self.exam_name,
@@ -373,7 +373,9 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
             context={
                 'is_proctored': True,
                 'display_name': self.exam_name,
-                'default_time_limit_mins': 90
+                'default_time_limit_mins': 90,
+                'verification_status': 'approved',
+                'verification_url': '/reverify',
             }
         )
         self.assertIn(self.chose_proctored_exam_msg, rendered_response)
@@ -394,7 +396,9 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
             context={
                 'is_proctored': True,
                 'display_name': self.exam_name,
-                'default_time_limit_mins': 90
+                'default_time_limit_mins': 90,
+                'verification_status': 'approved',
+                'verification_url': '/reverify',
             }
         )
         self.assertIn(self.chose_proctored_exam_msg, rendered_response)

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -414,6 +414,7 @@ class TestStudentProctoredExamAttempt(LoggedInTestCase):
         self.student_taking_exam = User()
         self.student_taking_exam.save()
 
+        set_runtime_service('credit', MockCreditService())
         set_runtime_service('instructor', MockInstructorService(is_user_course_staff=True))
 
     def _create_exam_attempt(self):


### PR DESCRIPTION
## [TNL-5083](https://openedx.atlassian.net/browse/TNL-5083)

### Description

This change introduces a new id verification step when rendering a proctored exam that is shown when the user has not yet passed verification. It also updates the subsequent instruction step to remove the unnecessary recommendation to ensure that the learner is verified.

### Sandbox
- [x] https://id-verification.sandbox.edx.org/courses/course-v1:AndyA+AAPT+1/courseware/9b7aeac146d54fc7a552f2feb2b00f51/be3702e5245a4d6f96194449303bdbf3/

You can use the four test users which are already in the various states:
```
verified_id_none@example.com
verified_id_failed@example.com
verified_id_pending@example.com
verified@example.com
```

### Testing
~~- [x] i18n~~
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @robrap 
- [x] Doc Review: @catong 
- [ ] UX review: @chris-mike 
- [ ] Product review: @marcotuts 

FYI: @douglashall 

### Post-review
- [x] Rebase and squash commits