### PR TITLE
Proctored exam allowed time calculation clean up

### DIFF
--- a/edx_proctoring/migrations/0006_allowed_time_limit_mins.py
+++ b/edx_proctoring/migrations/0006_allowed_time_limit_mins.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edx_proctoring', '0005_proctoredexam_hide_after_due'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='proctoredexamstudentattempt',
+            name='allowed_time_limit_mins',
+            field=models.IntegerField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='proctoredexamstudentattempthistory',
+            name='allowed_time_limit_mins',
+            field=models.IntegerField(null=True),
+        ),
+    ]

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -463,7 +463,7 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
     external_id = models.CharField(max_length=255, null=True, db_index=True)
 
     # this is the time limit allowed to the student
-    allowed_time_limit_mins = models.IntegerField()
+    allowed_time_limit_mins = models.IntegerField(null=True)
 
     # what is the status of this attempt
     status = models.CharField(max_length=64)
@@ -494,19 +494,17 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
         unique_together = (('user', 'proctored_exam'),)
 
     @classmethod
-    def create_exam_attempt(cls, exam_id, user_id, student_name, allowed_time_limit_mins,
-                            attempt_code, taking_as_proctored, is_sample_attempt, external_id,
+    def create_exam_attempt(cls, exam_id, user_id, student_name, attempt_code,
+                            taking_as_proctored, is_sample_attempt, external_id,
                             review_policy_id=None):
         """
         Create a new exam attempt entry for a given exam_id and
         user_id.
         """
-
         return cls.objects.create(
             proctored_exam_id=exam_id,
             user_id=user_id,
             student_name=student_name,
-            allowed_time_limit_mins=allowed_time_limit_mins,
             attempt_code=attempt_code,
             taking_as_proctored=taking_as_proctored,
             is_sample_attempt=is_sample_attempt,
@@ -547,7 +545,7 @@ class ProctoredExamStudentAttemptHistory(TimeStampedModel):
     external_id = models.CharField(max_length=255, null=True, db_index=True)
 
     # this is the time limit allowed to the student
-    allowed_time_limit_mins = models.IntegerField()
+    allowed_time_limit_mins = models.IntegerField(null=True)
 
     # what is the status of this attempt
     status = models.CharField(max_length=64)

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -282,7 +282,7 @@ class ProctoredExamStudentAttemptTests(LoggedInTestCase):
         # create number of exam attempts
         for i in range(90):
             ProctoredExamStudentAttempt.create_exam_attempt(
-                proctored_exam.id, i, 'test_name{0}'.format(i), i + 1,
+                proctored_exam.id, i, 'test_name{0}'.format(i),
                 'test_attempt_code{0}'.format(i), True, False, 'test_external_id{0}'.format(i)
             )
 
@@ -314,7 +314,6 @@ class ProctoredExamStudentAttemptTests(LoggedInTestCase):
             proctored_exam.id,
             self.user.id,
             'test_name{0}'.format(self.user.id),
-            self.user.id + 1,
             'test_attempt_code{0}'.format(self.user.id),
             True,
             False,


### PR DESCRIPTION
## [EDUCATOR-2314](https://openedx.atlassian.net/browse/EDUCATOR-2314)

### Description
This PR address the following discrepancy in calculation and usage of allowed time for a proctored exam.
- Allowed time is calculated and stored at time of entrance into proctored exam.
- When a learner starts exam, starting time is used as a benchmark to provide learner with previously calculated time.
- At time of starting exam, learner is nearer to deadline from when allowed time was calculated (at time of entrance into exam).
- Consider a scenario where learner is provided with time past deadline. (This is possible by following above given sequence)
- Deadline is reached but provided time is still running.
- After deadline, submission is not possible as no submit button will be shown and timeout will not be considered a submit.

This is illustrated by following diagram:
![proctoring - page 1 2](https://user-images.githubusercontent.com/22347092/36529282-b89fdd3a-17d9-11e8-8cc6-d856f523ee52.png)

This PR moves allowed time calculation to 'Exam Started' step i.e time will be calculated and stored when learner starts exam. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @efischer19 
- [x] Code review: @awaisdar001 

FYI: @sstack22 

### Post-review
- [ ] Rebase and squash commits