### PR TITLE
Record architecture decision records

### DIFF
--- a/docs/decisions/0001-record-architecture-decisions.rst
+++ b/docs/decisions/0001-record-architecture-decisions.rst
@@ -1,0 +1,32 @@
+1. Record Architecture Decisions
+--------------------------------
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+We would like to keep a historical record on the architectural
+decisions we make with this app as it evolves over time.
+
+Decision
+--------
+
+We will use Architecture Decision Records, as described by
+Michael Nygard in `Documenting Architecture Decisions`_
+
+.. _Documenting Architecture Decisions: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+Consequences
+------------
+
+See Michael Nygard's article, linked above.
+
+References
+----------
+
+* https://resources.sei.cmu.edu/asset_files/Presentation/2017_017_001_497746.pdf
+* https://github.com/npryce/adr-tools/tree/master/doc/adr


### PR DESCRIPTION
this process change is motivated by the need to document and openly
discuss the architectural decisions made in the course of refactoring
edx-proctoring to allow pluggable proctoring providers. This will
encourage us to document these decisions in a way that encodes context
of the context in which these decisions were made.