### PR TITLE
EDUCATOR-2748 give proctored exams access to course staff in allowance section under special exams tab

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1131,7 +1131,7 @@ def remove_exam_attempt(attempt_id, requesting_user):
     emit_event(exam, 'deleted', attempt=attempt)
 
 
-def get_all_exams_for_course(course_id, timed_exams_only=False, active_only=False):
+def get_all_exams_for_course(course_id, active_only=False):
     """
     This method will return all exams for a course. This will return a list
     of dictionaries, whose schema is the same as what is returned in
@@ -1157,8 +1157,7 @@ def get_all_exams_for_course(course_id, timed_exams_only=False, active_only=Fals
     """
     exams = ProctoredExam.get_all_exams_for_course(
         course_id,
-        active_only=active_only,
-        timed_exams_only=timed_exams_only
+        active_only=active_only
     )
 
     return [ProctoredExamSerializer(proctored_exam).data for proctored_exam in exams]

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -99,8 +99,7 @@ class ProctoredExam(TimeStampedModel):
         return proctored_exam
 
     @classmethod
-    def get_all_exams_for_course(cls, course_id, active_only=False, timed_exams_only=False,
-                                 proctored_exams_only=False):
+    def get_all_exams_for_course(cls, course_id, active_only=False, proctored_exams_only=False):
         """
         Returns all exams for a give course
         """
@@ -108,8 +107,6 @@ class ProctoredExam(TimeStampedModel):
 
         if active_only:
             filtered_query = filtered_query & Q(is_active=True)
-        if timed_exams_only:
-            filtered_query = filtered_query & Q(is_proctored=False)
         if proctored_exams_only:
             filtered_query = filtered_query & Q(is_proctored=True) & Q(is_practice_exam=False)
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -193,7 +193,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         self.assertEqual(proctored_exam['content_id'], self.content_id)
         self.assertEqual(proctored_exam['exam_name'], self.exam_name)
 
-        exams = get_all_exams_for_course(self.course_id, False)
+        exams = get_all_exams_for_course(self.course_id)
         self.assertEqual(len(exams), 4)
 
     def test_create_exam_review_policy(self):
@@ -365,8 +365,8 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         self.assertEqual(timed_exam['content_id'], self.content_id_timed)
         self.assertEqual(timed_exam['exam_name'], self.exam_name)
 
-        exams = get_all_exams_for_course(self.course_id, True)
-        self.assertEqual(len(exams), 2)
+        exams = get_all_exams_for_course(self.course_id)
+        self.assertEqual(len(exams), 4)
 
     def test_get_invalid_proctored_exam(self):
         """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -256,10 +256,8 @@ class ProctoredExamView(AuthenticatedAPIView):
                             data={"detail": "The exam with course_id, content_id does not exist."}
                         )
                 else:
-                    timed_exams_only = not request.user.is_staff
                     result_set = get_all_exams_for_course(
                         course_id=course_id,
-                        timed_exams_only=timed_exams_only,
                         active_only=True
                     )
                     return Response(result_set)


### PR DESCRIPTION
# [EDUCATOR-2748](https://openedx.atlassian.net/browse/EDUCATOR-2748)

### Description
This PR includes Proctored Exams in Special Exam list when course teams clicks on "Add a New Allowance" under the Special Exams tab. This case was missed in https://github.com/edx/edx-proctoring/pull/391.

### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @MichaelRoytman  
- [x] Code review: @efischer19 

### Post-review
- [ ] Rebase and squash commits