### PR TITLE
handle grading service failure

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1120,11 +1120,14 @@ def remove_exam_attempt(attempt_id, requesting_user):
         instructor_service.delete_student_attempt(username, course_id, content_id, requesting_user=requesting_user)
     if grades_service:
         # EDUCATOR-2141: Also remove any grade overrides that may exist
-        grades_service.undo_override_subsection_grade(
-            user_id=user_id,
-            course_key_or_id=course_id,
-            usage_key_or_id=content_id,
-        )
+        try:
+            grades_service.undo_override_subsection_grade(
+                user_id=user_id,
+                course_key_or_id=course_id,
+                usage_key_or_id=content_id,
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            log.exception(ex)
 
     # see if the status transition this changes credit requirement status
     if ProctoredExamStudentAttemptStatus.needs_credit_status_update(to_status):


### PR DESCRIPTION
Continue deleting special exam attempt if grade override undo operation is failed.

[undo_override_subsection_grade](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/grades/services.py#L98) is failed if related PersistentSubsectionGrade entry does not exist.
PersistentSubsectionGrade does not exist in a case where a user started/submitted special exam but did not submit any problem.

FYI: @awaisdar001 / @efischer19 