### PR TITLE
Add logging to find out the cause of error.

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -313,6 +313,10 @@ def get_exam_by_content_id(course_id, content_id):
     """
     proctored_exam = ProctoredExam.get_exam_by_content_id(course_id, content_id)
     if proctored_exam is None:
+        log.exception(
+            'Cannot find the proctored exams in this course %s with content_id: %s',
+            course_id, content_id
+        )
         raise ProctoredExamNotFoundException
 
     serialized_exam_object = ProctoredExamSerializer(proctored_exam)


### PR DESCRIPTION
# [EDUCATOR-1441](https://openedx.atlassian.net/browse/EDUCATOR-1441)
### Description:
I have added the logs to find out the root cause of problem because currently, we don't have enough information that in which courses `ProctoredExamNotFoundException` exception is raises