### PR TITLE
Make pytest more useful

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     django111: Django>=1.11,<2.0
     -rrequirements/test.txt
 commands =
-    py.test --cov=edx_proctoring --cov-report=html --ds=test_settings -n auto
+    py.test -rfe --cov=edx_proctoring --cov-report=html --ds=test_settings -n auto {posargs}
 
 [testenv:docs]
 setenv =
@@ -52,3 +52,7 @@ deps =
 commands =
     pylint edx_proctoring
     pycodestyle edx_proctoring
+
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:responses


### PR DESCRIPTION
- Quiet the many repeated warnings
- list the failed tests at the end as a summary
- pass command-line args from tox to pytest so you can choose a subset of test