### PR TITLE
bump version to 1.3.9

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '1.3.8'
+__version__ = '1.3.9'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Abandoning 1.3.8 as https://github.com/edx/edx-proctoring/pull/416/ is not getting included in this release. 
1.3.8 was initially made to include changes of https://github.com/edx/edx-proctoring/pull/412. https://github.com/edx/edx-proctoring/pull/416/ is added later and is not getting picked up.
FYI: @awaisdar001 