### PR TITLE
EDUCATOR-1256 Fix 500 error when user is not enrolled.

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1896,7 +1896,7 @@ def get_student_view(user_id, course_id, content_id,
 
     # call service to get course end date.
     credit_state = credit_service.get_credit_state(user_id, course_id, return_course_info=True)
-    course_end_date = credit_state.get('course_end_date', None)
+    course_end_date = credit_state.get('course_end_date') if credit_state else None
 
     exam_id = None
     try:

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -29,7 +29,7 @@ from edx_proctoring.models import (
 )
 from edx_proctoring.runtime import set_runtime_service
 
-from .test_services import MockCreditServiceWithCourseEndDate
+from .test_services import MockCreditServiceWithCourseEndDate, MockCreditServiceNone
 from .utils import ProctoredExamTestCase
 
 
@@ -387,6 +387,24 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
                 }
             )
         )
+
+    def test_student_response_without_credit_state(self):
+        """
+        Test that response is not None for users who are not enrolled.
+        """
+        set_runtime_service('credit', MockCreditServiceNone())
+        rendered_response = get_student_view(
+            user_id=self.user_id,
+            course_id=self.course_id,
+            content_id=self.content_id,
+            context={
+                'is_proctored': True,
+                'display_name': self.exam_name,
+                'default_time_limit_mins': 90
+            },
+            user_role='student'
+        )
+        self.assertIsNotNone(rendered_response)
 
     @ddt.data(False, True)
     def test_get_studentview_unstarted_exam(self, allow_proctoring_opt_out):


### PR DESCRIPTION
## [EDUCATOR-1256](https://openedx.atlassian.net/browse/EDUCATOR-1256)

### Description
This PR fixes that when the user is not enrolled in the course and credit state is None, it wouldn't raise the 500 error.

### Tests
 - [x] Unit Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @afzaledx 
- [x] @Rabia23 


### Post-review
- [x] Rebase and squash commits

