### PR TITLE
Specify package dependencies in setup.py

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '1.3.3'
+__version__ = '1.3.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,18 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.8,<2.0"
+        "Django>=1.8,<2.0",
+        "django-model-utils>=2.3.1",
+        "djangorestframework>=3.1,<3.7",
+        "django-ipware>=1.1.0",
+        "edx-opaque-keys>=0.4",
+        "pytz>=2012h",
+        "pycryptodomex>=3.4.7",
+        "python-dateutil>=2.1",
+        "requests",
+        "six",
     ],
+    dependency_links=[
+        "git+https://github.com/edx/event-tracking.git@0.2.2#egg=event-tracking==0.2.2",
+    ]
 )


### PR DESCRIPTION
Production bugs like EDUCATOR-2003 could have been prevented if this package had explicitly defined its dependencies. This will ensure that even if edx-platform removes a package from its own requirements that this package depends on, edx-platform will still install this package's dependencies.