### PR TITLE
invalidate certificate when marked proctored exam as suspicious

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -936,6 +936,22 @@ def update_attempt_status(exam_id, user_id, to_status,
                 earned_graded=REJECTED_GRADE_OVERRIDE_EARNED
             )
 
+            certificates_service = get_runtime_service('certificates')
+
+            log.info(
+                'Invalidating certificate for user_id {user_id} in course {course_id} whose '
+                'grade dropped below passing threshold due to suspicious proctored exam'.format(
+                    user_id=exam_attempt_obj.user_id,
+                    course_id=exam['course_id']
+                )
+            )
+
+            # invalidate certificate after overriding subsection grade
+            certificates_service.invalidate_certificate(
+                user_id=exam_attempt_obj.user_id,
+                course_key_or_id=exam['course_id']
+            )
+
     if (to_status == ProctoredExamStudentAttemptStatus.verified and
             ProctoredExamStudentAttemptStatus.needs_grade_override(from_status)):
         grades_service = get_runtime_service('grades')

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -43,7 +43,12 @@ from edx_proctoring.models import (
     ProctoredExamStudentAllowance
 )
 from edx_proctoring.backends.tests.test_review_payload import create_test_review_payload
-from edx_proctoring.tests.test_services import MockCreditService, MockInstructorService, MockGradesService
+from edx_proctoring.tests.test_services import (
+    MockCreditService,
+    MockInstructorService,
+    MockGradesService,
+    MockCertificateService
+)
 from edx_proctoring.backends.software_secure import SOFTWARE_SECURE_INVALID_CHARS
 
 
@@ -105,6 +110,7 @@ class SoftwareSecureTests(TestCase):
         set_runtime_service('credit', MockCreditService())
         set_runtime_service('instructor', MockInstructorService())
         set_runtime_service('grades', MockGradesService())
+        set_runtime_service('certificates', MockCertificateService())
 
     def tearDown(self):
         """
@@ -113,6 +119,7 @@ class SoftwareSecureTests(TestCase):
         super(SoftwareSecureTests, self).tearDown()
         set_runtime_service('credit', None)
         set_runtime_service('grades', None)
+        set_runtime_service('certificates', None)
 
     def test_provider_instance(self):
         """

--- a/edx_proctoring/management/commands/tests/test_set_attempt_status.py
+++ b/edx_proctoring/management/commands/tests/test_set_attempt_status.py
@@ -15,7 +15,8 @@ from edx_proctoring.management.commands import set_attempt_status
 from edx_proctoring.models import ProctoredExamStudentAttemptStatus, ProctoredExamStudentAttempt
 from edx_proctoring.tests.test_services import (
     MockCreditService,
-    MockGradesService
+    MockGradesService,
+    MockCertificateService
 )
 from edx_proctoring.runtime import set_runtime_service
 
@@ -33,6 +34,7 @@ class SetAttemptStatusTests(LoggedInTestCase):
         super(SetAttemptStatusTests, self).setUp()
         set_runtime_service('credit', MockCreditService())
         set_runtime_service('grades', MockGradesService())
+        set_runtime_service('certificates', MockCertificateService())
         self.exam_id = create_exam(
             course_id='foo',
             content_id='bar',

--- a/edx_proctoring/tests/test_email.py
+++ b/edx_proctoring/tests/test_email.py
@@ -19,6 +19,8 @@ from edx_proctoring.runtime import set_runtime_service, get_runtime_service
 
 from .test_services import (
     MockCreditService,
+    MockGradesService,
+    MockCertificateService
 )
 from .utils import (
     ProctoredExamTestCase,
@@ -31,6 +33,23 @@ class ProctoredExamEmailTests(ProctoredExamTestCase):
     """
     All tests for proctored exam emails.
     """
+
+    def setUp(self):
+        """
+        Initialize
+        """
+        super(ProctoredExamEmailTests, self).setUp()
+
+        set_runtime_service('grades', MockGradesService())
+        set_runtime_service('certificates', MockCertificateService())
+
+    def tearDown(self):
+        """
+        When tests are done
+        """
+        super(ProctoredExamEmailTests, self).tearDown()
+        set_runtime_service('grades', None)
+        set_runtime_service('certificates', None)
 
     @ddt.data(
         [

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -189,6 +189,26 @@ class MockGradeOverride(object):
         self.earned_graded_override = earned_graded
 
 
+class MockGeneratedCertificate(object):
+    """Fake GeneratedCertificate instance."""
+    def __init__(self):
+        self.verify_uuid = 'test_verify_uuid'
+        self.download_uuid = 'test_download_uuid'
+        self.download_url = 'test_download_url'
+        self.grade = 1.0
+        self.status = 'downloadable'
+
+    def mock_invalidate(self):
+        """
+        Invalidate Generated Certificate by  marking it 'unavailable'.
+        """
+        self.verify_uuid = ''
+        self.download_uuid = ''
+        self.download_url = ''
+        self.grade = ''
+        self.status = 'unavailable'
+
+
 class MockGradesService(object):
     """
     Simple mock of the Grades Service
@@ -239,3 +259,29 @@ class MockGradesService(object):
     def should_override_grade_on_rejected_exam(self, course_key):
         """Mock will always return instance variable: rejected_exam_overrides_grade"""
         return self.rejected_exam_overrides_grade
+
+
+class MockCertificateService(object):
+    """
+    mock Certificate Service
+    """
+    def __init__(self):
+        """
+        Initialize empty data stores for generated certificate
+        """
+        self.generated_certificate = {}
+
+    def invalidate_certificate(self, user_id, course_key_or_id):
+        """
+        Get the generated certificate for key (user_id + course_key) and invalidate certificate
+        whose grade dropped below passing threshold due to suspicious proctored exam
+        """
+        key = str(user_id) + str(course_key_or_id)
+        self.generated_certificate[key] = MockGeneratedCertificate()
+        self.generated_certificate[key].mock_invalidate()
+
+    def get_invalidated_certificate(self, user_id, course_key_or_id):
+        """
+        Returns invalidated certificate for key (user_id + course_key)
+        """
+        return self.generated_certificate.get(str(user_id) + str(course_key_or_id))


### PR DESCRIPTION
  # [Learners who drop below passing threshold due to Suspicious proctored exams should not receive certificates - EDUCATOR-2016](https://openedx.atlassian.net/browse/EDUCATOR-2016)

### Description
In the past, because of proctoring, a learners have temporarily passing score and certificate, and later have their score lowered due to being flagged as suspicious. So, they have `certificate delivered = Y` in the grade report, and  `Download Now` link when viewed in the course tools. 

Now the learners will not be able to receive certificates after lowering their score due to "suspicious" flag and grade report will have `certificate delivered = N`.


### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @thallada 

### Post-review
- [ ] Rebase and squash commits