### PR TITLE
Instructor dashboard backend support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ quality: ## check coding style with pycodestyle and pylint
 
 test-python: clean ## run tests in the current virtualenv
 	pip install -e .
-	py.test --cov=edx_proctoring --cov-report=html --ds=test_settings -n auto
+	py.test --cov=edx_proctoring --cov-report=html --ds=test_settings -n 3
 
 test-js:
 	gulp test

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -20,7 +20,7 @@ All requests and responses in this API are formatted as JSON objects.
 Proctoring System configuration endpoint
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    /v1/config/
+    /api/v1/config/
 
 ``GET``: returns an object of the available configuration options and metadata for the proctoring service.::
 
@@ -48,7 +48,7 @@ If a download_url is included in the response, Open edX will redirect learners t
 Exam endpoint
 ^^^^^^^^^^^^^
 
-    /v1/exam/{exam_id}/
+    /api/v1/exam/{exam_id}/
 
 ``GET``: returns an object describing the exam. If no exam exists, return 404 error.::
 
@@ -59,7 +59,7 @@ Exam endpoint
         }
     }
 
-    /v1/exam/
+    /api/v1/exam/
 
 ``POST``: may be used to create the exam on the PS, by sending an object like this::
 
@@ -88,7 +88,7 @@ The PS system should respond with an object containing at least the following fi
 Exam attempt endpoint
 ^^^^^^^^^^^^^^^^^^^^^
 
-    /v1/exam/{exam_id}/attempt/
+    /api/v1/exam/{exam_id}/attempt/
 
 ``{exam_id}`` is the id returned by the PS during exam creation.
 
@@ -108,7 +108,7 @@ The PS system should respond with an object containing at least the following fi
 
 ..
 
-    /v1/exam/{exam_id}/attempt/{attempt_id}/
+    /api/v1/exam/{exam_id}/attempt/{attempt_id}/
 
 ``{exam_id}`` is the id returned by the PS at exam creation and ``{attempt_id}`` is the id returned by the PS during exam attempt creation.
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '1.5.0'
+__version__ = '1.5.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -19,7 +19,6 @@ from edx_proctoring.models import (
     ProctoredExamSoftwareSecureReview,
     ProctoredExamSoftwareSecureReviewHistory,
     ProctoredExamStudentAttempt,
-    ProctoredExamStudentAttemptStatus,
 )
 from edx_proctoring.api import update_attempt_status
 from edx_proctoring.backends import get_backend_provider
