### PR TITLE
When there is no instructor dashboard for the backend, return a 404 instead of a 500

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -4,6 +4,6 @@ The exam proctoring subsystem for the Open edX platform.
 
 from __future__ import absolute_import
 
-__version__ = '1.5.0b2'
+__version__ = '1.5.0b3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -53,11 +53,14 @@ class EdxProctoringConfig(AppConfig):
         config = settings.PROCTORING_BACKENDS
 
         self.backends = {}  # pylint: disable=W0201
+        not_found = []
         for extension in ExtensionManager(namespace='openedx.proctoring'):
             name = extension.name
             try:
                 options = config[name]
                 self.backends[name] = extension.plugin(**options)
             except KeyError:
-                warnings.warn("No proctoring backend configured for '{}'.  "
-                              "Available: {}".format(name, list(self.backends)))
+                not_found.append(name)
+        if not_found:  # pragma: no branch
+            warnings.warn("No proctoring backend configured for '{}'.  "
+                          "Available: {}".format(not_found, list(self.backends)))

--- a/edx_proctoring/backends/backend.py
+++ b/edx_proctoring/backends/backend.py
@@ -82,3 +82,10 @@ class ProctoringBackendProvider(six.with_metaclass(abc.ABCMeta)):
             dict: backend exam attempt object
         """
         return attempt
+
+    # pylint: disable=unused-argument
+    def get_instructor_url(self, course_id, user, exam_id=None, attempt_id=None):
+        """
+        Returns the instructor dashboard url for reviews
+        """
+        return None

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -8,7 +8,7 @@ import jwt
 import responses
 
 from django.test import TestCase
-from django.utils.translation import activate
+from django.utils import translation
 
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 
@@ -93,7 +93,6 @@ class RESTBackendTests(TestCase):
 
     @responses.activate
     def test_get_attempt_i18n(self):
-        activate('es')
         attempt = {
             'id': 1,
             'external_id': 'abcd',
@@ -107,7 +106,8 @@ class RESTBackendTests(TestCase):
                 exam_id=self.backend_exam['external_id'], attempt_id=attempt['external_id']),
             json=attempt
         )
-        external_attempt = self.provider.get_attempt(attempt)
+        with translation.override('es'):
+            external_attempt = self.provider.get_attempt(attempt)
         self.assertEqual(external_attempt, attempt)
         self.assertEqual(responses.calls[1].request.headers['Accept-Language'], 'es;en-us')
 

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2570,6 +2570,23 @@ class TestInstructorDashboard(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+        # test the case of no PROCTORED exams
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content',
+            exam_name='Timed Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+            is_proctored=False,
+            backend='software_secure',
+        )
+        response = self.client.get(
+            reverse('edx_proctoring.instructor_dashboard_course',
+                    kwargs={'course_id': course_id})
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_error_with_no_dashboard(self):
         course_id = 'a/b/d'
 

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2569,3 +2569,23 @@ class TestInstructorDashboard(LoggedInTestCase):
                     kwargs={'course_id': course_id})
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_error_with_no_dashboard(self):
+        course_id = 'a/b/d'
+
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+            is_proctored=True,
+            backend='software_secure',
+        )
+        response = self.client.get(
+            reverse('edx_proctoring.instructor_dashboard_course',
+                    kwargs={'course_id': course_id})
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual('No instructor dashboard for RPNow', response.data)

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -986,4 +986,8 @@ class InstructorDashboard(AuthenticatedAPIView):
             'email': request.user.email
         }
         url = backend.get_instructor_url(exam['course_id'], user, exam_id=exam_id)
-        return redirect(url)
+        if url:
+            resp = redirect(url)
+        else:
+            resp = Response(data='No instructor dashboard for %s' % backend.verbose_name, status=404)
+        return resp


### PR DESCRIPTION
This slightly improves the LMS instructor dashboard experience when the course proctoring backend does not offer a review dashboard. The accordion option will still appear, but the iframe will show a 404 message instead of a 500 error...
