### PR TITLE
exam violation report with deleted exam attempt

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1981,15 +1981,15 @@ def get_exam_violation_report(course_id, include_practice_exams=False):
 
     for review in reviews:
         attempt_code = review.attempt_code
+        if attempt_code in attempts_by_code:
+            attempts_by_code[attempt_code]['review_status'] = review.review_status
 
-        attempts_by_code[attempt_code]['review_status'] = review.review_status
+            for comment in review.proctoredexamsoftwaresecurecomment_set.all():
+                comments_key = '{status} Comments'.format(status=comment.status)
 
-        for comment in review.proctoredexamsoftwaresecurecomment_set.all():
-            comments_key = '{status} Comments'.format(status=comment.status)
+                if comments_key not in attempts_by_code[attempt_code]:
+                    attempts_by_code[attempt_code][comments_key] = []
 
-            if comments_key not in attempts_by_code[attempt_code]:
-                attempts_by_code[attempt_code][comments_key] = []
-
-            attempts_by_code[attempt_code][comments_key].append(comment.comment)
+                attempts_by_code[attempt_code][comments_key].append(comment.comment)
 
     return sorted(attempts_by_code.values(), key=lambda a: a['exam_name'])

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1817,3 +1817,37 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         self.assertEqual(report[1]['review_status'], 'Clean')
 
         self.assertIsNone(report[0]['review_status'])
+
+    def test_get_exam_violation_report_with_deleted_exam_attempt(self):
+        """
+        Tests that get_exam_violation_report does not fail in scenerio
+        where an exam attempt does not exist for related review.
+        """
+        test_exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='test_content_1',
+            exam_name='test_exam',
+            time_limit_mins=self.default_time_limit
+        )
+
+        test_attempt_id = create_exam_attempt(
+            exam_id=test_exam_id,
+            user_id=self.user_id
+        )
+
+        exam1_attempt = ProctoredExamStudentAttempt.objects.get_exam_attempt_by_id(test_attempt_id)
+
+        ProctoredExamSoftwareSecureReview.objects.create(
+            exam=ProctoredExam.get_exam_by_id(test_exam_id),
+            attempt_code=exam1_attempt.attempt_code,
+            review_status="Suspicious"
+        )
+
+        # exam attempt is deleted but corresponding review instance exists.
+        exam1_attempt.delete()
+
+        report = get_exam_violation_report(self.course_id)
+
+        # call to get_exam_violation_report did not fail. Assert that report is empty as
+        # the only exam atempt was deleted.
+        self.assertEqual(len(report), 0)


### PR DESCRIPTION
## [EDUCATOR-1391](https://openedx.atlassian.net/browse/EDUCATOR-1391)

### Description
[get_exam_violation_report](https://github.com/edx/edx-proctoring/blob/master/edx_proctoring/api.py#L1953) code is made more robust to handle scenario where an exam attempt does not exists for corresponding attempt review. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Rabia23 
- [x] Code review: @awaisdar001 
- [ ] Code review: @asadazam93 

### Post-review
- [x] Rebase and squash commits