### PR TITLE
Remove credit and progress page references.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,5 @@ Chris Dodge <cdodge@edx.org>
 Muhammad Shoaib <mshoaib@edx.org>
 Afzal Wali <afzal@edx.org>
 Mushtaq Ali <mushtaak@gmail.com>
+Christina Roberts <christina@edx.org>
+

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '0.18.0'
+__version__ = '0.18.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
@@ -9,8 +9,7 @@
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was reviewed and you
-        met all exam requirements. You can view your grade on the course
-        progress page.
+        met all exam requirements.
     {% endblocktrans %}
 </p>
 <p>

--- a/edx_proctoring/templates/practice_exam/submitted.html
+++ b/edx_proctoring/templates/practice_exam/submitted.html
@@ -8,7 +8,7 @@
 
   <p>
     {% blocktrans %}
-      Practice exams do not affect your grade or your credit eligibility.
+      Practice exams do not affect your grade.
       You have completed this practice exam and can continue with your course work.
     {% endblocktrans %}
   </p>

--- a/edx_proctoring/templates/proctored_exam/confirm-decline.html
+++ b/edx_proctoring/templates/proctored_exam/confirm-decline.html
@@ -8,7 +8,7 @@
     </div>
     <div class="msg-content">
       {% blocktrans %}
-        If you take this exam without proctoring, you will <strong> no longer be eligible for academic credit. </strong>
+        If you take this exam without proctoring, you will not be eligible for course credit or the MicroMasters credential if either applies to this course.
       {% endblocktrans %}
     </div>
     <div class="proctored-exam-skip-actions">

--- a/edx_proctoring/templates/proctored_exam/entrance.html
+++ b/edx_proctoring/templates/proctored_exam/entrance.html
@@ -11,7 +11,7 @@
     {% endblocktrans %}
   </p>
   <button class="gated-sequence start-timed-exam action-primary" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
-    {% trans "Continue to my proctored exam. I want to be eligible for credit." %}
+    {% trans "Continue to my proctored exam." %}
     <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
     <p>
       {% blocktrans %}

--- a/edx_proctoring/templates/proctored_exam/error.html
+++ b/edx_proctoring/templates/proctored_exam/error.html
@@ -14,12 +14,6 @@
       the exam and complete all problems again.
     {% endblocktrans %}
   </p>
-  <hr>
-  <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
-  </p>
 </div>
 <div class="footer-sequence border-b-0 padding-b-0">
   <p>

--- a/edx_proctoring/templates/proctored_exam/expired.html
+++ b/edx_proctoring/templates/proctored_exam/expired.html
@@ -10,10 +10,4 @@
       Because the due date has passed, you are no longer able to take this exam.
     {% endblocktrans %}
   </p>
-  <hr>
-  <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
-  </p>
 </div>

--- a/edx_proctoring/templates/proctored_exam/failed-prerequisites.html
+++ b/edx_proctoring/templates/proctored_exam/failed-prerequisites.html
@@ -7,7 +7,7 @@
   </h3>
   <p>
     {% blocktrans %}
-    You did not satisfy the requirements for taking this exam with proctoring, and are not eligible for credit. See your <a href="{{progress_page_url}}">Progress</a> page for a list of requirements and your status for each.
+    You did not satisfy the requirements for taking this exam with proctoring.
     {% endblocktrans %}
   </p>
   <p>
@@ -38,7 +38,7 @@
   {% endif %}
   <p>
     {% blocktrans %}
-      If you have questions about the status of your requirements for course credit, contact {{ platform_name }} Support.
+      If you have questions about the status of your requirements, contact {{ platform_name }} Support.
     {% endblocktrans %}
   </p>
 </div>

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -84,7 +84,6 @@
       <a href="#" class="proctored-decline-exam" data-action="decline" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}">
         {% trans "Take this exam without proctoring." %}
       </a>
-      {% trans "Doing so means that you are no longer eligible for academic credit." %}
     </p>
   {% endif %}
 </div>
