### PR TITLE
Ensure that the instructions are translated on the backend

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -41,7 +41,7 @@ Proctoring System configuration endpoint
     }
 
 The keys in the rules object should be machine readable. The values are human readable. PS should respect the HTTP request ``Accept-Language``
-header and translate all human readable rules into the requested language.
+header and translate all human readable rules and instructions into the requested language.
 
 If a download_url is included in the response, Open edX will redirect learners to the address before the proctoring session starts. The address will include ``attempt={attempt_id}`` in the query string.
 

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 import pkg_resources
+
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_rest_api_client.client import OAuthAPIClient
@@ -89,7 +90,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         url = self.config_url
         log.debug('Requesting config from %r', url)
-        response = self.session.get(url).json()
+        response = self.session.get(url, headers=self._get_language_headers()).json()
         return response
 
     def get_exam(self, exam):
@@ -200,6 +201,20 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         log.debug('Created instructor url for %r %r %r', course_id, exam_id, attempt_id)
         return url
 
+    def _get_language_headers(self):
+        """
+        Makes the Accept-Language header based on the currently active language
+        """
+        from django.conf import settings
+        from django.utils.translation import get_language
+
+        headers = {}
+        current_lang = get_language()
+        default_lang = settings.LANGUAGE_CODE
+        if current_lang and current_lang != default_lang:
+            headers['Accept-Language'] = '{};{}'.format(current_lang, default_lang)
+        return headers
+
     def _make_attempt_request(self, exam, attempt, method='POST', status=None, **payload):
         """
         Calls backend attempt API
@@ -209,6 +224,9 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         else:
             payload = None
         url = self.exam_attempt_url.format(exam_id=exam, attempt_id=attempt)
+        headers = {}
+        if method == 'GET':
+            headers.update(self._get_language_headers())
         log.debug('Making %r attempt request at %r', method, url)
-        response = self.session.request(method, url, json=payload).json()
+        response = self.session.request(method, url, json=payload, headers=headers).json()
         return response

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -203,17 +203,20 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
 
     def _get_language_headers(self):
         """
-        Makes the Accept-Language header based on the currently active language
+        Returns a dictionary of the Accept-Language headers
         """
+        # This import is here because developers writing backends which subclass this class
+        # may want to import this module and use the other methods, without having to run in the context
+        # of django settings, etc.
         from django.conf import settings
         from django.utils.translation import get_language
 
-        headers = {}
         current_lang = get_language()
         default_lang = settings.LANGUAGE_CODE
+        lang_header = default_lang
         if current_lang and current_lang != default_lang:
-            headers['Accept-Language'] = '{};{}'.format(current_lang, default_lang)
-        return headers
+            lang_header = '{};{}'.format(current_lang, default_lang)
+        return {'Accept-Language': lang_header}
 
     def _make_attempt_request(self, exam, attempt, method='POST', status=None, **payload):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -90,6 +90,27 @@ class RESTBackendTests(TestCase):
         self.assertEqual(external_attempt, attempt)
 
     @responses.activate
+    def test_get_attempt_i18n(self):
+        from django.utils.translation import activate
+        activate('es')
+        attempt = {
+            'id': 1,
+            'external_id': 'abcd',
+            'proctored_exam': self.backend_exam,
+            'user': 1,
+            'instructions': []
+        }
+        responses.add(
+            responses.GET,
+            url=self.provider.exam_attempt_url.format(
+                exam_id=self.backend_exam['external_id'], attempt_id=attempt['external_id']),
+            json=attempt
+        )
+        external_attempt = self.provider.get_attempt(attempt)
+        self.assertEqual(external_attempt, attempt)
+        self.assertEqual(responses.calls[1].request.headers['Accept-Language'], 'es;en-us')
+
+    @responses.activate
     def test_on_exam_saved(self):
         responses.add(
             responses.POST,

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -8,6 +8,7 @@ import jwt
 import responses
 
 from django.test import TestCase
+from django.utils.translation import activate
 
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 
@@ -88,10 +89,10 @@ class RESTBackendTests(TestCase):
         )
         external_attempt = self.provider.get_attempt(attempt)
         self.assertEqual(external_attempt, attempt)
+        self.assertEqual(responses.calls[1].request.headers['Accept-Language'], 'en-us')
 
     @responses.activate
     def test_get_attempt_i18n(self):
-        from django.utils.translation import activate
         activate('es')
         attempt = {
             'id': 1,


### PR DESCRIPTION
[EDUCATOR-3687](https://openedx.atlassian.net/browse/EDUCATOR-3687)