### PR TITLE
Switch from PyCrypto to PyCryptodomex

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -17,7 +17,7 @@ import requests
 
 from django.conf import settings
 
-from Crypto.Cipher import DES3
+from Cryptodome.Cipher import DES3
 
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring import constants

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -337,7 +337,8 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
             """
             Apply padding
             """
-            return text + (block_size - len(text) % block_size) * chr(block_size - len(text) % block_size)
+            return (text + (block_size - len(text) % block_size) *
+                    chr(block_size - len(text) % block_size)).encode('utf-8')
         cipher = DES3.new(key, DES3.MODE_ECB)
         encrypted_text = cipher.encrypt(pad(pwd))
         return base64.b64encode(encrypted_text)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ django-model-utils>=2.3.1
 djangorestframework>=3.1,<3.7
 django-ipware>=1.1.0
 pytz>=2012h
-pycrypto>=2.6
+pycryptodomex>=3.4.7
 python-dateutil>=2.1
 
 # edX packages


### PR DESCRIPTION
I suspect this might fix EDUCATOR-2003 because PyCrypto was removed in edx-platform by edx/edx-platform#16612. The PR installed [PyCryptodome](https://github.com/Legrandin/pycryptodome) as a replacement for PyCrypto because it is more maintained.