### PR TITLE
Fix icon alignment for practice exams

### DIFF
--- a/edx_proctoring/templates/practice_exam/entrance.html
+++ b/edx_proctoring/templates/practice_exam/entrance.html
@@ -12,14 +12,13 @@
     {% endblocktrans %}
   </p>
   <button class="gated-sequence start-timed-exam action-primary" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
-      {% trans "Continue to my practice exam" %}
+    {% trans "Continue to my practice exam" %}
+    <span class="icon fa fa-arrow-circle-right" aria-hidden="true" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false></span>
     <p>
       {% blocktrans %}
         You will be guided through steps to set up online proctoring software and to perform various checks.
       {% endblocktrans %}
     </p>
-
-    <span class="icon fa fa-arrow-circle-right" aria-hidden="true" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false></span>
   </button>
 </div>
 {% include 'proctored_exam/footer.html' %}

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-proctoring',
-    version='0.16.0',
+    version='0.16.1',
     description='Proctoring subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
@marcotuts noticed an alignment bug for practice exams which I'd forgotten to verify. This fix moves the icon span before the paragraph tag, in order to make the right alignment work as expected.

@dianakhuang @robrap please review.

P.S. I'm updating the sandbox now.