### PR TITLE
Update for django 1.11 compatibility.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,4 @@ Muhammad Shoaib <mshoaib@edx.org>
 Afzal Wali <afzal@edx.org>
 Mushtaq Ali <mushtaak@gmail.com>
 Christina Roberts <christina@edx.org>
-
+Dennis Jen <djen@edx.org>

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '0.18.1'
+__version__ = '0.18.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/management/commands/set_attempt_status.py
+++ b/edx_proctoring/management/commands/set_attempt_status.py
@@ -4,9 +4,7 @@ Django management command to manually set the attempt status for a user in a pro
 
 from __future__ import absolute_import
 
-from optparse import make_option
-
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from edx_proctoring.models import ProctoredExamStudentAttemptStatus
 
@@ -16,20 +14,28 @@ class Command(BaseCommand):
     Django Management command to force a background check of all possible notifications
     """
 
-    option_list = BaseCommand.option_list + (
-        make_option('-e', '--exam',
-                    metavar='EXAM_ID',
-                    dest='exam_id',
-                    help='exam_id to change'),
-        make_option('-u', '--user',
-                    metavar='USER',
-                    dest='user_id',
-                    help="user_id of user to affect"),
-        make_option('-t', '--to',
-                    metavar='TO_STATUS',
-                    dest='to_status',
-                    help='the status to set'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-e',
+            '--exam',
+            metavar='EXAM_ID',
+            dest='exam_id',
+            help='exam_id to change',
+        )
+        parser.add_argument(
+            '-u',
+            '--user',
+            metavar='USER',
+            dest='user_id',
+            help='user_id of user to affect',
+        )
+        parser.add_argument(
+            '-t',
+            '--to',
+            metavar='TO_STATUS',
+            dest='to_status',
+            help='the status to set',
+        )
 
     def handle(self, *args, **options):
         """
@@ -56,7 +62,7 @@ class Command(BaseCommand):
         print msg
 
         if not ProctoredExamStudentAttemptStatus.is_valid_status(to_status):
-            raise Exception('{to_status} is not a valid attempt status!'.format(to_status=to_status))
+            raise CommandError('{to_status} is not a valid attempt status!'.format(to_status=to_status))
 
         # get exam, this will throw exception if does not exist, so let it bomb out
         get_exam_by_id(exam_id)

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -5,12 +5,11 @@ URL mappings for edX Proctoring Server.
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from edx_proctoring import views, callbacks
 
-urlpatterns = patterns(  # pylint: disable=invalid-name
-    '',
+urlpatterns = [
     url(
         r'edx_proctoring/v1/proctored_exam/exam$',
         views.ProctoredExamView.as_view(),
@@ -89,4 +88,4 @@ urlpatterns = patterns(  # pylint: disable=invalid-name
         name='edx_proctoring.anonymous.proctoring_review_callback'
     ),
     url(r'^', include('rest_framework.urls', namespace='rest_framework'))
-)
+]

--- a/test_settings.py
+++ b/test_settings.py
@@ -100,3 +100,10 @@ PROCTORING_SETTINGS = {
 DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 CONTACT_EMAIL = 'info@edx.org'
 TECH_SUPPORT_EMAIL = 'technical@example.com'
+
+########## TEMPLATE CONFIGURATION
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': True,
+}]
+########## END TEMPLATE CONFIGURATION

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27}-django{18}
+envlist = {py27}-django{18,111}
 
 [doc8]
 max-line-length = 120
@@ -21,8 +21,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = test_settings
 deps =
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     -rrequirements/test.txt
 commands =
     coverage run ./manage.py test {posargs}


### PR DESCRIPTION
[EDUCATOR-766](https://openedx.atlassian.net/browse/EDUCATOR-766): Upgrade edx-proctoring to Django 1.11:
* Added django 1.11 to tox and added it to the `envlist`. This will run tests against django 1.8 & 1.11
* To support django 1.11, management commands are updated to use `parser.add_arguments()` instead of `make_option`, `patterns` is removed, and test settings are updated to indicate the template backend and that this is an app (e.g. installed w/in the platform)

Please review, @edx/educator-dahlia 