### PR TITLE
EDUCATOR-757

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -205,6 +205,19 @@ def get_review_policy_by_exam_id(exam_id):
     return ProctoredExamReviewPolicySerializer(exam_review_policy).data
 
 
+def _get_review_policy_by_exam_id(exam_id):
+    """
+    Looks up exam by the primary key. Returns None if not found
+
+    Returns review_policy field of the Django ORM object
+    """
+    try:
+        exam_review_policy = get_review_policy_by_exam_id(exam_id)
+        return ProctoredExamReviewPolicySerializer(exam_review_policy).data['review_policy']
+    except ProctoredExamReviewPolicyNotFoundException:
+        return None
+
+
 def update_exam(exam_id, exam_name=None, time_limit_mins=None, due_date=constants.MINIMUM_TIME,
                 is_proctored=None, is_practice_exam=None, external_id=None, is_active=None, hide_after_due=None):
     """
@@ -1623,6 +1636,7 @@ def _get_proctored_exam_context(exam, attempt, course_id, is_practice_exam=False
         ) if attempt else '',
         'link_urls': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}),
         'tech_support_email': settings.TECH_SUPPORT_EMAIL,
+        'exam_review_policy': _get_review_policy_by_exam_id(exam['id']),
     }
 
 

--- a/edx_proctoring/templates/proctored_exam/ready_to_start.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_start.html
@@ -12,8 +12,29 @@
         &#8226; You cannot stop the timer once you start. </br>
         &#8226; If time expires before you finish your exam, your completed answers will be
                 submitted for review. </br>
+        &#8226; If you have not taken a proctored exam before using {{ platform_name }} please read
+                the exam rules and guidelines first. Reading these will ensure you don't accidentally violate
+                any of the proctored exam rules. {% endblocktrans %}
+                <a href="{{link_urls.online_proctoring_rules}}" target="_blank">
+                  {% blocktrans %}
+                  Read the {{ platform_name }} Online Proctoring Rules for Learners
+                  {% endblocktrans %}
+                </a> </br>
+    </p>
+    {% if exam_review_policy %}
+    <h3>
+    {% blocktrans %}
+      Additional Exam Rules
+    {% endblocktrans %}
+    </h3>
+    <p>
+      {% blocktrans %}
+        In addition to the general exam rules above, the following additions or exceptions apply to this exam: </br> </br>
+
+        {{ exam_review_policy }} </br>
       {% endblocktrans %}
     </p>
+    {% endif %}
     <div>
       <button type="button" class="exam-action-button proctored-enter-exam btn btn-pl-primary btn-base" data-action="start" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}">
         {% blocktrans %}

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -43,6 +43,7 @@ from edx_proctoring.api import (
     _are_prerequirements_satisfied,
     create_exam_review_policy,
     get_review_policy_by_exam_id,
+    _get_review_policy_by_exam_id,
     update_review_policy,
     remove_review_policy,
 )
@@ -194,6 +195,23 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         self.assertEqual(exam_review_policy['proctored_exam']['id'], proctored_exam['id'])
         self.assertEqual(exam_review_policy['set_by_user']['id'], self.user_id)
         self.assertEqual(exam_review_policy['review_policy'], u'allow use of paper')
+
+    def test_get_exam_review_policy(self):
+        """
+        Test that creates a new exam policy and tests
+        that the policy can be properly retrieved
+        """
+        proctored_exam = get_exam_by_id(self.proctored_exam_id)
+        create_exam_review_policy(
+            exam_id=proctored_exam['id'],
+            set_by_user_id=self.user_id,
+            review_policy=u'allow use of paper'
+        )
+
+        # now get the exam review policy for the proctored exam
+        exam_review_policy_string = _get_review_policy_by_exam_id(proctored_exam['id'])
+
+        self.assertEqual(exam_review_policy_string, u'allow use of paper')
 
     def test_update_exam_review_policy(self):
         """


### PR DESCRIPTION
Allows learners to see the proctor review rules set by the instructor before beginning a proctored exam as well as a link to the online proctoring review rules. 

Before:
![image](https://user-images.githubusercontent.com/16583647/29033244-62082f54-7b62-11e7-8f0c-ae3baa996802.png)

After:
![image](https://user-images.githubusercontent.com/16583647/29033287-8e2a086e-7b62-11e7-8074-c1b1822cfa06.png)

https://openedx.atlassian.net/browse/EDUCATOR-757
https://proctor-review-rules.sandbox.edx.org

To see the affected page, log in as a verified user and go to [this](https://proctor-review-rules.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40workflow) link. I currently have the review rules set to `Test test test`.
PR in edx-platform for Studio changes: https://github.com/edx/edx-platform/pull/15743

Updated sandbox with new text: https://proctor-review-rules-2.sandbox.edx.org
Updated link for affected pages: [link](https://proctor-review-rules-2.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40workflow)

@edx/educator-dahlia 