### PR TITLE
add report generation endpoint + tests

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Adds an endpoint `get_exam_violation_report` to generate an exam violation report.

Details of the product request are in https://openedx.atlassian.net/browse/EDUCATOR-411.

Sandbox available at https://dahlia.sandbox.edx.org.

See also https://github.com/edx/edx-platform/pull/15806.