### PR TITLE
Pin pip version to 9.0.3 for Travis/Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-- pip install --upgrade pip  # pip-tools requires pip >= 6.1
+- pip install --upgrade pip==9.0.3  # pip-tools requires pip >= 6.1 & pin to 9.0.3 until tox-battery upgrades
 install:
 - pip install setuptools==32.3.1  # need newer version than Travis default
 - make install


### PR DESCRIPTION
Pinning pip version because pip 10 was recently released, and tox-battery doesn't support it yet: https://github.com/signalpillar/tox-battery/issues/14