### PR TITLE
Save the review policy with the exam on the backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ quality: ## check coding style with pycodestyle and pylint
 	tox -e quality
 
 test-python: clean ## run tests in the current virtualenv
+	pip install -e .
 	py.test --cov=edx_proctoring --cov-report=html --ds=test_settings -n auto
 
 test-js:

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -25,7 +25,7 @@ Proctoring System configuration endpoint
 ``GET``: returns an object of the available configuration options and metadata for the proctoring service.::
 
     {
-        "config": {
+        "rules": {
             "allow_multiple": "Allow multiple monitors",
             "allow_notes": "Allow paper notes",
             "allow_apps": "Allow other applications to be running",
@@ -40,8 +40,8 @@ Proctoring System configuration endpoint
         ]
     }
 
-The keys in the config object should be machine readable. The values are human readable. PS should respect the HTTP request ``Accept-Language``
-header and translate all human readable configuration options into the requested language.
+The keys in the rules object should be machine readable. The values are human readable. PS should respect the HTTP request ``Accept-Language``
+header and translate all human readable rules into the requested language.
 
 If a download_url is included in the response, Open edX will redirect learners to the address before the proctoring session starts. The address will include ``attempt={attempt_id}`` in the query string.
 
@@ -53,7 +53,7 @@ Exam endpoint
 ``GET``: returns an object describing the exam. If no exam exists, return 404 error.::
 
     {
-        "config": {
+        "rules": {
             "allow_notes": true,
             "allow_multiple": false
         }
@@ -64,10 +64,11 @@ Exam endpoint
 ``POST``: may be used to create the exam on the PS, by sending an object like this::
 
     {
-        "config": {
+        "rules": {
             "allow_notes": false,
             "allow_multiple": true
         },
+        "rule_summary": "Human readable summary of rules.",
         "course_id": "myOrgX:Course101",
         "is_practice": false,
         "is_proctored": true,
@@ -75,7 +76,7 @@ Exam endpoint
         "name": "Course Final Exam"
     }
 
-The config object will match the config keys returned from the configuration endpoint above. Any options which aren't passed in should be set to default values by the proctoring service.
+The rules object will match the rule keys returned from the configuration endpoint above. Any options which aren't passed in should be set to default values by the proctoring service.
 
 The PS system should respond with an object containing at least the following fields::
 

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -226,7 +226,7 @@ def _save_exam_on_backend(sender, instance, **kwargs):  # pylint: disable=unused
             exam['rule_summary'] = review_policy.review_policy
             # When the rules are defined as boolean options,
             # save them here
-            exam['rules'] = getattr(review_policy, 'rules', {})
+            exam['rules'] = review_policy.rules
         backend = get_backend_provider(exam)
         external_id = backend.on_exam_saved(exam)
         if external_id and external_id != exam_obj.external_id:

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -50,9 +50,7 @@ class EdxProctoringConfig(AppConfig):
         """
         Loads the available proctoring backends
         """
-        config = getattr(settings, 'PROCTORING_BACKENDS', None)  # pylint: disable=literal-used-as-attribute
-        if not config:
-            raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKENDS!")
+        config = settings.PROCTORING_BACKENDS
 
         self.backends = {}  # pylint: disable=W0201
         for extension in ExtensionManager(namespace='openedx.proctoring'):

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -5,6 +5,8 @@ edx_proctoring Django application initialization.
 
 from __future__ import absolute_import
 
+import warnings
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -23,33 +25,41 @@ class EdxProctoringConfig(AppConfig):
         Returns an iterator of available backends:
         backend_name, verbose name
         """
-        for extension in self.backends:
-            yield extension.name, getattr(extension.plugin, 'verbose_name', u'Unknown')
+        for name, backend in self.backends.items():
+            yield name, getattr(backend, 'verbose_name', u'Unknown')
 
-    def get_backend(self, name=None, options=None):
+    def get_backend(self, name=None):
         """
         Returns an instance of the proctoring backend.
 
         :param str name: Name of entrypoint in openedx.proctoring
         :param dict options: Keyword arguments to use when instantiating the backend
         """
-        config = getattr(settings, 'PROCTORING_BACKENDS', None)  # pylint: disable=literal-used-as-attribute
-        if not config:
-            raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKENDS!")
         if name is None:
             try:
-                name = config['DEFAULT']
-            except KeyError:
+                name = settings.PROCTORING_BACKENDS['DEFAULT']
+            except (KeyError, AttributeError):
                 raise ImproperlyConfigured("No default proctoring backend set in settings.PROCTORING_BACKENDS")
         try:
-            options = options or config[name]
-            return self.backends[name].plugin(**options)
+            return self.backends[name]
         except KeyError:
             raise NotImplementedError("No proctoring backend configured for '{}'.  "
-                                      "Available: {} {}".format(name, self.backends.names(), config))
+                                      "Available: {}".format(name, list(self.backends)))
 
     def ready(self):
         """
         Loads the available proctoring backends
         """
-        self.backends = ExtensionManager(namespace='openedx.proctoring')  # pylint: disable=W0201
+        config = getattr(settings, 'PROCTORING_BACKENDS', None)  # pylint: disable=literal-used-as-attribute
+        if not config:
+            raise ImproperlyConfigured("Settings not configured with PROCTORING_BACKENDS!")
+
+        self.backends = {}  # pylint: disable=W0201
+        for extension in ExtensionManager(namespace='openedx.proctoring'):
+            name = extension.name
+            try:
+                options = config[name]
+                self.backends[name] = extension.plugin(**options)
+            except KeyError:
+                warnings.warn("No proctoring backend configured for '{}'.  "
+                              "Available: {}".format(name, list(self.backends)))

--- a/edx_proctoring/backends/__init__.py
+++ b/edx_proctoring/backends/__init__.py
@@ -9,7 +9,6 @@ def get_backend_provider(exam=None):
     Returns an instance of the configured backend provider
     """
     backend_name = None
-    options = {}
     if exam and exam['backend']:
         backend_name = exam['backend']
-    return apps.get_app_config('edx_proctoring').get_backend(name=backend_name, options=options)
+    return apps.get_app_config('edx_proctoring').get_backend(name=backend_name)

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -52,7 +52,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         ProctoringBackendProvider.__init__(self)
         self.client_id = client_id
         self.client_secret = client_secret
-        self.default_config = None
+        self.default_rules = None
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.session = OAuthAPIClient(self.base_url, self.client_id, self.client_secret)
@@ -142,9 +142,9 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         Called after an exam is saved.
         """
-        if 'config' not in exam and self.default_config:
+        if self.default_rules and not exam.get('rules', None):
             # allows the platform to define a default configuration
-            exam['config'] = self.default_config
+            exam['rules'] = self.default_rules
         external_id = exam.get('external_id', None)
         if external_id:
             url = self.exam_url.format(exam_id=external_id)

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -22,6 +22,7 @@ class TestBackendProvider(ProctoringBackendProvider):
     """
     Implementation of the ProctoringBackendProvider that does nothing
     """
+    last_exam = None
 
     def register_exam_attempt(self, exam, context):
         """
@@ -57,7 +58,8 @@ class TestBackendProvider(ProctoringBackendProvider):
         return payload
 
     def on_exam_saved(self, exam):
-        return exam.get('external_id', 'examexternalid')
+        self.last_exam = exam
+        return exam.get('external_id', None) or 'externalid'
 
 
 class PassthroughBackendProvider(ProctoringBackendProvider):
@@ -207,11 +209,12 @@ class BackendChooserTests(TestCase):
         """
         from django.apps import apps
         choices = list(apps.get_app_config('edx_proctoring').get_backend_choices())
+        choices.sort()
         expected = [
-            ('test', u'Unknown'),
-            ('null', u'Null Backend'),
             ('mock', u'Mock Backend'),
-            ('software_secure', u'RPNow')
+            ('null', u'Null Backend'),
+            ('software_secure', u'RPNow'),
+            ('test', u'Unknown'),
         ]
         self.assertEqual(choices, expected)
 

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -100,7 +100,7 @@ class RESTBackendTests(TestCase):
 
     @responses.activate
     def test_create_exam_with_defaults(self):
-        provider = BaseRestProctoringProvider(default_config={'allow_grok': True})
+        provider = BaseRestProctoringProvider(default_rules={'allow_grok': True})
         responses.add(
             responses.POST,
             url=self.provider.create_exam_url,
@@ -110,7 +110,7 @@ class RESTBackendTests(TestCase):
         external_id = provider.on_exam_saved(self.backend_exam)
         request = json.loads(responses.calls[1].request.body)
         self.assertEqual(external_id, 'abcdefg')
-        self.assertTrue(request['config']['allow_grok'])
+        self.assertTrue(request['rules']['allow_grok'])
 
     @responses.activate
     def test_update_exam(self):

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -318,7 +318,7 @@ class ProctoredExamReviewPolicyHistory(TimeStampedModel):
         raise NotImplementedError()
 
 
-# Hook up the post_save signal to record creations in the ProctoredExamReviewPolicyHistory table.
+# Hook up the pre_save signal to record creations in the ProctoredExamReviewPolicyHistory table.
 @receiver(pre_save, sender=ProctoredExamReviewPolicy)
 def on_review_policy_saved(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """

--- a/edx_proctoring/tests/__init__.py
+++ b/edx_proctoring/tests/__init__.py
@@ -1,7 +1,6 @@
 """
-Monkeypatches the extension manager to add the default backends
+Monkeypatches the default backends
 """
-from stevedore.extension import ExtensionManager, Extension
 
 
 def setup_test_backends():
@@ -13,15 +12,9 @@ def setup_test_backends():
     from edx_proctoring.backends.tests.test_backend import TestBackendProvider
     from edx_proctoring.backends.null import NullBackendProvider
     from edx_proctoring.backends.mock import MockProctoringBackendProvider
-    from edx_proctoring.backends.software_secure import SoftwareSecureBackendProvider
-    extensions = [
-        Extension('test', 'openedx.proctoring', TestBackendProvider, None),
-        Extension('null', 'openedx.proctoring', NullBackendProvider, None),
-        Extension('mock', 'openedx.proctoring', MockProctoringBackendProvider, None),
-        Extension('software_secure', 'openedx.proctoring', SoftwareSecureBackendProvider, None)
-    ]
-
-    config.backends = ExtensionManager.make_test_instance(extensions)
+    config.backends['test'] = TestBackendProvider()
+    config.backends['null'] = NullBackendProvider()
+    config.backends['mock'] = MockProctoringBackendProvider()
 
 
 setup_test_backends()

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -5,3 +5,4 @@ edx_lint==0.5.5           # Python code linting rules
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
+django<2.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,6 +14,7 @@ click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, edx-lint
 configparser==3.5.0       # via pydocstyle, pylint
 distlib==0.2.8            # via caniusepython3
+django==1.11.16
 edx_lint==0.5.5
 enum34==1.1.6             # via astroid
 futures==3.2.0            # via caniusepython3, isort
@@ -29,6 +30,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.3.0          # via packaging
+pytz==2018.7              # via django
 requests==2.20.1          # via caniusepython3
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.11.0               # via astroid, edx-lint, packaging, pydocstyle, pylint, singledispatch

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ whitelist_externals =
     rm
     touch
 deps =
-    -r{toxinidir}/requirements/doc.txt
     -r{toxinidir}/requirements/quality.txt
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
Whenever the ProctoredExam or ProctoredExamReviewPolicy models change, the backend `on_exam_saved` method will be called, passing in the correct serialized exam.

This will simplify the next step, which is to add the exam rules as a JSON blob.

@MichaelRoytman @nedbat 