@@ -28,6 +27,7 @@ from edx_proctoring.exceptions import (
     ProctoredExamIllegalStatusTransition,
     StudentExamAttemptDoesNotExistsException,
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 
 class ProctoredExamReviewPolicyAdmin(admin.ModelAdmin):

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -39,7 +39,6 @@ from edx_proctoring.models import (
     ProctoredExam,
     ProctoredExamStudentAllowance,
     ProctoredExamStudentAttempt,
-    ProctoredExamStudentAttemptStatus,
     ProctoredExamReviewPolicy,
     ProctoredExamSoftwareSecureReview,
 )
@@ -49,6 +48,8 @@ from edx_proctoring.serializers import (
     ProctoredExamStudentAllowanceSerializer,
     ProctoredExamReviewPolicySerializer
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+
 from edx_proctoring.utils import (
     humanized_time,
     emit_event
@@ -635,7 +636,7 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
         scheme = 'https' if getattr(settings, 'HTTPS', 'on') == 'on' else 'http'
         lms_host = '{scheme}://{hostname}'.format(scheme=scheme, hostname=settings.SITE_NAME)
 
-        obs_user_id = hashlib.sha1((u'%s%s' % (attempt_code, user_id)).encode('ascii')).hexdigest()
+        obs_user_id = hashlib.sha1((u'%s%s' % (exam['course_id'], user_id)).encode('ascii')).hexdigest()
 
         # get the name of the user, if the service is available
         full_name = None

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -88,7 +88,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         Returns the metadata and configuration options for the proctoring service
         """
         url = self.config_url
-        log.debug('Requesting config from %s', url)
+        log.debug('Requesting config from %r', url)
         response = self.session.get(url).json()
         return response
 
@@ -97,7 +97,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         Returns the exam metadata stored by the proctoring service
         """
         url = self.exam_url.format(exam_id=exam['id'])
-        log.debug('Requesting exam from %s', url)
+        log.debug('Requesting exam from %r', url)
         response = self.session.get(url).json()
         return response
 
@@ -118,7 +118,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         url = self.create_exam_attempt_url.format(exam_id=exam['external_id'])
         payload = context
         payload['status'] = 'created'
-        log.debug('Creating exam attempt for %s at %s', exam['external_id'], url)
+        log.debug('Creating exam attempt for %r at %r', exam['external_id'], url)
         response = self.session.post(url, json=payload)
         response = response.json()
         return response['id']
@@ -166,12 +166,12 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             url = self.exam_url.format(exam_id=external_id)
         else:
             url = self.create_exam_url
-        log.debug('Saving exam to %s', url)
+        log.debug('Saving exam to %r', url)
         try:
             response = self.session.post(url, json=exam)
             data = response.json()
         except Exception:  # pylint: disable=broad-except
-            log.exception('saving exam. %s', response.content)
+            log.exception('saving exam. %r', response.content)
             data = {}
         return data.get('id')
 
@@ -179,7 +179,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         Return a URL to the instructor dashboard
         course_id: str
-        user: dict of {id, full_name, email}
+        user: dict of {id, full_name, email} for the instructor or reviewer
         exam_id: str optional exam external id
         attempt_id: str optional exam attempt external id
         """
@@ -197,7 +197,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
                 token['attempt_id'] = attempt_id
         encoded = jwt.encode(token, self.client_secret)
         url = self.instructor_url.format(client_id=self.client_id, jwt=encoded)
-        log.debug('Created instructor url for %s %s %s', course_id, exam_id, attempt_id)
+        log.debug('Created instructor url for %r %r %r', course_id, exam_id, attempt_id)
         return url
 
     def _make_attempt_request(self, exam, attempt, method='POST', status=None, **payload):
@@ -209,6 +209,6 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         else:
             payload = None
         url = self.exam_attempt_url.format(exam_id=exam, attempt_id=attempt)
-        log.debug('Making %s attempt request at %s', method, url)
+        log.debug('Making %r attempt request at %r', method, url)
         response = self.session.request(method, url, json=payload).json()
         return response

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -25,32 +25,32 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
     @property
     def exam_attempt_url(self):
         "Returns exam attempt url"
-        return self.base_url + u'/v1/exam/{exam_id}/attempt/{attempt_id}/'
+        return self.base_url + u'/api/v1/exam/{exam_id}/attempt/{attempt_id}/'
 
     @property
     def create_exam_attempt_url(self):
         "Returns the create exam url"
-        return self.base_url + u'/v1/exam/{exam_id}/attempt/'
+        return self.base_url + u'/api/v1/exam/{exam_id}/attempt/'
 
     @property
     def create_exam_url(self):
         "Returns create exam url"
-        return self.base_url + u'/v1/exam/'
+        return self.base_url + u'/api/v1/exam/'
 
     @property
     def exam_url(self):
         "Returns exam url"
-        return self.base_url + u'/v1/exam/{exam_id}/'
+        return self.base_url + u'/api/v1/exam/{exam_id}/'
 
     @property
     def config_url(self):
         "Returns proctor config url"
-        return self.base_url + u'/v1/config/'
+        return self.base_url + u'/api/v1/config/'
 
     @property
     def instructor_url(self):
         "Returns the instructor dashboar url"
-        return self.base_url + u'/v1/instructor/{client_id}/?jwt={jwt}'
+        return self.base_url + u'/api/v1/instructor/{client_id}/?jwt={jwt}'
 
     def __init__(self, client_id=None, client_secret=None, **kwargs):
         """

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -27,7 +27,7 @@ from edx_proctoring.exceptions import (
     BackendProvideCannotRegisterAttempt,
     ProctoredExamSuspiciousLookup,
 )
-from edx_proctoring.models import SoftwareSecureReviewStatus
+from edx_proctoring.statuses import SoftwareSecureReviewStatus
 
 log = logging.getLogger(__name__)
 

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -61,6 +61,14 @@ class TestBackendProvider(ProctoringBackendProvider):
         self.last_exam = exam
         return exam.get('external_id', None) or 'externalid'
 
+    # pylint: disable=unused-argument
+    def get_instructor_url(self, course_id, user, exam_id=None, attempt_id=None):
+        "Return a fake instructor url"
+        url = '/instructor/%s/' % course_id
+        if exam_id:
+            url += '?exam=%s' % exam_id
+        return url
+
 
 class PassthroughBackendProvider(ProctoringBackendProvider):
     """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -17,7 +17,7 @@ class RESTBackendTests(TestCase):
     def setUp(self):
         "setup tests"
         BaseRestProctoringProvider.base_url = 'http://rr.fake'
-        self.provider = BaseRestProctoringProvider()
+        self.provider = BaseRestProctoringProvider('client_id', 'client_secret')
         responses.add(
             responses.POST,
             url=self.provider.base_url + '/oauth2/access_token',
@@ -185,3 +185,20 @@ class RESTBackendTests(TestCase):
         # A real backend would return real javascript from backend.js
         with self.assertRaises(IOError):
             self.provider.get_javascript()
+
+    def test_instructor_url(self):
+        user = {
+            'id': 1,
+            'full_name': 'Instructor',
+            'email': 'instructor@example.com'
+        }
+        course_id = 'course+abc'
+        base_url = self.provider.get_instructor_url(course_id, user)
+        self.assertIn('?jwt=', base_url)
+        # now try with an exam_id and an attempt_id.
+        # the tokens will be different, but let's not bother decoding them
+        exam_url = self.provider.get_instructor_url(course_id, user, exam_id='abcd')
+        self.assertNotEqual(exam_url, base_url)
+        attempt_url = self.provider.get_instructor_url(course_id, user, exam_id='abcd', attempt_id='defgh')
+        self.assertNotEqual(attempt_url, base_url)
+        self.assertNotEqual(attempt_url, exam_url)

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -29,10 +29,11 @@ from edx_proctoring.api import (
 )
 
 from edx_proctoring.models import (
-    ProctoredExamStudentAttemptStatus,
     ProctoredExamReviewPolicy,
     ProctoredExamStudentAllowance
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+
 from edx_proctoring.backends.tests.test_review_payload import create_test_review_payload
 from edx_proctoring.tests.test_services import (
     MockCreditService,

--- a/edx_proctoring/callbacks.py
+++ b/edx_proctoring/callbacks.py
@@ -11,7 +11,7 @@ from edx_proctoring.api import (
     get_exam_attempt_by_code,
     mark_exam_attempt_as_ready,
 )
-from edx_proctoring.models import ProctoredExamStudentAttemptStatus
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 log = logging.getLogger(__name__)
 

--- a/edx_proctoring/management/commands/set_attempt_status.py
+++ b/edx_proctoring/management/commands/set_attempt_status.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 from django.core.management.base import BaseCommand, CommandError
 
-from edx_proctoring.models import ProctoredExamStudentAttemptStatus
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 
 class Command(BaseCommand):

--- a/edx_proctoring/management/commands/tests/test_set_attempt_status.py
+++ b/edx_proctoring/management/commands/tests/test_set_attempt_status.py
@@ -13,7 +13,8 @@ from django.core.management import call_command
 from edx_proctoring.tests.utils import LoggedInTestCase
 from edx_proctoring.api import create_exam, get_exam_attempt
 
-from edx_proctoring.models import ProctoredExamStudentAttemptStatus, ProctoredExamStudentAttempt
+from edx_proctoring.models import ProctoredExamStudentAttempt
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import (
     MockCreditService,
     MockGradesService,

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -22,9 +22,9 @@ from model_utils.models import TimeStampedModel
 from edx_proctoring.exceptions import (
     UserNotFoundException,
     ProctoredExamNotActiveException,
-    ProctoredExamBadReviewStatus,
     AllowanceValueNotAllowedException,
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 
 @six.python_2_unicode_compatible
@@ -116,130 +116,6 @@ class ProctoredExam(TimeStampedModel):
             filtered_query = filtered_query & Q(is_proctored=True) & Q(is_practice_exam=False)
 
         return cls.objects.filter(filtered_query)
-
-
-class ProctoredExamStudentAttemptStatus(object):
-    """
-    A class to enumerate the various status that an attempt can have
-
-    IMPORTANT: Since these values are stored in a database, they are system
-    constants and should not be language translated, since translations
-    might change over time.
-    """
-
-    # the student is eligible to decide if he/she wants to pursue credit
-    eligible = 'eligible'
-
-    # the attempt record has been created, but the exam has not yet
-    # been started
-    created = 'created'
-
-    # the student has clicked on the external
-    # software download link
-    download_software_clicked = 'download_software_clicked'
-
-    # the attempt is ready to start but requires
-    # user to acknowledge that he/she wants to start the exam
-    ready_to_start = 'ready_to_start'
-
-    # the student has started the exam and is
-    # in the process of completing the exam
-    started = 'started'
-
-    # the student has completed the exam
-    ready_to_submit = 'ready_to_submit'
-
-    #
-    # The follow statuses below are considered in a 'completed' state
-    # and we will not allow transitions to status above this mark
-    #
-
-    # the student declined to take the exam as a proctored exam
-    declined = 'declined'
-
-    # the exam has timed out
-    timed_out = 'timed_out'
-
-    # the student has submitted the exam for proctoring review
-    submitted = 'submitted'
-
-    # the student has submitted the exam for proctoring review
-    second_review_required = 'second_review_required'
-
-    # the exam has been verified and approved
-    verified = 'verified'
-
-    # the exam has been rejected
-    rejected = 'rejected'
-
-    # the exam is believed to be in error
-    error = 'error'
-
-    # the course end date has passed
-    expired = 'expired'
-
-    # status alias for sending email
-    status_alias_mapping = {
-        submitted: ugettext_noop('pending'),
-        verified: ugettext_noop('satisfactory'),
-        rejected: ugettext_noop('unsatisfactory')
-    }
-
-    @classmethod
-    def is_completed_status(cls, status):
-        """
-        Returns a boolean if the passed in status is in a "completed" state, meaning
-        that it cannot go backwards in state
-        """
-        return status in [
-            cls.declined, cls.timed_out, cls.submitted, cls.second_review_required,
-            cls.verified, cls.rejected, cls.error
-        ]
-
-    @classmethod
-    def is_incomplete_status(cls, status):
-        """
-        Returns a boolean if the passed in status is in an "incomplete" state.
-        """
-        return status in [
-            cls.eligible, cls.created, cls.download_software_clicked, cls.ready_to_start, cls.started,
-            cls.ready_to_submit
-        ]
-
-    @classmethod
-    def needs_credit_status_update(cls, to_status):
-        """
-        Returns a boolean if the passed in to_status calls for an update to the credit requirement status.
-        """
-        return to_status in [
-            cls.verified, cls.rejected, cls.declined, cls.submitted, cls.error
-        ]
-
-    @classmethod
-    def needs_grade_override(cls, to_status):
-        """
-        Returns a boolean if the passed in to_status calls for an override of the learner's grade.
-        """
-        return to_status in [
-            cls.rejected
-        ]
-
-    @classmethod
-    def is_a_cascadable_failure(cls, to_status):
-        """
-        Returns a boolean if the passed in to_status has a failure that needs to be cascaded
-        to other unattempted exams.
-        """
-        return to_status in [
-            cls.declined
-        ]
-
-    @classmethod
-    def is_valid_status(cls, status):
-        """
-        Makes sure that passed in status string is valid
-        """
-        return cls.is_completed_status(status) or cls.is_incomplete_status(status)
 
 
 @six.python_2_unicode_compatible
@@ -884,72 +760,6 @@ def _make_archive_copy(item):
         value=item.value
     )
     archive_object.save()
-
-
-class ReviewStatus(object):
-    """
-    Standard review statuses
-    """
-    passed = u'passed'
-    violation = u'violation'
-    suspicious = u'suspicious'
-    not_reviewed = u'not_reviewed'
-
-    @classmethod
-    def validate(cls, status):
-        """
-        Validate review status
-        """
-        if status not in [cls.passed, cls.violation, cls.suspicious, cls.not_reviewed]:
-            raise ProctoredExamBadReviewStatus(status)
-        return True
-
-
-class SoftwareSecureReviewStatus(object):
-    """
-    These are the valid review statuses from
-    SoftwareSecure
-    """
-
-    clean = u'Clean'
-    violation = u'Rules Violation'
-    suspicious = u'Suspicious'
-    not_reviewed = u'Not Reviewed'
-
-    passing_statuses = [
-        clean,
-        violation]
-    failing_statuses = [
-        not_reviewed,
-        suspicious]
-    notify_support_for_status = suspicious
-
-    from_standard_status = {
-        ReviewStatus.passed: clean,
-        ReviewStatus.violation: violation,
-        ReviewStatus.suspicious: suspicious,
-        ReviewStatus.not_reviewed: not_reviewed,
-    }
-
-    to_standard_status = {
-        clean: ReviewStatus.passed,
-        violation: ReviewStatus.violation,
-        suspicious: ReviewStatus.suspicious,
-        not_reviewed: ReviewStatus.not_reviewed,
-    }
-
-    @classmethod
-    def validate(cls, status):
-        """
-        Validates the status, or raises ProctoredExamBadReviewStatus
-        """
-        if status not in cls.passing_statuses + cls.failing_statuses:
-            err_msg = (
-                'Received unexpected reviewStatus field value from payload. '
-                'Was {review_status}.'.format(review_status=status)
-            )
-            raise ProctoredExamBadReviewStatus(err_msg)
-        return True
 
 
 class ProctoredExamSoftwareSecureReview(TimeStampedModel):

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -1,0 +1,187 @@
+"""
+Status enums for edx-proctoring
+"""
+from edx_proctoring.exceptions import ProctoredExamBadReviewStatus
+
+
+class ProctoredExamStudentAttemptStatus(object):
+    """
+    A class to enumerate the various status that an attempt can have
+
+    IMPORTANT: Since these values are stored in a database, they are system
+    constants and should not be language translated, since translations
+    might change over time.
+    """
+
+    # the student is eligible to decide if he/she wants to pursue credit
+    eligible = 'eligible'
+
+    # the attempt record has been created, but the exam has not yet
+    # been started
+    created = 'created'
+
+    # the student has clicked on the external
+    # software download link
+    download_software_clicked = 'download_software_clicked'
+
+    # the attempt is ready to start but requires
+    # user to acknowledge that he/she wants to start the exam
+    ready_to_start = 'ready_to_start'
+
+    # the student has started the exam and is
+    # in the process of completing the exam
+    started = 'started'
+
+    # the student has completed the exam
+    ready_to_submit = 'ready_to_submit'
+
+    #
+    # The follow statuses below are considered in a 'completed' state
+    # and we will not allow transitions to status above this mark
+    #
+
+    # the student declined to take the exam as a proctored exam
+    declined = 'declined'
+
+    # the exam has timed out
+    timed_out = 'timed_out'
+
+    # the student has submitted the exam for proctoring review
+    submitted = 'submitted'
+
+    # the student has submitted the exam for proctoring review
+    second_review_required = 'second_review_required'
+
+    # the exam has been verified and approved
+    verified = 'verified'
+
+    # the exam has been rejected
+    rejected = 'rejected'
+
+    # the exam is believed to be in error
+    error = 'error'
+
+    # the course end date has passed
+    expired = 'expired'
+
+    @classmethod
+    def is_completed_status(cls, status):
+        """
+        Returns a boolean if the passed in status is in a "completed" state, meaning
+        that it cannot go backwards in state
+        """
+        return status in [
+            cls.declined, cls.timed_out, cls.submitted, cls.second_review_required,
+            cls.verified, cls.rejected, cls.error
+        ]
+
+    @classmethod
+    def is_incomplete_status(cls, status):
+        """
+        Returns a boolean if the passed in status is in an "incomplete" state.
+        """
+        return status in [
+            cls.eligible, cls.created, cls.download_software_clicked, cls.ready_to_start, cls.started,
+            cls.ready_to_submit
+        ]
+
+    @classmethod
+    def needs_credit_status_update(cls, to_status):
+        """
+        Returns a boolean if the passed in to_status calls for an update to the credit requirement status.
+        """
+        return to_status in [
+            cls.verified, cls.rejected, cls.declined, cls.submitted, cls.error
+        ]
+
+    @classmethod
+    def needs_grade_override(cls, to_status):
+        """
+        Returns a boolean if the passed in to_status calls for an override of the learner's grade.
+        """
+        return to_status in [
+            cls.rejected
+        ]
+
+    @classmethod
+    def is_a_cascadable_failure(cls, to_status):
+        """
+        Returns a boolean if the passed in to_status has a failure that needs to be cascaded
+        to other unattempted exams.
+        """
+        return to_status in [
+            cls.declined
+        ]
+
+    @classmethod
+    def is_valid_status(cls, status):
+        """
+        Makes sure that passed in status string is valid
+        """
+        return cls.is_completed_status(status) or cls.is_incomplete_status(status)
+
+
+class ReviewStatus(object):
+    """
+    Standard review statuses
+    """
+    passed = u'passed'
+    violation = u'violation'
+    suspicious = u'suspicious'
+    not_reviewed = u'not_reviewed'
+
+    @classmethod
+    def validate(cls, status):
+        """
+        Validate review status
+        """
+        if status not in [cls.passed, cls.violation, cls.suspicious, cls.not_reviewed]:
+            raise ProctoredExamBadReviewStatus(status)
+        return True
+
+
+class SoftwareSecureReviewStatus(object):
+    """
+    These are the valid review statuses from
+    SoftwareSecure
+    """
+
+    clean = u'Clean'
+    violation = u'Rules Violation'
+    suspicious = u'Suspicious'
+    not_reviewed = u'Not Reviewed'
+
+    passing_statuses = [
+        clean,
+        violation]
+    failing_statuses = [
+        not_reviewed,
+        suspicious]
+    notify_support_for_status = suspicious
+
+    from_standard_status = {
+        ReviewStatus.passed: clean,
+        ReviewStatus.violation: violation,
+        ReviewStatus.suspicious: suspicious,
+        ReviewStatus.not_reviewed: not_reviewed,
+    }
+
+    to_standard_status = {
+        clean: ReviewStatus.passed,
+        violation: ReviewStatus.violation,
+        suspicious: ReviewStatus.suspicious,
+        not_reviewed: ReviewStatus.not_reviewed,
+    }
+
+    @classmethod
+    def validate(cls, status):
+        """
+        Validates the status, or raises ProctoredExamBadReviewStatus
+        """
+        if status not in cls.passing_statuses + cls.failing_statuses:
+            err_msg = (
+                'Received unexpected reviewStatus field value from payload. '
+                'Was {review_status}.'.format(review_status=status)
+            )
+            raise ProctoredExamBadReviewStatus(err_msg)
+        return True

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -70,10 +70,10 @@ from edx_proctoring.models import (
     ProctoredExamSoftwareSecureComment,
     ProctoredExamStudentAllowance,
     ProctoredExamStudentAttempt,
-    ProctoredExamStudentAttemptStatus,
     ProctoredExamReviewPolicy,
 )
 from edx_proctoring.runtime import set_runtime_service, get_runtime_service
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 from .test_services import (
     MockCreditService,

--- a/edx_proctoring/tests/test_email.py
+++ b/edx_proctoring/tests/test_email.py
@@ -12,10 +12,10 @@ from mock import MagicMock, patch
 from edx_proctoring.api import (
     update_attempt_status,
 )
-from edx_proctoring.models import (
+from edx_proctoring.runtime import set_runtime_service, get_runtime_service
+from edx_proctoring.statuses import (
     ProctoredExamStudentAttemptStatus,
 )
-from edx_proctoring.runtime import set_runtime_service, get_runtime_service
 
 from .test_services import (
     MockCreditService,

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -15,8 +15,8 @@ from edx_proctoring.models import (
     ProctoredExamStudentAttemptHistory,
     ProctoredExamReviewPolicy,
     ProctoredExamReviewPolicyHistory,
-    ProctoredExamStudentAttemptStatus,
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 from .utils import (
     LoggedInTestCase

--- a/edx_proctoring/tests/test_reviews.py
+++ b/edx_proctoring/tests/test_reviews.py
@@ -15,9 +15,9 @@ from edx_proctoring.api import create_exam, create_exam_attempt, get_exam_attemp
 from edx_proctoring.backends.tests.test_review_payload import create_test_review_payload
 from edx_proctoring.exceptions import (ProctoredExamBadReviewStatus, ProctoredExamReviewAlreadyExists)
 from edx_proctoring.models import (ProctoredExamSoftwareSecureComment, ProctoredExamSoftwareSecureReview,
-                                   ProctoredExamSoftwareSecureReviewHistory, ProctoredExamStudentAttemptHistory,
-                                   ProctoredExamStudentAttemptStatus, ReviewStatus, SoftwareSecureReviewStatus)
+                                   ProctoredExamSoftwareSecureReviewHistory, ProctoredExamStudentAttemptHistory)
 from edx_proctoring.runtime import get_runtime_service, set_runtime_service
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus, ReviewStatus, SoftwareSecureReviewStatus
 from edx_proctoring.tests.test_services import (MockCertificateService, MockCreditService, MockGradesService,
                                                 MockInstructorService)
 from edx_proctoring.utils import locate_attempt_by_attempt_code

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -27,9 +27,9 @@ from edx_proctoring.models import (
     ProctoredExam,
     ProctoredExamStudentAllowance,
     ProctoredExamStudentAttempt,
-    ProctoredExamStudentAttemptStatus,
 )
 from edx_proctoring.runtime import set_runtime_service
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 from .test_services import MockCreditServiceWithCourseEndDate, MockCreditServiceNone
 from .utils import ProctoredExamTestCase

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2551,8 +2551,17 @@ class TestInstructorDashboard(LoggedInTestCase):
             is_active=True,
             backend='null',
         )
-        with self.assertRaises(Exception):
-            self.client.get(
-                reverse('edx_proctoring.instructor_dashboard_course',
-                        kwargs={'course_id': course_id})
-            )
+        response = self.client.get(
+            reverse('edx_proctoring.instructor_dashboard_course',
+                    kwargs={'course_id': course_id})
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Multiple backends for course', response.data)
+
+    def test_error_with_no_exams(self):
+        course_id = 'a/b/c'
+        response = self.client.get(
+            reverse('edx_proctoring.instructor_dashboard_course',
+                    kwargs={'course_id': course_id})
+        )
+        self.assertEqual(response.status_code, 404)

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2477,3 +2477,82 @@ class TestActiveExamsForUserView(LoggedInTestCase):
             exams_query_data
         )
         self.assertEqual(response.status_code, 200)
+
+
+class TestInstructorDashboard(LoggedInTestCase):
+    """
+    Tests for launching the instructor dashboard
+    """
+    def setUp(self):
+        super(TestInstructorDashboard, self).setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.second_user = User(username='tester2', email='tester2@test.com')
+        self.second_user.save()
+        self.client.login_user(self.user)
+
+        set_runtime_service('instructor', MockInstructorService(is_user_course_staff=True))
+
+    def test_launch_for_course(self):
+        course_id = 'a/b/c'
+
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+        )
+
+        expected_url = '/instructor/%s/' % course_id
+        response = self.client.get(
+            reverse('edx_proctoring.instructor_dashboard_course', args=[course_id])
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+    def test_launch_for_exam(self):
+        course_id = 'a/b/c'
+
+        proctored_exam = ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+        )
+        exam_id = proctored_exam.id
+
+        expected_url = '/instructor/%s/?exam=%s' % (course_id, exam_id)
+        response = self.client.get(
+            reverse('edx_proctoring.instructor_dashboard_exam', kwargs={'course_id': course_id, 'exam_id': exam_id})
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+    def test_error_with_multiple_backends(self):
+        course_id = 'a/b/c'
+
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+            backend='test',
+        )
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content2',
+            exam_name='Test Exam',
+            external_id='123aXqe4',
+            time_limit_mins=90,
+            is_active=True,
+            backend='null',
+        )
+        with self.assertRaises(Exception):
+            self.client.get(
+                reverse('edx_proctoring.instructor_dashboard_course',
+                        kwargs={'course_id': course_id})
+            )

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -21,7 +21,6 @@ from edx_proctoring.models import (
     ProctoredExam,
     ProctoredExamStudentAttempt,
     ProctoredExamStudentAllowance,
-    ProctoredExamStudentAttemptStatus,
 )
 from edx_proctoring.exceptions import (
     ProctoredExamIllegalStatusTransition,
@@ -34,7 +33,7 @@ from edx_proctoring.api import (
     update_attempt_status,
     _calculate_allowed_mins
 )
-
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.serializers import ProctoredExamSerializer
 from edx_proctoring.backends.tests.test_review_payload import create_test_review_payload
 from edx_proctoring.backends.tests.test_software_secure import mock_response_content

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -23,8 +23,8 @@ from edx_proctoring.api import (
 )
 from edx_proctoring.models import (
     ProctoredExamStudentAttempt,
-    ProctoredExamStudentAttemptStatus,
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 from edx_proctoring.tests.test_services import (
     MockCreditService,

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -83,6 +83,16 @@ urlpatterns = [
         views.ActiveExamsForUserView.as_view(),
         name='edx_proctoring.proctored_exam.active_exams_for_user'
     ),
+    url(
+        r'edx_proctoring/v1/instructor/{}$'.format(settings.COURSE_ID_PATTERN),
+        views.InstructorDashboard.as_view(),
+        name='edx_proctoring.instructor_dashboard_course'
+    ),
+    url(
+        r'edx_proctoring/v1/instructor/{}/(?P<exam_id>\d+)$'.format(settings.COURSE_ID_PATTERN),
+        views.InstructorDashboard.as_view(),
+        name='edx_proctoring.instructor_dashboard_exam'
+    ),
     #
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -51,11 +51,13 @@ from edx_proctoring.exceptions import (
 from edx_proctoring.runtime import get_runtime_service
 from edx_proctoring.serializers import ProctoredExamSerializer, ProctoredExamStudentAttemptSerializer
 from edx_proctoring.models import (
-    ProctoredExamStudentAttemptStatus,
     ProctoredExamStudentAttempt,
     ProctoredExam,
     ProctoredExamSoftwareSecureComment,
     ProctoredExamSoftwareSecureReview,
+)
+from edx_proctoring.statuses import (
+    ProctoredExamStudentAttemptStatus,
     ReviewStatus,
     SoftwareSecureReviewStatus,
 )

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -960,6 +960,7 @@ class InstructorDashboard(AuthenticatedAPIView):
         """
         Redirect to dashboard for a given course and optional exam_id
         """
+        exam = None
         if exam_id:
             exam = get_exam_by_id(exam_id)
         else:
@@ -970,10 +971,14 @@ class InstructorDashboard(AuthenticatedAPIView):
                     # In this case, what are we supposed to do?!
                     # It should not be possible to get in this state, because
                     # course teams will be prevented from updating the backend after the course start date
-                    raise ProctoredBaseException("Multiple backends for course %s %s != %s" %
-                                                 (course_id, found_backend, exam['backend']))
+                    error_message = "Multiple backends for course %r %r != %r" % (course_id,
+                                                                                  found_backend,
+                                                                                  exam['backend'])
+                    return Response(data=error_message, status=400)
                 else:
                     found_backend = exam_backend
+        if exam is None:
+            return Response(data='No exam found for course %r.' % course_id, status=404)
         backend = get_backend_provider(exam)
         user = {
             'id': request.user.id,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -11,6 +11,7 @@ import six
 from django.conf import settings
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.urls import reverse, NoReverseMatch
+from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.utils.decorators import method_decorator
 
@@ -948,3 +949,36 @@ class AnonymousReviewCallback(BaseReviewCallback, APIView):
                          request.data,
                          backend=provider)
         return Response('OK')
+
+
+class InstructorDashboard(AuthenticatedAPIView):
+    """
+    Redirects to the instructor dashboard for reviewing exams on the configured backend
+    """
+    @method_decorator(require_course_or_global_staff)
+    def get(self, request, course_id, exam_id=None):
+        """
+        Redirect to dashboard for a given course and optional exam_id
+        """
+        if exam_id:
+            exam = get_exam_by_id(exam_id)
+        else:
+            found_backend = None
+            for exam in get_all_exams_for_course(course_id, True):
+                exam_backend = exam['backend'] or settings.PROCTORING_BACKENDS.get('DEFAULT', None)
+                if found_backend and exam_backend != found_backend:
+                    # In this case, what are we supposed to do?!
+                    # It should not be possible to get in this state, because
+                    # course teams will be prevented from updating the backend after the course start date
+                    raise ProctoredBaseException("Multiple backends for course %s %s != %s" %
+                                                 (course_id, found_backend, exam['backend']))
+                else:
+                    found_backend = exam_backend
+        backend = get_backend_provider(exam)
+        user = {
+            'id': request.user.id,
+            'full_name': request.user.get_full_name(),
+            'email': request.user.email
+        }
+        url = backend.get_instructor_url(exam['course_id'], user, exam_id=exam_id)
+        return redirect(url)

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     django111: Django>=1.11,<2.0
     -rrequirements/test.txt
 commands =
-    py.test -rfe --cov=edx_proctoring --cov-report=html --ds=test_settings -n auto {posargs}
+    py.test -rfe --cov=edx_proctoring --cov-report=html --ds=test_settings -n 3 {posargs}
 
 [testenv:docs]
 setenv =


### PR DESCRIPTION
This adds a way for backends to define an instructor dashboard URL, and it adds a staff-only endpoint which will redirect to the dashboard.

It also refactors the attempt and review status objects into their own file, so that you can import them outside of the context of django.
