### PR TITLE
Only request reviewed translations from transifex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ detect_changed_source_translations:
 	cd edx_proctoring && i18n_tool changed
 
 pull_translations: ## pull translations from Transifex
-	tx pull -af
+	tx pull -af --mode reviewed
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s


### PR DESCRIPTION
This adds the `--mode reviewed` option to the transifex command to ensure that we only pull translations that have been reviewed into the codebase from transifex. This should reduce the likelihood that bad translations make it into the application.