@@ -111,8 +110,7 @@
       var action = $(this).data('action');
 
       var msg = gettext(
-        "Are you sure you want to take this exam without proctoring? " +
-        "You will no longer be eligible to use this course for academic credit."
+        "Are you sure you want to take this exam without proctoring?"
       );
       if (!confirm(msg)) {
         return;

--- a/edx_proctoring/templates/proctored_exam/pending-prerequisites.html
+++ b/edx_proctoring/templates/proctored_exam/pending-prerequisites.html
@@ -7,7 +7,7 @@
   </h3>
   <p>
     {% blocktrans %}
-    You have not completed the prerequisites for this exam. All requirements must be satisfied before you can take this proctored exam and be eligible for credit. See your <a href="{{progress_page_url}}">Progress</a> page for a list of requirements in the order that they must be completed.
+    You have not completed the prerequisites for this exam. All requirements must be satisfied before you can take this proctored exam.
     {% endblocktrans %}
   </p>
   <p>
@@ -28,7 +28,7 @@
   </p>
   <p>
     {% blocktrans %}
-    You can take this exam with proctoring only when all prerequisites have been successfully completed. Check your <a href="{{progress_page_url}}">Progress</a>  page to see if prerequisite results have been updated. You can also take this exam now without proctoring, but you will not be eligible for credit.
+    You can take this exam with proctoring only when all prerequisites have been successfully completed.
     {% endblocktrans %}
   </p>
 

--- a/edx_proctoring/templates/proctored_exam/proctoring_opt_out_button.html
+++ b/edx_proctoring/templates/proctored_exam/proctoring_opt_out_button.html
@@ -4,10 +4,5 @@
   <button class="gated-sequence start-timed-exam" data-attempt-proctored=false>
     {% trans "Take this exam without proctoring." %}
     <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
-    <p>
-      {% blocktrans %}
-        I am not interested in academic credit.
-      {% endblocktrans %}
-    </p>
   </button>
 {% endif %}

--- a/edx_proctoring/templates/proctored_exam/ready_to_submit.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_submit.html
@@ -13,8 +13,6 @@
   <p>
     {% blocktrans %}
       After you submit your exam, your responses are graded and your proctoring session is reviewed.
-      You might be eligible to earn academic credit for this course if you complete all required exams
-      as well as achieve a final grade that meets credit requirements for the course.
     {% endblocktrans %}
   </p>
   <button type="button" name="submit-proctored-exam" class="exam-action-button btn btn-pl-primary btn-base" data-action="submit" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}">

--- a/edx_proctoring/templates/proctored_exam/rejected.html
+++ b/edx_proctoring/templates/proctored_exam/rejected.html
@@ -8,18 +8,10 @@
 
   <p>
     {% blocktrans %}
-      You are no longer eligible for academic credit for this course, regardless of your final grade.
       If you have questions about the status of your proctored exam results, contact {{ platform_name }} Support.
     {% endblocktrans %}
   </p>
   {% include 'proctored_exam/visit_exam_content.html' %}
-
-  <hr>
-  <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
-  </p>
 </div>
 <div class="footer-sequence border-b-0 padding-b-0">
   <p>

--- a/edx_proctoring/templates/proctored_exam/submitted.html
+++ b/edx_proctoring/templates/proctored_exam/submitted.html
@@ -24,11 +24,5 @@
       If you have questions about the status of your proctored exam results, contact {{ platform_name }} Support.
     {% endblocktrans %}
   </p>
-  <hr>
-  <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
-  </p>
 </div>
 {% include 'proctored_exam/footer.html' %}

--- a/edx_proctoring/templates/proctored_exam/verified.html
+++ b/edx_proctoring/templates/proctored_exam/verified.html
@@ -6,18 +6,6 @@
     {% endblocktrans %}
   </h3>
 
-  <p>
-    {% blocktrans %}
-      You are eligible to purchase academic credit for this course if you complete all required exams
-      and also achieve a final grade that meets the credit requirements for the course.
-    {% endblocktrans %}
-  </p>
     {% include 'proctored_exam/visit_exam_content.html' %}
-  <hr>
-  <p>
-    {% blocktrans %}
-      View your credit eligibility status on your <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
-  </p>
 </div>
 {% include 'proctored_exam/footer.html' %}

--- a/edx_proctoring/templates/proctored_exam/visit_exam_content.html
+++ b/edx_proctoring/templates/proctored_exam/visit_exam_content.html
@@ -35,10 +35,4 @@
       }
     );
   </script>
-{% elif has_due_date %}
-  <p>
-    {% blocktrans %}
-      After the due date for this exam has passed, you will be able to review your answers on this page.
-    {% endblocktrans %}
-  </p>
 {% endif %}

--- a/edx_proctoring/templates/timed_exam/submitted.html
+++ b/edx_proctoring/templates/timed_exam/submitted.html
@@ -15,9 +15,6 @@
   </h3>
   <hr>
   <p>
-    {% blocktrans %}
-      Your grade for this timed exam will be immediately available on the <a href="{{progress_page_url}}">Progress</a> page.
-    {% endblocktrans %}
     {% if will_be_revealed %}
       {% blocktrans %}
         After the due date has passed, you can review the exam, but you cannot change your answers.


### PR DESCRIPTION
EDUCATOR-396

Removes references to credit, the course progress page, and viewing exam content after the due date has passed.

Please review: @andy-armstrong @catong @marcotuts 