### PR TITLE
 EDUCATOR-1104 Fix 500 error in course page.

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1235,7 +1235,7 @@ def _check_eligibility_of_enrollment_mode(credit_state):
     # Also make an exception for the honor students to take the "practice exam" as a proctored exam.
     # For the rest of the enrollment modes, None is returned which shows the exam content
     # to the student rather than the proctoring prompt.
-    return credit_state['enrollment_mode'] == 'verified'
+    return credit_state and credit_state['enrollment_mode'] == 'verified'
 
 
 def _get_ordered_prerequisites(prerequisites_statuses, filter_out_namespaces=None):

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1648,3 +1648,18 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         self.assertEqual(len(results['failed_prerequisites']), expected_len_failed_prerequisites)
         self.assertEqual(len(results['pending_prerequisites']), expected_len_pending_prerequisites)
         self.assertEqual(len(results['declined_prerequisites']), expected_len_declined_prerequisites)
+
+    def test_summary_without_credit_state(self):
+        """
+        Test that attempt status summary is None for users who are not enrolled.
+        """
+        exam_id = self._create_exam_with_due_time()
+        set_runtime_service('credit', MockCreditServiceNone())
+
+        timed_exam = get_exam_by_id(exam_id)
+        summary = get_attempt_status_summary(
+            self.user.id,
+            timed_exam['course_id'],
+            timed_exam['content_id']
+        )
+        self.assertIsNone(summary)


### PR DESCRIPTION
## [EDUCATOR-1104](https://openedx.atlassian.net/browse/EDUCATOR-1104)

### Description
This PR fixes that when the user is not enrolled in the course and credit state is None, it wouldn't raise the 500 error.

### How to Test?

**Production** 
- https://courses.edx.org/courses/course-v1:ASUx+SOC101x+2174C/course/

**Sandbox**
- https://proctoring-app.sandbox.edx.org/courses/course-v1:edx+PC101+2017/course/

### Tests
 - [x] Unit Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @afzaledx 
- [x] @noraiz-anwar 


### Post-review
- [x] Rebase and squash commits

