### PR TITLE
Matthugs/apply eslint everywhere

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules/
 build/
 edx_proctoring/static/proctoring/js/vendor/
 htmlcov/
+edx_proctoring/static/proctoring/js/views/Backbone.ModalDialog.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+edx_proctoring/static/proctoring/js/vendor/
+htmlcov/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "globals": {
     "sinon": false,
     "setFixtures": false,
+    "spyOnEvent": false,
     "edx": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,8 @@
     "sinon": false,
     "setFixtures": false,
     "spyOnEvent": false,
+    "_": false,
+    "Backbone": false,
     "gettext": false,
     "edx": true
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": "eslint-config-edx-es5"
+  "extends": "eslint-config-edx-es5",
+  "globals": {
+    "sinon": false,
+    "setFixtures": false,
+    "edx": true
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "sinon": false,
     "setFixtures": false,
     "spyOnEvent": false,
+    "gettext": false,
     "edx": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-edx-es5"
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "_": false,
     "Backbone": false,
     "gettext": false,
+    "Promise": false,
     "edx": true
   }
 }

--- a/.eslintrc.worker.json
+++ b/.eslintrc.worker.json
@@ -1,0 +1,6 @@
+{
+  "extends": "eslint-config-edx",
+  "env": {
+    "worker": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 - make validate_translations
 - make test-all
 - make test-js
+- make lint-js
 after_success:
 - coverage xml
 - bash <(curl -s https://codecov.io/bash) -cF python -f coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ test-js:
 	gulp test
 
 lint-js:
-	./node_modules/.bin/eslint --ext .js --ext .jsx .
+	./node_modules/.bin/eslint --ignore-pattern 'edx_proctoring/static/index.js' --ext .js --ext .jsx .
+	./node_modules/.bin/eslint --config .eslintrc.worker.json 'edx_proctoring/static/index.js'
 
 test-all: ## run tests on every supported Python/Django combination
 	tox -e quality

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ test-python: clean ## run tests in the current virtualenv
 test-js:
 	gulp test
 
+lint-js:
+	./node_modules/.bin/eslint --ext .js --ext .jsx .
+
 test-all: ## run tests on every supported Python/Django combination
 	tox -e quality
 	tox

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -1,3 +1,4 @@
+/* eslint no-restricted-globals: "off" */
 export const handlerWrapper = (Handler) => {
   let handler = new Handler({});
 

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_allowance_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_allowance_collection.js
@@ -1,5 +1,7 @@
-var edx = edx || {};
+edx = edx || {};
 (function(Backbone) {
+    'use strict';
+
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
@@ -8,5 +10,6 @@ var edx = edx || {};
         model: edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel,
         url: '/api/edx_proctoring/v1/proctored_exam/'
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection = edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection =
+        edx.instructor_dashboard.proctoring.ProctoredExamAllowanceCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_allowance_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_allowance_collection.js
@@ -1,6 +1,5 @@
 var edx = edx || {};
 (function(Backbone) {
-
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_collection.js
@@ -1,6 +1,5 @@
 var edx = edx || {};
 (function(Backbone) {
-
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_collection.js
@@ -1,5 +1,7 @@
-var edx = edx || {};
+edx = edx || {};
 (function(Backbone) {
+    'use strict';
+
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
@@ -8,5 +10,6 @@ var edx = edx || {};
         model: edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel,
         url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/'
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptCollection = edx.instructor_dashboard.proctoring.ProctoredExamAttemptCollection;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptCollection =
+        edx.instructor_dashboard.proctoring.ProctoredExamAttemptCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_collection.js
@@ -1,5 +1,8 @@
-var edx = edx || {};
+/* global ProctoredExamModel */
+edx = edx || {};
 (function(Backbone) {
+    'use strict';
+
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
@@ -8,5 +11,6 @@ var edx = edx || {};
         model: ProctoredExamModel,
         url: '/api/edx_proctoring/v1/proctored_exam/exam/course_id/'
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamCollection = edx.instructor_dashboard.proctoring.ProctoredExamCollection;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamCollection =
+        edx.instructor_dashboard.proctoring.ProctoredExamCollection;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_collection.js
@@ -1,6 +1,5 @@
 var edx = edx || {};
 (function(Backbone) {
-
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -1,9 +1,8 @@
-var edx = edx || {};
+/* global accessible_modal */
+edx = edx || {};
 
 (function($) {
     'use strict';
-
-    var ONE_MINUTE_MS = 60000;
 
     var actionToMessageTypesMap = {
         submit: {
@@ -111,14 +110,18 @@ var edx = edx || {};
     edx.courseware = edx.courseware || {};
     edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
     edx.courseware.proctored_exam.examStartHandler = function(e) {
+        var $this,
+            actionUrl,
+            action,
+            shouldUseWorker;
         e.preventDefault();
         e.stopPropagation();
 
-        var $this = $(this);
-        var actionUrl = $this.data('change-state-url');
-        var action = $this.data('action');
+        $this = $(this);
+        actionUrl = $this.data('change-state-url');
+        action = $this.data('action');
 
-        var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
+        shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
         if (shouldUseWorker) {
             workerPromiseForEventNames(actionToMessageTypesMap[action])()
                 .then(updateExamAttemptStatusPromise(actionUrl, action))
@@ -129,52 +132,21 @@ var edx = edx || {};
         }
     };
     edx.courseware.proctored_exam.examEndHandler = function() {
+        var $this,
+            actionUrl,
+            action,
+            shouldUseWorker;
         $(window).unbind('beforeunload');
 
-        var $this = $(this);
-        var actionUrl = $this.data('change-state-url');
-        var action = $this.data('action');
+        $this = $(this);
+        actionUrl = $this.data('change-state-url');
+        action = $this.data('action');
 
         setActionButtonLoadingState($this);
 
-        var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
-        if (shouldUseWorker) {
-            workerPromiseForEventNames(actionToMessageTypesMap[action])()
-                .then(updateExamAttemptStatusPromise(actionUrl, action))
-                .then(reloadPage)
-                .catch(errorHandlerGivenMessage(
-                    $this,
-                    gettext('Error Starting Exam'),
-                    gettext(
-                        'Something has gone wrong starting your exam. ' +
-                        'Please double-check that the application is running.'
-                    )
-                ));
-        } else {
-            updateExamAttemptStatusPromise(actionUrl, action)()
-                .then(reloadPage)
-                .catch(errorHandlerGivenMessage(
-                    $this,
-                    gettext('Error Starting Exam'),
-                    gettext(
-                        'Something has gone wrong starting your exam. ' +
-                        'Please reload the page and start again.'
-                    )
-                ));
-        }
-    };
-    edx.courseware.proctored_exam.examEndHandler = function() {
-        $(window).unbind('beforeunload');
-
-        var $this = $(this);
-        var actionUrl = $this.data('change-state-url');
-        var action = $this.data('action');
-
-        setActionButtonLoadingState($this);
-
-        var shouldUseWorker = window.Worker &&
-                              edx.courseware.proctored_exam.configuredWorkerURL &&
-                              action === 'submit';
+        shouldUseWorker = window.Worker &&
+                          edx.courseware.proctored_exam.configuredWorkerURL &&
+                          action === 'submit';
         if (shouldUseWorker) {
             updateExamAttemptStatusPromise(actionUrl, action)()
                 .then(workerPromiseForEventNames(actionToMessageTypesMap[action]))

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -1,198 +1,210 @@
 var edx = edx || {};
 
 (function($) {
-  'use strict';
+    'use strict';
 
-  var ONE_MINUTE_MS = 60000;
+    var ONE_MINUTE_MS = 60000;
 
-  var actionToMessageTypesMap = {
-    'submit': {
-      promptEventName: 'endExamAttempt',
-      successEventName: 'examAttemptEnded',
-      failureEventName: 'examAttemptEndFailed'
-    },
-    'start': {
-      promptEventName: 'startExamAttempt',
-      successEventName: 'examAttemptStarted',
-      failureEventName: 'examAttemptStartFailed'
-    },
-    'ping': {
-      promptEventName: 'ping',
-      successEventName: 'echo',
-      failureEventName: 'pingFailed'
+    var actionToMessageTypesMap = {
+        submit: {
+            promptEventName: 'endExamAttempt',
+            successEventName: 'examAttemptEnded',
+            failureEventName: 'examAttemptEndFailed'
+        },
+        start: {
+            promptEventName: 'startExamAttempt',
+            successEventName: 'examAttemptStarted',
+            failureEventName: 'examAttemptStartFailed'
+        },
+        ping: {
+            promptEventName: 'ping',
+            successEventName: 'echo',
+            failureEventName: 'pingFailed'
 
-    }
-  };
-
-  /**
-   * Launch modals, handling a11y focus behavior
-   *
-   * Note: don't try to leverage this for the heartbeat; the DOM
-   * structure this depends on doesn't live everywhere that handler
-   * needs to live
-   */
-   function accessibleError(title, message) {
-     accessible_modal(
-       "#accessible-error-modal #confirm_open_button",
-       "#accessible-error-modal .close-modal",
-       "#accessible-error-modal",
-       ".content-wrapper"
-     );
-     $("#accessible-error-modal #confirm_open_button").click();
-     $("#accessible-error-modal .message-title").html(message);
-     $('#accessible-error-modal #acessible-error-title').html(title);
-     $("#accessible-error-modal .ok-button")
-       .html(gettext("OK"))
-       .off('click.closeModal')
-       .on('click.closeModal', function(){
-         $("#accessible-error-modal .close-modal").click();
-       });
-  };
-
-
-  function workerPromiseForEventNames(eventNames) {
-    return function() {
-      var proctoringBackendWorker = new Worker(edx.courseware.proctored_exam.configuredWorkerURL);
-      return new Promise(function(resolve, reject) {
-        var responseHandler = function(e) {
-          if (e.data.type === eventNames.successEventName) {
-            proctoringBackendWorker.removeEventListener('message', responseHandler);
-            proctoringBackendWorker.terminate();
-            resolve();
-          } else {
-            reject();
-          }
-        };
-        proctoringBackendWorker.addEventListener('message', responseHandler);
-        proctoringBackendWorker.postMessage({ type: eventNames.promptEventName});
-      });
-    };
-  }
-
-  function timeoutPromise(timeoutMilliseconds) {
-    return new Promise(function(resolve, reject) {
-      setTimeout(reject, timeoutMilliseconds);
-    });
-  }
-
-  // Update the state of the attempt
-  function updateExamAttemptStatusPromise(actionUrl, action) {
-    return function() {
-      return Promise.resolve($.ajax({
-        url: actionUrl,
-        type: 'PUT',
-        data: {
-          action: action
         }
-      }));
     };
-  }
 
-  function reloadPage() {
-    location.reload();
-  }
+    function workerPromiseForEventNames(eventNames) {
+        return function() {
+            var proctoringBackendWorker = new Worker(edx.courseware.proctored_exam.configuredWorkerURL);
+            return new Promise(function(resolve, reject) {
+                var responseHandler = function(e) {
+                    if (e.data.type === eventNames.successEventName) {
+                        proctoringBackendWorker.removeEventListener('message', responseHandler);
+                        proctoringBackendWorker.terminate();
+                        resolve();
+                    } else {
+                        reject();
+                    }
+                };
+                proctoringBackendWorker.addEventListener('message', responseHandler);
+                proctoringBackendWorker.postMessage({type: eventNames.promptEventName});
+            });
+        };
+    }
 
-  function setActionButtonLoadingState($button) {
-    $button.prop('disabled', true);
-    $button.html($button.data('loading-text'));
-  }
+    function timeoutPromise(timeoutMilliseconds) {
+        return new Promise(function(resolve, reject) {
+            setTimeout(reject, timeoutMilliseconds);
+        });
+    }
 
-  function setActionButtonSteadyState($button) {
-    $button.prop('disabled', false);
-    $button.html($button.data('cta-text'));
-  }
+    /**
+     * Launch modals, handling a11y focus behavior
+     *
+     * Note: don't try to leverage this for the heartbeat; the DOM
+     * structure this depends on doesn't live everywhere that handler
+     * needs to live
+     */
+    function accessibleError(title, message) {
+        accessible_modal(
+            '#accessible-error-modal #confirm_open_button',
+            '#accessible-error-modal .close-modal',
+            '#accessible-error-modal',
+            '.content-wrapper'
+        );
+        $('#accessible-error-modal #confirm_open_button').click();
+        $('#accessible-error-modal .message-title').html(message);
+        $('#accessible-error-modal #acessible-error-title').html(title);
+        $('#accessible-error-modal .ok-button')
+            .html(gettext('OK'))
+            .off('click.closeModal')
+            .on('click.closeModal', function() {
+                $('#accessible-error-modal .close-modal').click();
+            });
+    }
 
-  function errorHandlerGivenMessage($button, title, message) {
-    setActionButtonSteadyState($button);
-    return function() {
-      accessibleError(title, message);
+    // Update the state of the attempt
+    function updateExamAttemptStatusPromise(actionUrl, action) {
+        return function() {
+            return Promise.resolve($.ajax({
+                url: actionUrl,
+                type: 'PUT',
+                data: {
+                    action: action
+                }
+            }));
+        };
+    }
+
+    function reloadPage() {
+        location.reload();
+    }
+
+    function setActionButtonLoadingState($button) {
+        $button.prop('disabled', true);
+        $button.html($button.data('loading-text'));
+    }
+
+    function setActionButtonSteadyState($button) {
+        $button.prop('disabled', false);
+        $button.html($button.data('cta-text'));
+    }
+
+    function errorHandlerGivenMessage($button, title, message) {
+        setActionButtonSteadyState($button);
+        return function() {
+            accessibleError(title, message);
+        };
+    }
+
+    edx.courseware = edx.courseware || {};
+    edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
+    edx.courseware.proctored_exam.examStartHandler = function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var $this = $(this);
+        var actionUrl = $this.data('change-state-url');
+        var action = $this.data('action');
+
+        var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
+        if (shouldUseWorker) {
+            workerPromiseForEventNames(actionToMessageTypesMap[action])()
+                .then(updateExamAttemptStatusPromise(actionUrl, action))
+                .then(reloadPage);
+        } else {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(reloadPage);
+        }
     };
-  }
+    edx.courseware.proctored_exam.examEndHandler = function() {
+        $(window).unbind('beforeunload');
 
+        var $this = $(this);
+        var actionUrl = $this.data('change-state-url');
+        var action = $this.data('action');
 
-  edx.courseware = edx.courseware || {};
-  edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
-  edx.courseware.proctored_exam.examStartHandler = function(e) {
-    e.preventDefault();
-    e.stopPropagation();
+        setActionButtonLoadingState($this);
 
-    var $this = $(this);
-    var actionUrl = $this.data('change-state-url');
-    var action = $this.data('action');
+        var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
+        if (shouldUseWorker) {
+            workerPromiseForEventNames(actionToMessageTypesMap[action])()
+                .then(updateExamAttemptStatusPromise(actionUrl, action))
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Starting Exam'),
+                    gettext(
+                        'Something has gone wrong starting your exam. ' +
+                        'Please double-check that the application is running.'
+                    )
+                ));
+        } else {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Starting Exam'),
+                    gettext(
+                        'Something has gone wrong starting your exam. ' +
+                        'Please reload the page and start again.'
+                    )
+                ));
+        }
+    };
+    edx.courseware.proctored_exam.examEndHandler = function() {
+        $(window).unbind('beforeunload');
 
-    setActionButtonLoadingState($this);
+        var $this = $(this);
+        var actionUrl = $this.data('change-state-url');
+        var action = $this.data('action');
 
-    var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
-    if(shouldUseWorker) {
-      workerPromiseForEventNames(actionToMessageTypesMap[action])()
-        .then(updateExamAttemptStatusPromise(actionUrl, action))
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Starting Exam'),
-          gettext(
-            'Something has gone wrong starting your exam. ' +
-            'Please double-check that the application is running.'
-          )
-        ));
-    } else {
-      updateExamAttemptStatusPromise(actionUrl, action)()
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Starting Exam'),
-          gettext(
-            'Something has gone wrong starting your exam. ' +
-            'Please reload the page and start again.'
-          )
-        ));
+        setActionButtonLoadingState($this);
 
-    }
-  };
-  edx.courseware.proctored_exam.examEndHandler = function() {
-
-    $(window).unbind('beforeunload');
-
-    var $this = $(this);
-    var actionUrl = $this.data('change-state-url');
-    var action = $this.data('action');
-
-    setActionButtonLoadingState($this);
-
-    var shouldUseWorker = window.Worker &&
-                          edx.courseware.proctored_exam.configuredWorkerURL &&
-                          action === "submit";
-    if(shouldUseWorker) {
-
-      updateExamAttemptStatusPromise(actionUrl, action)()
-        .then(workerPromiseForEventNames(actionToMessageTypesMap[action]))
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Ending Exam'),
-          gettext(
-            'Something has gone wrong ending your exam. ' +
-            'Please double-check that the application is running.'
-          )
-        ));
-    } else {
-      updateExamAttemptStatusPromise(actionUrl, action)()
-        .then(reloadPage)
-        .catch(errorHandlerGivenMessage(
-          $this,
-          gettext('Error Ending Exam'),
-          gettext(
-            'Something has gone wrong ending your exam. ' +
-            'Please reload the page and start again.'
-          )
-        ));
-    }
-  }
-  edx.courseware.proctored_exam.pingApplication = function(timeoutInSeconds) {
-    return Promise.race([
-      workerPromiseForEventNames(actionToMessageTypesMap.ping)(),
-      timeoutPromise(timeoutInSeconds * 1000)
-    ]);
-  }
-  edx.courseware.proctored_exam.accessibleError = accessibleError;
+        var shouldUseWorker = window.Worker &&
+                              edx.courseware.proctored_exam.configuredWorkerURL &&
+                              action === 'submit';
+        if (shouldUseWorker) {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(workerPromiseForEventNames(actionToMessageTypesMap[action]))
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Ending Exam'),
+                    gettext(
+                        'Something has gone wrong ending your exam. ' +
+                        'Please double-check that the application is running.'
+                    )
+                ));
+        } else {
+            updateExamAttemptStatusPromise(actionUrl, action)()
+                .then(reloadPage)
+                .catch(errorHandlerGivenMessage(
+                    $this,
+                    gettext('Error Ending Exam'),
+                    gettext(
+                        'Something has gone wrong ending your exam. ' +
+                        'Please reload the page and start again.'
+                    )
+                ));
+        }
+    };
+    edx.courseware.proctored_exam.pingApplication = function(timeoutInSeconds) {
+        return Promise.race([
+            workerPromiseForEventNames(actionToMessageTypesMap.ping)(),
+            timeoutPromise(timeoutInSeconds * 1000)
+        ]);
+    };
+    edx.courseware.proctored_exam.accessibleError = accessibleError;
 }).call(this, $);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_allowance_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_allowance_model.js
@@ -1,7 +1,6 @@
 var edx = edx || {};
 
 (function(Backbone) {
-
     'use strict';
 
     edx.instructor_dashboard = edx.instructor_dashboard || {};

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_allowance_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_allowance_model.js
@@ -1,4 +1,4 @@
-var edx = edx || {};
+edx = edx || {};
 
 (function(Backbone) {
     'use strict';
@@ -10,5 +10,6 @@ var edx = edx || {};
         url: '/api/edx_proctoring/v1/proctored_exam/allowance'
 
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel = edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel =
+      edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_attempt_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_attempt_model.js
@@ -1,7 +1,6 @@
 var edx = edx || {};
 
 (function(Backbone) {
-
     'use strict';
 
     edx.instructor_dashboard = edx.instructor_dashboard || {};

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_attempt_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_attempt_model.js
@@ -1,4 +1,4 @@
-var edx = edx || {};
+edx = edx || {};
 
 (function(Backbone) {
     'use strict';
@@ -10,5 +10,6 @@ var edx = edx || {};
         url: '/api/edx_proctoring/v1/proctored_exam/attempt/'
 
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel = edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel =
+      edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel;
 }).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
@@ -1,4 +1,6 @@
 (function(Backbone) {
+    'use strict';
+
     var ProctoredExamModel = Backbone.Model.extend({
         /* we should probably pull this from a data attribute on the HTML */
         url: '/api/edx_proctoring/v1/proctored_exam/attempt',
@@ -18,12 +20,16 @@
             lastFetched: new Date()
         },
         getFormattedRemainingTime: function(secondsLeft) {
+            var totalSeconds = parseInt(secondsLeft, 10),
+                hours,
+                minutes,
+                seconds;
             /* since we can have a small grace period, we can end in the negative numbers */
-            if (secondsLeft < 0) { secondsLeft = 0; }
+            if (secondsLeft < 0) { totalSeconds = 0; }
 
-            var hours = parseInt(secondsLeft / 3600);
-            var minutes = parseInt(secondsLeft / 60) % 60;
-            var seconds = Math.floor(secondsLeft % 60);
+            hours = totalSeconds / 3600;
+            minutes = (totalSeconds / 60) % 60;
+            seconds = Math.floor(totalSeconds % 60);
 
             return hours + ':' + (minutes < 10 ? '0' + minutes : minutes)
                 + ':' + (seconds < 10 ? '0' + seconds : seconds);
@@ -31,7 +37,10 @@
         getRemainingTimeState: function(secondsLeft) {
             if (secondsLeft > this.get('low_threshold_sec')) {
                 return null;
-            } else if (secondsLeft <= this.get('low_threshold_sec') && secondsLeft > this.get('critically_low_threshold_sec')) {
+            } else if (
+                secondsLeft <= this.get('low_threshold_sec')
+                && secondsLeft > this.get('critically_low_threshold_sec')
+            ) {
                 // returns the class name that has some css properties
                 // and it displays the user with the waring message if
                 // total seconds is less than the low_threshold value.

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
@@ -17,34 +17,30 @@
             accessibility_time_string: '',
             lastFetched: new Date()
         },
-        getFormattedRemainingTime: function (secondsLeft) {
+        getFormattedRemainingTime: function(secondsLeft) {
             /* since we can have a small grace period, we can end in the negative numbers */
-            if (secondsLeft < 0)
-                secondsLeft = 0;
+            if (secondsLeft < 0) { secondsLeft = 0; }
 
             var hours = parseInt(secondsLeft / 3600);
             var minutes = parseInt(secondsLeft / 60) % 60;
             var seconds = Math.floor(secondsLeft % 60);
 
-            return hours + ":" + (minutes < 10 ? "0" + minutes : minutes)
-                + ":" + (seconds < 10 ? "0" + seconds : seconds);
-
+            return hours + ':' + (minutes < 10 ? '0' + minutes : minutes)
+                + ':' + (seconds < 10 ? '0' + seconds : seconds);
         },
-        getRemainingTimeState: function (secondsLeft) {
+        getRemainingTimeState: function(secondsLeft) {
             if (secondsLeft > this.get('low_threshold_sec')) {
                 return null;
-            }
-            else if (secondsLeft <= this.get('low_threshold_sec') && secondsLeft > this.get('critically_low_threshold_sec')) {
+            } else if (secondsLeft <= this.get('low_threshold_sec') && secondsLeft > this.get('critically_low_threshold_sec')) {
                 // returns the class name that has some css properties
                 // and it displays the user with the waring message if
                 // total seconds is less than the low_threshold value.
-                return "warning";
-            }
-            else {
+                return 'warning';
+            } else {
                 // returns the class name that has some css properties
                 // and it displays the user with the critical message if
                 // total seconds is less than the critically_low_threshold_sec value.
-                return "critical";
+                return 'critical';
             }
         }
     });

--- a/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
+++ b/edx_proctoring/static/proctoring/js/models/proctored_exam_model.js
@@ -27,8 +27,8 @@
             /* since we can have a small grace period, we can end in the negative numbers */
             if (secondsLeft < 0) { totalSeconds = 0; }
 
-            hours = totalSeconds / 3600;
-            minutes = (totalSeconds / 60) % 60;
+            hours = Math.floor(totalSeconds / 3600);
+            minutes = Math.floor(totalSeconds / 60) % 60;
             seconds = Math.floor(totalSeconds % 60);
 
             return hours + ':' + (minutes < 10 ? '0' + minutes : minutes)

--- a/edx_proctoring/static/proctoring/js/proctored_app.js
+++ b/edx_proctoring/static/proctoring/js/proctored_app.js
@@ -1,6 +1,6 @@
 $(function() {
     var proctored_exam_view = new edx.courseware.proctored_exam.ProctoredExamView({
-        el: $(".proctored_exam_status"),
+        el: $('.proctored_exam_status'),
         proctored_template: '#proctored-exam-status-tpl',
         model: new ProctoredExamModel()
     });

--- a/edx_proctoring/static/proctoring/js/proctored_app.js
+++ b/edx_proctoring/static/proctoring/js/proctored_app.js
@@ -1,8 +1,11 @@
+/* global ProctoredExamModel */
 $(function() {
-    var proctored_exam_view = new edx.courseware.proctored_exam.ProctoredExamView({
+    'use strict';
+
+    var proctoredExamView = new edx.courseware.proctored_exam.ProctoredExamView({
         el: $('.proctored_exam_status'),
         proctored_template: '#proctored-exam-status-tpl',
         model: new ProctoredExamModel()
     });
-    proctored_exam_view.render();
+    proctoredExamView.render();
 });

--- a/edx_proctoring/static/proctoring/js/views/Backbone.ModalDialog.js
+++ b/edx_proctoring/static/proctoring/js/views/Backbone.ModalDialog.js
@@ -9,7 +9,7 @@
 Backbone.ModalView =
     Backbone.View.extend(
         {
-            name: 'ModalView',
+            name: "ModalView",
             modalBlanket: null,
             modalContainer: null,
             defaultOptions: {
@@ -22,40 +22,40 @@ Backbone.ModalView =
                 slideFromAbove: false,
                 slideFromBelow: false,
                 slideDistance: 150,
-                closeImageUrl: '/static/proctoring/close-modal.png',
-                closeImageHoverUrl: '/static/proctoring/close-modal-hover.png',
+                closeImageUrl: "/static/proctoring/close-modal.png",
+                closeImageHoverUrl: "/static/proctoring/close-modal-hover.png",
                 showModalAtScrollPosition: true,
                 permanentlyVisible: false,
                 backgroundClickClosesModal: true,
                 pressingEscapeClosesModal: true,
                 css: {
-                    border: '1px solid #111',
-                    display: 'block',
-                    'background-color': '#fff',
-                    '-webkit-box-shadow': '0px 0px 15px 4px rgba(0, 0, 0, 0.5)',
-                    '-moz-box-shadow': '0px 0px 15px 4px rgba(0, 0, 0, 0.5)',
-                    'box-shadow': '0px 0px 15px 4px rgba(0, 0, 0, 0.5)',
-                    '-webkit-border-radius': '10px',
-                    '-moz-border-radius': '10px',
-                    'border-radius': '6px',
-                    padding: '0px'
+                    "border": "1px solid #111",
+                    "display": "block",
+                    "background-color": "#fff",
+                    "-webkit-box-shadow": "0px 0px 15px 4px rgba(0, 0, 0, 0.5)",
+                    "-moz-box-shadow": "0px 0px 15px 4px rgba(0, 0, 0, 0.5)",
+                    "box-shadow": "0px 0px 15px 4px rgba(0, 0, 0, 0.5)",
+                    "-webkit-border-radius": "10px",
+                    "-moz-border-radius": "10px",
+                    "border-radius": "6px",
+                    "padding": "0px"
                 }
             },
 
-            initialize: function() {
+            initialize: function () {
             },
             events: {
             },
 
-            showModalBlanket: function() {
+            showModalBlanket: function () {
                 return this.ensureModalBlanket().fadeIn(this.options.fadeInDuration);
             },
 
-            hideModalBlanket: function() {
+            hideModalBlanket: function () {
                 return this.modalBlanket.fadeOut(this.options.fadeOutDuration);
             },
 
-            ensureModalContainer: function(target) {
+            ensureModalContainer: function (target) {
                 if (target != null) {
                     // A target is passed in, we need to re-render the modal container into the target.
                     if (this.modalContainer != null) {
@@ -68,11 +68,11 @@ Backbone.ModalView =
                     this.modalContainer =
                         $("<div id='modalContainer'>")
                             .css({
-                                'z-index': '99999',
-                                position: 'relative',
-                                '-webkit-border-radius': '6px',
-                                '-moz-border-radius': '6px',
-                                'border-radius': '6px'
+                                "z-index": "99999",
+                                "position": "relative",
+                                "-webkit-border-radius": "6px",
+                                "-moz-border-radius": "6px",
+                                "border-radius": "6px"
                             })
                             .appendTo(target);
                 }
@@ -80,78 +80,79 @@ Backbone.ModalView =
                 return this.modalContainer;
             },
 
-            ensureModalBlanket: function() {
-                this.modalBlanket = $('#modal-blanket');
+            ensureModalBlanket: function () {
+                this.modalBlanket = $("#modal-blanket");
 
                 if (this.modalBlanket.length == 0) {
                     this.modalBlanket =
                         $("<div id='modal-blanket'>")
                             .css(
-                                {
-                                    position: 'absolute',
-                                    top: 0,
-                                    left: 0,
-                                    height: $(document).height(), // Span the full document height...
-                                    width: '100%', // ...and full width
-                                    opacity: 0.5, // Make it slightly transparent
-                                    backgroundColor: '#000',
-                                    'z-index': 99900
-                                })
+                            {
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                height: $(document).height(), // Span the full document height...
+                                width: "100%", // ...and full width
+                                opacity: 0.5, // Make it slightly transparent
+                                backgroundColor: "#000",
+                                "z-index": 99900
+                            })
                             .appendTo(document.body)
                             .hide();
-                } else {
+                }
+                else {
                     // Ensure the blanket spans the whole document, screen may have been updated.
                     this.modalBlanket.css(
                         {
                             height: $(document).height(), // Span the full document height...
-                            width: '100%' // ...and full width
+                            width: "100%" // ...and full width
                         });
                 }
 
                 return this.modalBlanket;
             },
 
-            keyup: function(event) {
+            keyup: function (event) {
                 if (event.keyCode == 27 && this.options.pressingEscapeClosesModal) {
                     this.hideModal();
                 }
             },
 
-            click: function(event) {
-                if (event.target.id == 'modal-blanket' && this.options.backgroundClickClosesModal) {
+            click: function (event) {
+                if (event.target.id == "modal-blanket" && this.options.backgroundClickClosesModal) {
                     this.hideModal();
                 }
             },
 
-            setFocusOnFirstFormControl: function() {
-                var $controls = $('input, select, email, url, number, range, date, month, week, time, datetime, datetime-local, search, color', $(this.el));
-                if ($controls.length > 0) {
-                    $($controls[0]).focus();
+            setFocusOnFirstFormControl: function () {
+                var controls = $("input, select, email, url, number, range, date, month, week, time, datetime, datetime-local, search, color", $(this.el));
+                if (controls.length > 0) {
+                    $(controls[0]).focus();
                 }
             },
 
-            hideModal: function() {
-                this.trigger('closeModalWindow');
+            hideModal: function () {
+                this.trigger("closeModalWindow");
 
                 this.hideModalBlanket();
-                $(document.body).unbind('keyup', this.keyup);
-                this.modalBlanket.unbind('click', this.click);
+                $(document.body).unbind("keyup", this.keyup);
+                this.modalBlanket.unbind("click", this.click);
 
                 if (this.options.bodyOverflowHidden === true) {
-                    $(document.body).css('overflow', this.originalBodyOverflowValue);
+                    $(document.body).css("overflow", this.originalBodyOverflowValue);
                 }
 
                 var container = this.modalContainer;
                 $(this.modalContainer)
                     .fadeOut(
-                        this.options.fadeOutDuration,
-                        function() {
-                            container.remove();
-                        });
+                    this.options.fadeOutDuration,
+                    function () {
+                        container.remove();
+                    });
             },
 
-            getCoordinate: function(coordinate, css) {
-                if (typeof (css[coordinate]) !== 'undefined') {
+            getCoordinate: function (coordinate, css) {
+                if (typeof( css[coordinate]) !== "undefined") {
                     var value = css[coordinate];
                     delete css[coordinate]; // Don't apply positioning to the $el, we apply it to the modal container. Remove it from options.css
 
@@ -159,19 +160,19 @@ Backbone.ModalView =
                 }
             },
 
-            recenter: function() {
+            recenter: function () {
                 return this.recentre();
             },
 
             recentre: // Re-centre the modal dialog after it has been displayed. Useful if the height changes after initial rendering eg; jquery ui tabs will hide tab sections
-                function() {
+                function () {
                     var $el = $(this.el);
                     var coords = {
-                        top: this.getCoordinate('top', this.options.css),
-                        left: this.getCoordinate('left', this.options.css),
-                        right: this.getCoordinate('right', this.options.css),
-                        bottom: this.getCoordinate('bottom', this.options.css),
-                        isEmpty: function() {
+                        top: this.getCoordinate("top", this.options.css),
+                        left: this.getCoordinate("left", this.options.css),
+                        right: this.getCoordinate("right", this.options.css),
+                        bottom: this.getCoordinate("bottom", this.options.css),
+                        isEmpty: function () {
                             return (this.top == null && this.left == null && this.right == null && this.bottom == null);
                         }
                     };
@@ -181,26 +182,25 @@ Backbone.ModalView =
                     var centreX = $(window).width() / 2;
                     var modalContainer = this.modalContainer;
                     var positionY = centreY - ($el.outerHeight() / 2);
-                    modalContainer.css({top: (positionY + offsets.y) + 'px'});
+                    modalContainer.css({"top": (positionY + offsets.y) + "px"});
 
                     var positionX = centreX - ($el.outerWidth() / 2);
-                    modalContainer.css({left: (positionX + offsets.x) + 'px'});
+                    modalContainer.css({"left": (positionX + offsets.x) + "px"});
 
                     return this;
                 },
 
-            getOffsets: function() {
-                var offsetY = 0,
-                    offsetX = 0;
+            getOffsets: function () {
+                var offsetY = 0, offsetX = 0;
                 if (this.options.showModalAtScrollPosition) {
                     offsetY = $(document).scrollTop(),
-                    offsetX = $(document).scrollLeft();
+                        offsetX = $(document).scrollLeft()
                 }
 
                 return {x: offsetX, y: offsetY};
             },
 
-            showModal: function(options) {
+            showModal: function (options) {
                 this.defaultOptions.targetContainer = document.body;
                 this.options = $.extend(true, {}, this.defaultOptions, options, this.options);
 
@@ -210,21 +210,21 @@ Backbone.ModalView =
                     this.options.pressingEscapeClosesModal = false;
                 }
 
-                // Set the center alignment padding + border see css style
+                //Set the center alignment padding + border see css style
                 var $el = $(this.el);
 
                 var centreY = $(window).height() / 2;
                 var centreX = $(window).width() / 2;
                 var modalContainer = this.ensureModalContainer(this.options.targetContainer).empty();
 
-                $el.addClass('modal');
+                $el.addClass("modal");
 
                 var coords = {
-                    top: this.getCoordinate('top', this.options.css),
-                    left: this.getCoordinate('left', this.options.css),
-                    right: this.getCoordinate('right', this.options.css),
-                    bottom: this.getCoordinate('bottom', this.options.css),
-                    isEmpty: function() {
+                    top: this.getCoordinate("top", this.options.css),
+                    left: this.getCoordinate("left", this.options.css),
+                    right: this.getCoordinate("right", this.options.css),
+                    bottom: this.getCoordinate("bottom", this.options.css),
+                    isEmpty: function () {
                         return (this.top == null && this.left == null && this.right == null && this.bottom == null);
                     }
                 };
@@ -238,17 +238,17 @@ Backbone.ModalView =
                 this.modalBlanket.click(this.click); // This handler is unbound in hideModal()
 
                 if (this.options.bodyOverflowHidden === true) {
-                    this.originalBodyOverflowValue = $(document.body).css('overflow');
-                    $(document.body).css('overflow', 'hidden');
+                    this.originalBodyOverflowValue = $(document.body).css("overflow");
+                    $(document.body).css("overflow", "hidden");
                 }
 
                 modalContainer
                     .append($el);
 
                 modalContainer.css({
-                    opacity: 0,
-                    position: 'absolute',
-                    'z-index': 999999});
+                    "opacity": 0,
+                    "position": "absolute",
+                    "z-index": 999999});
 
                 var offsets = this.getOffsets();
 
@@ -258,28 +258,31 @@ Backbone.ModalView =
                     if (positionY < 10) positionY = 10;
 
                     // Overriding the coordinates with explicit values if they are passed in
-                    if (typeof (this.options.y) !== 'undefined') {
+                    if (typeof( this.options.y) !== "undefined") {
                         positionY = this.options.y;
-                    } else {
+                    }
+                    else {
                         positionY += offsets.y;
                     }
 
-                    modalContainer.css({top: positionY + 'px'});
+                    modalContainer.css({"top": positionY + "px"});
 
                     var positionX = centreX - ($el.outerWidth() / 2);
                     // Overriding the coordinates with explicit values if they are passed in
-                    if (typeof (this.options.x) !== 'undefined') {
+                    if (typeof( this.options.x) !== "undefined") {
                         positionX = this.options.x;
-                    } else {
+                    }
+                    else {
                         positionX += offsets.x;
                     }
 
-                    modalContainer.css({left: positionX + 'px'});
-                } else {
-                    if (coords.top != null) modalContainer.css({top: coords.top + offsets.y});
-                    if (coords.left != null) modalContainer.css({left: coords.left + offsets.x});
-                    if (coords.right != null) modalContainer.css({right: coords.right});
-                    if (coords.bottom != null) modalContainer.css({bottom: coords.bottom});
+                    modalContainer.css({"left": positionX + "px"});
+                }
+                else {
+                    if (coords.top != null) modalContainer.css({"top": coords.top + offsets.y});
+                    if (coords.left != null) modalContainer.css({"left": coords.left + offsets.x});
+                    if (coords.right != null) modalContainer.css({"right": coords.right});
+                    if (coords.bottom != null) modalContainer.css({"bottom": coords.bottom});
                 }
 
                 if (this.options.setFocusOnFirstFormControl) {
@@ -291,39 +294,39 @@ Backbone.ModalView =
                     var image =
                         $("<a href='#' id='modalCloseButton'>&#160;</a>")
                             .css({
-                                position: 'absolute',
-                                top: '-8px',
-                                right: '-495px',
-                                width: '32px',
-                                height: '32px',
-                                'z-index': '999999',
-                                background: 'transparent url(' + view.options.closeImageUrl + ') top left no-repeat',
-                                'text-decoration': 'none'})
+                                "position": "absolute",
+                                "top": "-8px",
+                                "right": "-495px",
+                                "width": "32px",
+                                "height": "32px",
+                                "z-index": "999999",
+                                "background": "transparent url(" + view.options.closeImageUrl + ") top left no-repeat",
+                                "text-decoration": "none"})
                             .appendTo(this.modalContainer)
                             .hover(
-                                function() {
-                                    $(this).css('background-image', 'url(' + view.options.closeImageHoverUrl + ') !important');
-                                },
-                                function() {
-                                    $(this).css('background-image', 'url(' + view.options.closeImageUrl + ') !important');
-                                })
+                            function () {
+                                $(this).css("background-image", "url(" + view.options.closeImageHoverUrl + ") !important");
+                            },
+                            function () {
+                                $(this).css("background-image", "url(" + view.options.closeImageUrl + ") !important");
+                            })
                             .click(
-                                function(event) {
-                                    event.preventDefault();
-                                    view.hideModal();
-                                });
+                            function (event) {
+                                event.preventDefault();
+                                view.hideModal();
+                            });
                 }
 
                 var animateProperties = {opacity: 1};
                 var modalOffset = modalContainer.offset();
 
                 if (this.options.slideFromAbove) {
-                    modalContainer.css({top: (modalOffset.top - this.options.slideDistance) + 'px'});
+                    modalContainer.css({"top": (modalOffset.top - this.options.slideDistance) + "px"});
                     animateProperties.top = coords.top;
                 }
 
                 if (this.options.slideFromBelow) {
-                    modalContainer.css({top: (modalOffset.top + this.options.slideDistance) + 'px'});
+                    modalContainer.css({"top": (modalOffset.top + this.options.slideDistance) + "px"});
                     animateProperties.top = coords.top;
                 }
 

--- a/edx_proctoring/static/proctoring/js/views/Backbone.ModalDialog.js
+++ b/edx_proctoring/static/proctoring/js/views/Backbone.ModalDialog.js
@@ -9,7 +9,7 @@
 Backbone.ModalView =
     Backbone.View.extend(
         {
-            name: "ModalView",
+            name: 'ModalView',
             modalBlanket: null,
             modalContainer: null,
             defaultOptions: {
@@ -22,40 +22,40 @@ Backbone.ModalView =
                 slideFromAbove: false,
                 slideFromBelow: false,
                 slideDistance: 150,
-                closeImageUrl: "/static/proctoring/close-modal.png",
-                closeImageHoverUrl: "/static/proctoring/close-modal-hover.png",
+                closeImageUrl: '/static/proctoring/close-modal.png',
+                closeImageHoverUrl: '/static/proctoring/close-modal-hover.png',
                 showModalAtScrollPosition: true,
                 permanentlyVisible: false,
                 backgroundClickClosesModal: true,
                 pressingEscapeClosesModal: true,
                 css: {
-                    "border": "1px solid #111",
-                    "display": "block",
-                    "background-color": "#fff",
-                    "-webkit-box-shadow": "0px 0px 15px 4px rgba(0, 0, 0, 0.5)",
-                    "-moz-box-shadow": "0px 0px 15px 4px rgba(0, 0, 0, 0.5)",
-                    "box-shadow": "0px 0px 15px 4px rgba(0, 0, 0, 0.5)",
-                    "-webkit-border-radius": "10px",
-                    "-moz-border-radius": "10px",
-                    "border-radius": "6px",
-                    "padding": "0px"
+                    border: '1px solid #111',
+                    display: 'block',
+                    'background-color': '#fff',
+                    '-webkit-box-shadow': '0px 0px 15px 4px rgba(0, 0, 0, 0.5)',
+                    '-moz-box-shadow': '0px 0px 15px 4px rgba(0, 0, 0, 0.5)',
+                    'box-shadow': '0px 0px 15px 4px rgba(0, 0, 0, 0.5)',
+                    '-webkit-border-radius': '10px',
+                    '-moz-border-radius': '10px',
+                    'border-radius': '6px',
+                    padding: '0px'
                 }
             },
 
-            initialize: function () {
+            initialize: function() {
             },
             events: {
             },
 
-            showModalBlanket: function () {
+            showModalBlanket: function() {
                 return this.ensureModalBlanket().fadeIn(this.options.fadeInDuration);
             },
 
-            hideModalBlanket: function () {
+            hideModalBlanket: function() {
                 return this.modalBlanket.fadeOut(this.options.fadeOutDuration);
             },
 
-            ensureModalContainer: function (target) {
+            ensureModalContainer: function(target) {
                 if (target != null) {
                     // A target is passed in, we need to re-render the modal container into the target.
                     if (this.modalContainer != null) {
@@ -68,11 +68,11 @@ Backbone.ModalView =
                     this.modalContainer =
                         $("<div id='modalContainer'>")
                             .css({
-                                "z-index": "99999",
-                                "position": "relative",
-                                "-webkit-border-radius": "6px",
-                                "-moz-border-radius": "6px",
-                                "border-radius": "6px"
+                                'z-index': '99999',
+                                position: 'relative',
+                                '-webkit-border-radius': '6px',
+                                '-moz-border-radius': '6px',
+                                'border-radius': '6px'
                             })
                             .appendTo(target);
                 }
@@ -80,79 +80,78 @@ Backbone.ModalView =
                 return this.modalContainer;
             },
 
-            ensureModalBlanket: function () {
-                this.modalBlanket = $("#modal-blanket");
+            ensureModalBlanket: function() {
+                this.modalBlanket = $('#modal-blanket');
 
                 if (this.modalBlanket.length == 0) {
                     this.modalBlanket =
                         $("<div id='modal-blanket'>")
                             .css(
-                            {
-                                position: "absolute",
-                                top: 0,
-                                left: 0,
-                                height: $(document).height(), // Span the full document height...
-                                width: "100%", // ...and full width
-                                opacity: 0.5, // Make it slightly transparent
-                                backgroundColor: "#000",
-                                "z-index": 99900
-                            })
+                                {
+                                    position: 'absolute',
+                                    top: 0,
+                                    left: 0,
+                                    height: $(document).height(), // Span the full document height...
+                                    width: '100%', // ...and full width
+                                    opacity: 0.5, // Make it slightly transparent
+                                    backgroundColor: '#000',
+                                    'z-index': 99900
+                                })
                             .appendTo(document.body)
                             .hide();
-                }
-                else {
+                } else {
                     // Ensure the blanket spans the whole document, screen may have been updated.
                     this.modalBlanket.css(
                         {
                             height: $(document).height(), // Span the full document height...
-                            width: "100%" // ...and full width
+                            width: '100%' // ...and full width
                         });
                 }
 
                 return this.modalBlanket;
             },
 
-            keyup: function (event) {
+            keyup: function(event) {
                 if (event.keyCode == 27 && this.options.pressingEscapeClosesModal) {
                     this.hideModal();
                 }
             },
 
-            click: function (event) {
-                if (event.target.id == "modal-blanket" && this.options.backgroundClickClosesModal) {
+            click: function(event) {
+                if (event.target.id == 'modal-blanket' && this.options.backgroundClickClosesModal) {
                     this.hideModal();
                 }
             },
 
-            setFocusOnFirstFormControl: function () {
-                var controls = $("input, select, email, url, number, range, date, month, week, time, datetime, datetime-local, search, color", $(this.el));
-                if (controls.length > 0) {
-                    $(controls[0]).focus();
+            setFocusOnFirstFormControl: function() {
+                var $controls = $('input, select, email, url, number, range, date, month, week, time, datetime, datetime-local, search, color', $(this.el));
+                if ($controls.length > 0) {
+                    $($controls[0]).focus();
                 }
             },
 
-            hideModal: function () {
-                this.trigger("closeModalWindow");
+            hideModal: function() {
+                this.trigger('closeModalWindow');
 
                 this.hideModalBlanket();
-                $(document.body).unbind("keyup", this.keyup);
-                this.modalBlanket.unbind("click", this.click);
+                $(document.body).unbind('keyup', this.keyup);
+                this.modalBlanket.unbind('click', this.click);
 
                 if (this.options.bodyOverflowHidden === true) {
-                    $(document.body).css("overflow", this.originalBodyOverflowValue);
+                    $(document.body).css('overflow', this.originalBodyOverflowValue);
                 }
 
                 var container = this.modalContainer;
                 $(this.modalContainer)
                     .fadeOut(
-                    this.options.fadeOutDuration,
-                    function () {
-                        container.remove();
-                    });
+                        this.options.fadeOutDuration,
+                        function() {
+                            container.remove();
+                        });
             },
 
-            getCoordinate: function (coordinate, css) {
-                if (typeof( css[coordinate]) !== "undefined") {
+            getCoordinate: function(coordinate, css) {
+                if (typeof (css[coordinate]) !== 'undefined') {
                     var value = css[coordinate];
                     delete css[coordinate]; // Don't apply positioning to the $el, we apply it to the modal container. Remove it from options.css
 
@@ -160,19 +159,19 @@ Backbone.ModalView =
                 }
             },
 
-            recenter: function () {
+            recenter: function() {
                 return this.recentre();
             },
 
             recentre: // Re-centre the modal dialog after it has been displayed. Useful if the height changes after initial rendering eg; jquery ui tabs will hide tab sections
-                function () {
+                function() {
                     var $el = $(this.el);
                     var coords = {
-                        top: this.getCoordinate("top", this.options.css),
-                        left: this.getCoordinate("left", this.options.css),
-                        right: this.getCoordinate("right", this.options.css),
-                        bottom: this.getCoordinate("bottom", this.options.css),
-                        isEmpty: function () {
+                        top: this.getCoordinate('top', this.options.css),
+                        left: this.getCoordinate('left', this.options.css),
+                        right: this.getCoordinate('right', this.options.css),
+                        bottom: this.getCoordinate('bottom', this.options.css),
+                        isEmpty: function() {
                             return (this.top == null && this.left == null && this.right == null && this.bottom == null);
                         }
                     };
@@ -182,25 +181,26 @@ Backbone.ModalView =
                     var centreX = $(window).width() / 2;
                     var modalContainer = this.modalContainer;
                     var positionY = centreY - ($el.outerHeight() / 2);
-                    modalContainer.css({"top": (positionY + offsets.y) + "px"});
+                    modalContainer.css({top: (positionY + offsets.y) + 'px'});
 
                     var positionX = centreX - ($el.outerWidth() / 2);
-                    modalContainer.css({"left": (positionX + offsets.x) + "px"});
+                    modalContainer.css({left: (positionX + offsets.x) + 'px'});
 
                     return this;
                 },
 
-            getOffsets: function () {
-                var offsetY = 0, offsetX = 0;
+            getOffsets: function() {
+                var offsetY = 0,
+                    offsetX = 0;
                 if (this.options.showModalAtScrollPosition) {
                     offsetY = $(document).scrollTop(),
-                        offsetX = $(document).scrollLeft()
+                    offsetX = $(document).scrollLeft();
                 }
 
                 return {x: offsetX, y: offsetY};
             },
 
-            showModal: function (options) {
+            showModal: function(options) {
                 this.defaultOptions.targetContainer = document.body;
                 this.options = $.extend(true, {}, this.defaultOptions, options, this.options);
 
@@ -210,21 +210,21 @@ Backbone.ModalView =
                     this.options.pressingEscapeClosesModal = false;
                 }
 
-                //Set the center alignment padding + border see css style
+                // Set the center alignment padding + border see css style
                 var $el = $(this.el);
 
                 var centreY = $(window).height() / 2;
                 var centreX = $(window).width() / 2;
                 var modalContainer = this.ensureModalContainer(this.options.targetContainer).empty();
 
-                $el.addClass("modal");
+                $el.addClass('modal');
 
                 var coords = {
-                    top: this.getCoordinate("top", this.options.css),
-                    left: this.getCoordinate("left", this.options.css),
-                    right: this.getCoordinate("right", this.options.css),
-                    bottom: this.getCoordinate("bottom", this.options.css),
-                    isEmpty: function () {
+                    top: this.getCoordinate('top', this.options.css),
+                    left: this.getCoordinate('left', this.options.css),
+                    right: this.getCoordinate('right', this.options.css),
+                    bottom: this.getCoordinate('bottom', this.options.css),
+                    isEmpty: function() {
                         return (this.top == null && this.left == null && this.right == null && this.bottom == null);
                     }
                 };
@@ -238,17 +238,17 @@ Backbone.ModalView =
                 this.modalBlanket.click(this.click); // This handler is unbound in hideModal()
 
                 if (this.options.bodyOverflowHidden === true) {
-                    this.originalBodyOverflowValue = $(document.body).css("overflow");
-                    $(document.body).css("overflow", "hidden");
+                    this.originalBodyOverflowValue = $(document.body).css('overflow');
+                    $(document.body).css('overflow', 'hidden');
                 }
 
                 modalContainer
                     .append($el);
 
                 modalContainer.css({
-                    "opacity": 0,
-                    "position": "absolute",
-                    "z-index": 999999});
+                    opacity: 0,
+                    position: 'absolute',
+                    'z-index': 999999});
 
                 var offsets = this.getOffsets();
 
@@ -258,31 +258,28 @@ Backbone.ModalView =
                     if (positionY < 10) positionY = 10;
 
                     // Overriding the coordinates with explicit values if they are passed in
-                    if (typeof( this.options.y) !== "undefined") {
+                    if (typeof (this.options.y) !== 'undefined') {
                         positionY = this.options.y;
-                    }
-                    else {
+                    } else {
                         positionY += offsets.y;
                     }
 
-                    modalContainer.css({"top": positionY + "px"});
+                    modalContainer.css({top: positionY + 'px'});
 
                     var positionX = centreX - ($el.outerWidth() / 2);
                     // Overriding the coordinates with explicit values if they are passed in
-                    if (typeof( this.options.x) !== "undefined") {
+                    if (typeof (this.options.x) !== 'undefined') {
                         positionX = this.options.x;
-                    }
-                    else {
+                    } else {
                         positionX += offsets.x;
                     }
 
-                    modalContainer.css({"left": positionX + "px"});
-                }
-                else {
-                    if (coords.top != null) modalContainer.css({"top": coords.top + offsets.y});
-                    if (coords.left != null) modalContainer.css({"left": coords.left + offsets.x});
-                    if (coords.right != null) modalContainer.css({"right": coords.right});
-                    if (coords.bottom != null) modalContainer.css({"bottom": coords.bottom});
+                    modalContainer.css({left: positionX + 'px'});
+                } else {
+                    if (coords.top != null) modalContainer.css({top: coords.top + offsets.y});
+                    if (coords.left != null) modalContainer.css({left: coords.left + offsets.x});
+                    if (coords.right != null) modalContainer.css({right: coords.right});
+                    if (coords.bottom != null) modalContainer.css({bottom: coords.bottom});
                 }
 
                 if (this.options.setFocusOnFirstFormControl) {
@@ -294,39 +291,39 @@ Backbone.ModalView =
                     var image =
                         $("<a href='#' id='modalCloseButton'>&#160;</a>")
                             .css({
-                                "position": "absolute",
-                                "top": "-8px",
-                                "right": "-495px",
-                                "width": "32px",
-                                "height": "32px",
-                                "z-index": "999999",
-                                "background": "transparent url(" + view.options.closeImageUrl + ") top left no-repeat",
-                                "text-decoration": "none"})
+                                position: 'absolute',
+                                top: '-8px',
+                                right: '-495px',
+                                width: '32px',
+                                height: '32px',
+                                'z-index': '999999',
+                                background: 'transparent url(' + view.options.closeImageUrl + ') top left no-repeat',
+                                'text-decoration': 'none'})
                             .appendTo(this.modalContainer)
                             .hover(
-                            function () {
-                                $(this).css("background-image", "url(" + view.options.closeImageHoverUrl + ") !important");
-                            },
-                            function () {
-                                $(this).css("background-image", "url(" + view.options.closeImageUrl + ") !important");
-                            })
+                                function() {
+                                    $(this).css('background-image', 'url(' + view.options.closeImageHoverUrl + ') !important');
+                                },
+                                function() {
+                                    $(this).css('background-image', 'url(' + view.options.closeImageUrl + ') !important');
+                                })
                             .click(
-                            function (event) {
-                                event.preventDefault();
-                                view.hideModal();
-                            });
+                                function(event) {
+                                    event.preventDefault();
+                                    view.hideModal();
+                                });
                 }
 
                 var animateProperties = {opacity: 1};
                 var modalOffset = modalContainer.offset();
 
                 if (this.options.slideFromAbove) {
-                    modalContainer.css({"top": (modalOffset.top - this.options.slideDistance) + "px"});
+                    modalContainer.css({top: (modalOffset.top - this.options.slideDistance) + 'px'});
                     animateProperties.top = coords.top;
                 }
 
                 if (this.options.slideFromBelow) {
-                    modalContainer.css({"top": (modalOffset.top + this.options.slideDistance) + "px"});
+                    modalContainer.css({top: (modalOffset.top + this.options.slideDistance) + 'px'});
                     animateProperties.top = coords.top;
                 }
 

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_add_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_add_allowance_view.js
@@ -1,4 +1,4 @@
-var edx = edx || {};
+edx = edx || {};
 
 (function(Backbone, $, _, gettext) {
     'use strict';
@@ -28,11 +28,11 @@ var edx = edx || {};
         loadTemplateData: function() {
             var self = this;
             $.ajax({url: self.template_url, dataType: 'html'})
-                .error(function(jqXHR, textStatus, errorThrown) {
+                .error(function() {
 
                 })
-                .done(function(template_data) {
-                    self.template = _.template(template_data);
+                .done(function(templateData) {
+                    self.template = _.template(templateData);
                     self.render();
                     self.showModal();
                     self.updateCss();
@@ -98,18 +98,19 @@ var edx = edx || {};
                 user_info: $('#user_info').val()
             };
         },
-        hideError: function(view, attr, selector) {
+        hideError: function(view, attr) {
             var $element = view.$form[attr];
 
             $element.removeClass('error');
             $element.parent().find('.error-message').empty();
         },
-        showError: function(view, attr, errorMessage, selector) {
-            var $element = view.$form[attr];
+        showError: function(view, attr, errorMessage) {
+            var $element = view.$form[attr],
+                $errorMessage;
 
             $element.addClass('error');
-            var $errorMessage = $element.parent().find('.error-message');
-            if ($errorMessage.length == 0) {
+            $errorMessage = $element.parent().find('.error-message');
+            if (!$errorMessage.length) {
                 $errorMessage = $("<div class='error-message'></div>");
                 $element.parent().append($errorMessage);
             }
@@ -118,14 +119,18 @@ var edx = edx || {};
             this.updateCss();
         },
         addAllowance: function(event) {
+            var self,
+                formHasErrors,
+                values,
+                $errorResponse;
             event.preventDefault();
-            var $error_response = $('.error-response');
-            $error_response.html();
-            var values = this.getCurrentFormValues();
-            var formHasErrors = false;
+            $errorResponse = $('.error-response');
+            $errorResponse.html();
+            values = this.getCurrentFormValues();
+            formHasErrors = false;
 
 
-            var self = this;
+            self = this;
             $.each(values, function(key, value) {
                 if (value === '') {
                     formHasErrors = true;
@@ -149,14 +154,15 @@ var edx = edx || {};
                     },
                     success: function() {
                         // fetch the allowances again.
-                        $error_response.html();
-                        self.proctored_exam_allowance_view.collection.url = self.proctored_exam_allowance_view.initial_url + self.course_id + '/allowance';
+                        $errorResponse.html();
+                        self.proctored_exam_allowance_view.collection.url =
+                            self.proctored_exam_allowance_view.initial_url + self.course_id + '/allowance';
                         self.proctored_exam_allowance_view.hydrate();
                         self.hideModal();
                     },
-                    error: function(self, response, options) {
+                    error: function(context, response) {
                         var data = $.parseJSON(response.responseText);
-                        $error_response.html(gettext(data.detail));
+                        $errorResponse.html(gettext(data.detail));
                     }
                 });
             }
@@ -166,7 +172,11 @@ var edx = edx || {};
 
             if (selectedExam.is_proctored) {
                 // Selected Exam is a Proctored or Practice-Proctored exam.
-                if (selectedExam.is_practice_exam) { $('#exam_type_label').text(gettext('Practice Exam')); } else { $('#exam_type_label').text(gettext('Proctored Exam')); }
+                if (selectedExam.is_practice_exam) {
+                    $('#exam_type_label').text(gettext('Practice Exam'));
+                } else {
+                    $('#exam_type_label').text(gettext('Proctored Exam'));
+                }
 
                 // In case of Proctored Exams, we hide the Additional Time label and show the Allowance Types Select
                 $('#additional_time_label').hide();
@@ -183,14 +193,14 @@ var edx = edx || {};
             }
             this.updateAllowanceLabels('additional_time_granted');
         },
-        selectExam: function(event) {
+        selectExam: function() {
             this.selectExamAtIndex($('#proctored_exam')[0].selectedIndex);
         },
-        selectAllowance: function(event) {
+        selectAllowance: function() {
             this.updateAllowanceLabels($('#allowance_type').val());
         },
         updateAllowanceLabels: function(selectedAllowanceType) {
-            if (selectedAllowanceType == 'additional_time_granted') {
+            if (selectedAllowanceType === 'additional_time_granted') {
                 $('#minutes_label').show();
                 $('#allowance_value_label').text(gettext('Additional Time'));
             } else {

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_add_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_add_allowance_view.js
@@ -1,37 +1,37 @@
 var edx = edx || {};
 
-(function (Backbone, $, _, gettext) {
+(function(Backbone, $, _, gettext) {
     'use strict';
 
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
     edx.instructor_dashboard.proctoring.AddAllowanceView = Backbone.ModalView.extend({
-        name: "AddAllowanceView",
+        name: 'AddAllowanceView',
         template: null,
         template_url: '/static/proctoring/templates/add-new-allowance.underscore',
-        initialize: function (options) {
+        initialize: function(options) {
             this.proctored_exams = options.proctored_exams;
             this.proctored_exam_allowance_view = options.proctored_exam_allowance_view;
             this.course_id = options.course_id;
             this.allowance_types = options.allowance_types;
             this.model = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceModel();
-            _.bindAll(this, "render");
+            _.bindAll(this, 'render');
             this.loadTemplateData();
-            //Backbone.Validation.bind( this,  {valid:this.hideError, invalid:this.showError});
+            // Backbone.Validation.bind( this,  {valid:this.hideError, invalid:this.showError});
         },
         events: {
-            "submit form": "addAllowance",
-            "change #proctored_exam": 'selectExam',
-            "change #allowance_type": 'selectAllowance'
+            'submit form': 'addAllowance',
+            'change #proctored_exam': 'selectExam',
+            'change #allowance_type': 'selectAllowance'
         },
-        loadTemplateData: function () {
+        loadTemplateData: function() {
             var self = this;
-            $.ajax({url: self.template_url, dataType: "html"})
-                .error(function (jqXHR, textStatus, errorThrown) {
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .error(function(jqXHR, textStatus, errorThrown) {
 
                 })
-                .done(function (template_data) {
+                .done(function(template_data) {
                     self.template = _.template(template_data);
                     self.render();
                     self.showModal();
@@ -42,73 +42,73 @@ var edx = edx || {};
         updateCss: function() {
             var $el = $(this.el);
             $el.find('.modal-header').css({
-                "color": "#1580b0",
-                "font-size": "20px",
-                "font-weight": "600",
-                "line-height": "normal",
-                "padding": "10px 15px",
-                "border-bottom": "1px solid #ccc"
+                color: '#1580b0',
+                'font-size': '20px',
+                'font-weight': '600',
+                'line-height': 'normal',
+                padding: '10px 15px',
+                'border-bottom': '1px solid #ccc'
             });
             $el.find('form').css({
-                "padding": "15px"
+                padding: '15px'
             });
             $el.find('form table.compact td').css({
-                "vertical-align": "middle",
-                "padding": "4px 8px"
+                'vertical-align': 'middle',
+                padding: '4px 8px'
             });
             $el.find('form label').css({
-                "display": "block",
-                "font-size": "14px",
-                "margin": 0,
-                "cursor": "default"
+                display: 'block',
+                'font-size': '14px',
+                margin: 0,
+                cursor: 'default'
             });
             $el.find('form #minutes_label').css({
-                "display": "inline-block"
+                display: 'inline-block'
             });
             $el.find('form input[type="text"]').css({
-                "height": "26px",
-                "padding": "1px 8px 2px",
-                "font-size": "14px"
+                height: '26px',
+                padding: '1px 8px 2px',
+                'font-size': '14px'
             });
             $el.find('form input[type="submit"]').css({
-                "margin-top": "10px",
-                "padding": "2px 32px"
+                'margin-top': '10px',
+                padding: '2px 32px'
             });
             $el.find('.error-message').css({
-                "color": "#ff0000",
-                "line-height": "normal",
-                "font-size": "14px"
+                color: '#ff0000',
+                'line-height': 'normal',
+                'font-size': '14px'
             });
             $el.find('.error-response').css({
-                "color": "#ff0000",
-                "line-height": "normal",
-                "font-size": "14px",
-                "padding": "0px 10px 5px 7px"
+                color: '#ff0000',
+                'line-height': 'normal',
+                'font-size': '14px',
+                padding: '0px 10px 5px 7px'
             });
-             $el.find('form select').css({
-                "padding": "2px 0px 2px 2px",
-                "font-size": "16px"
+            $el.find('form select').css({
+                padding: '2px 0px 2px 2px',
+                'font-size': '16px'
             });
         },
-        getCurrentFormValues: function () {
+        getCurrentFormValues: function() {
             return {
-                proctored_exam: $("select#proctored_exam").val(),
-                allowance_type: $("select#allowance_type").val(),
-                allowance_value: $("#allowance_value").val(),
-                user_info: $("#user_info").val()
+                proctored_exam: $('select#proctored_exam').val(),
+                allowance_type: $('select#allowance_type').val(),
+                allowance_value: $('#allowance_value').val(),
+                user_info: $('#user_info').val()
             };
         },
-        hideError: function (view, attr, selector) {
+        hideError: function(view, attr, selector) {
             var $element = view.$form[attr];
 
-            $element.removeClass("error");
-            $element.parent().find(".error-message").empty();
+            $element.removeClass('error');
+            $element.parent().find('.error-message').empty();
         },
-        showError: function (view, attr, errorMessage, selector) {
+        showError: function(view, attr, errorMessage, selector) {
             var $element = view.$form[attr];
 
-            $element.addClass("error");
-            var $errorMessage = $element.parent().find(".error-message");
+            $element.addClass('error');
+            var $errorMessage = $element.parent().find('.error-message');
             if ($errorMessage.length == 0) {
                 $errorMessage = $("<div class='error-message'></div>");
                 $element.parent().append($errorMessage);
@@ -117,21 +117,20 @@ var edx = edx || {};
             $errorMessage.empty().append(errorMessage);
             this.updateCss();
         },
-        addAllowance: function (event) {
+        addAllowance: function(event) {
             event.preventDefault();
-            var error_response = $('.error-response');
-            error_response.html();
+            var $error_response = $('.error-response');
+            $error_response.html();
             var values = this.getCurrentFormValues();
             var formHasErrors = false;
 
 
             var self = this;
             $.each(values, function(key, value) {
-                if (value==="") {
+                if (value === '') {
                     formHasErrors = true;
-                    self.showError(self, key, gettext("Required field"));
-                }
-                else {
+                    self.showError(self, key, gettext('Required field'));
+                } else {
                     self.hideError(self, key);
                 }
             });
@@ -139,44 +138,40 @@ var edx = edx || {};
             if (!formHasErrors) {
                 self.model.fetch({
                     headers: {
-                        "X-CSRFToken": self.proctored_exam_allowance_view.getCSRFToken()
+                        'X-CSRFToken': self.proctored_exam_allowance_view.getCSRFToken()
                     },
                     type: 'PUT',
                     data: {
-                        'exam_id': values.proctored_exam,
-                        'user_info': values.user_info,
-                        'key': values.allowance_type,
-                        'value': values.allowance_value
+                        exam_id: values.proctored_exam,
+                        user_info: values.user_info,
+                        key: values.allowance_type,
+                        value: values.allowance_value
                     },
-                    success: function () {
+                    success: function() {
                         // fetch the allowances again.
-                        error_response.html();
+                        $error_response.html();
                         self.proctored_exam_allowance_view.collection.url = self.proctored_exam_allowance_view.initial_url + self.course_id + '/allowance';
                         self.proctored_exam_allowance_view.hydrate();
                         self.hideModal();
                     },
                     error: function(self, response, options) {
                         var data = $.parseJSON(response.responseText);
-                        error_response.html(gettext(data.detail));
+                        $error_response.html(gettext(data.detail));
                     }
                 });
             }
         },
-        selectExamAtIndex: function (index) {
+        selectExamAtIndex: function(index) {
             var selectedExam = this.proctored_exams[index];
 
             if (selectedExam.is_proctored) {
                 // Selected Exam is a Proctored or Practice-Proctored exam.
-                if (selectedExam.is_practice_exam)
-                    $('#exam_type_label').text(gettext('Practice Exam'));
-                else
-                    $('#exam_type_label').text(gettext('Proctored Exam'));
+                if (selectedExam.is_practice_exam) { $('#exam_type_label').text(gettext('Practice Exam')); } else { $('#exam_type_label').text(gettext('Proctored Exam')); }
 
                 // In case of Proctored Exams, we hide the Additional Time label and show the Allowance Types Select
                 $('#additional_time_label').hide();
                 $('select#allowance_type').val('additional_time_granted').show();
-            }
-            else {
+            } else {
                 // Selected Exam is a Timed Exam.
                 $('#exam_type_label').text(gettext('Timed Exam'));
 
@@ -188,34 +183,33 @@ var edx = edx || {};
             }
             this.updateAllowanceLabels('additional_time_granted');
         },
-        selectExam: function (event) {
+        selectExam: function(event) {
             this.selectExamAtIndex($('#proctored_exam')[0].selectedIndex);
         },
-        selectAllowance: function (event) {
+        selectAllowance: function(event) {
             this.updateAllowanceLabels($('#allowance_type').val());
         },
-        updateAllowanceLabels: function (selectedAllowanceType) {
+        updateAllowanceLabels: function(selectedAllowanceType) {
             if (selectedAllowanceType == 'additional_time_granted') {
                 $('#minutes_label').show();
                 $('#allowance_value_label').text(gettext('Additional Time'));
-            }
-            else {
+            } else {
                 $('#minutes_label').hide();
                 $('#allowance_value_label').text(gettext('Value'));
             }
         },
 
-        render: function () {
+        render: function() {
             $(this.el).html(this.template({
                 proctored_exams: this.proctored_exams,
                 allowance_types: this.allowance_types
             }));
 
             this.$form = {
-                proctored_exam: this.$("select#proctored_exam"),
-                allowance_type: this.$("select#allowance_type"),
-                allowance_value: this.$("#allowance_value"),
-                user_info: this.$("#user_info")
+                proctored_exam: this.$('select#proctored_exam'),
+                allowance_type: this.$('select#allowance_type'),
+                allowance_value: this.$('#allowance_value'),
+                user_info: this.$('#user_info')
             };
             return this;
         }

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
@@ -1,14 +1,13 @@
 var edx = edx || {};
 
-(function (Backbone, $, _) {
+(function(Backbone, $, _) {
     'use strict';
 
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
 
     edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView = Backbone.View.extend({
-        initialize: function () {
-
+        initialize: function() {
             this.allowance_types = [
                 ['additional_time_granted', gettext('Additional Time (minutes)')],
                 ['review_policy_exception', gettext('Review Policy Exception')]
@@ -33,13 +32,12 @@ var edx = edx || {};
 
             this.proctoredExamCollection.url = this.proctoredExamCollection.url + this.course_id;
             this.collection.url = this.initial_url + this.course_id + '/allowance';
-
         },
         events: {
             'click #add-allowance': 'showAddModal',
             'click .remove_allowance': 'removeAllowance'
         },
-        getCSRFToken: function () {
+        getCSRFToken: function() {
             var cookieValue = null;
             var name = 'csrftoken';
             if (document.cookie && document.cookie != '') {
@@ -55,25 +53,25 @@ var edx = edx || {};
             }
             return cookieValue;
         },
-        removeAllowance: function (event) {
-            var element = $(event.currentTarget);
-            var userID = element.data('user-id');
-            var examID = element.data('exam-id');
-            var key = element.data('key-name');
+        removeAllowance: function(event) {
+            var $element = $(event.currentTarget);
+            var userID = $element.data('user-id');
+            var examID = $element.data('exam-id');
+            var key = $element.data('key-name');
             var self = this;
             self.collection.url = this.allowance_url;
             self.collection.fetch(
                 {
                     headers: {
-                        "X-CSRFToken": this.getCSRFToken()
+                        'X-CSRFToken': this.getCSRFToken()
                     },
                     type: 'DELETE',
                     data: {
-                        'exam_id': examID,
-                        'user_id': userID,
-                        'key': key
+                        exam_id: examID,
+                        user_id: userID,
+                        key: key
                     },
-                    success: function () {
+                    success: function() {
                         // fetch the allowances again.
                         self.collection.url = self.initial_url + self.course_id + '/allowance';
                         self.hydrate();
@@ -88,28 +86,28 @@ var edx = edx || {};
          See setup_instructor_dashboard_sections() in
          instructor_dashboard.coffee (in edx-platform)
          */
-        constructor: function (section) {
+        constructor: function(section) {
             /* the Instructor Dashboard javascript expects this to be set up */
             $(section).data('wrapper', this);
 
             this.initialize({});
         },
-        onClickTitle: function () {
+        onClickTitle: function() {
             // called when this is selected in the instructor dashboard
-            return;
+
         },
-        loadTemplateData: function () {
+        loadTemplateData: function() {
             var self = this;
-            $.ajax({url: self.template_url, dataType: "html"})
-                .error(function (jqXHR, textStatus, errorThrown) {
+            $.ajax({url: self.template_url, dataType: 'html'})
+                .error(function(jqXHR, textStatus, errorThrown) {
 
                 })
-                .done(function (template_data) {
+                .done(function(template_data) {
                     self.template = _.template(template_data);
                     self.hydrate();
                 });
         },
-        hydrate: function () {
+        hydrate: function() {
             /* This function will load the bound collection */
 
             /* add and remove a class when we do the initial loading */
@@ -117,21 +115,21 @@ var edx = edx || {};
             /* loading, like a spinner */
             var self = this;
             self.collection.fetch({
-                success: function () {
+                success: function() {
                     self.render();
                 }
             });
         },
-        collectionChanged: function () {
+        collectionChanged: function() {
             this.hydrate();
         },
-        render: function () {
+        render: function() {
             if (this.template !== null) {
                 var self = this;
-                this.collection.each(function(item){
+                this.collection.each(function(item) {
                     var key = item.get('key');
-                    var i
-                    for (i=0; i<self.allowance_types.length; i++) {
+                    var i;
+                    for (i = 0; i < self.allowance_types.length; i++) {
                         if (key === self.allowance_types[i][0]) {
                             item.set('key_display_name', self.allowance_types[i][1]);
                             break;
@@ -145,10 +143,10 @@ var edx = edx || {};
                 this.$el.html(html);
             }
         },
-        showAddModal: function (event) {
+        showAddModal: function(event) {
             var self = this;
             self.proctoredExamCollection.fetch({
-                success: function () {
+                success: function() {
                     var add_allowance_view = new edx.instructor_dashboard.proctoring.AddAllowanceView({
                         course_id: self.course_id,
                         proctored_exams: self.proctoredExamCollection.toJSON(),

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_allowance_view.js
@@ -1,4 +1,4 @@
-var edx = edx || {};
+edx = edx || {};
 
 (function(Backbone, $, _) {
     'use strict';
@@ -38,14 +38,17 @@ var edx = edx || {};
             'click .remove_allowance': 'removeAllowance'
         },
         getCSRFToken: function() {
-            var cookieValue = null;
-            var name = 'csrftoken';
-            if (document.cookie && document.cookie != '') {
-                var cookies = document.cookie.split(';');
-                for (var i = 0; i < cookies.length; i++) {
-                    var cookie = jQuery.trim(cookies[i]);
+            var cookieValue = null,
+                cookie,
+                cookies,
+                name = 'csrftoken',
+                i;
+            if (document.cookie && document.cookie !== '') {
+                cookies = document.cookie.split(';');
+                for (i = 0; i < cookies.length; i += 1) {
+                    cookie = jQuery.trim(cookies[i]);
                     // Does this cookie string begin with the name we want?
-                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
                         cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
                         break;
                     }
@@ -99,11 +102,11 @@ var edx = edx || {};
         loadTemplateData: function() {
             var self = this;
             $.ajax({url: self.template_url, dataType: 'html'})
-                .error(function(jqXHR, textStatus, errorThrown) {
+                .error(function() {
 
                 })
-                .done(function(template_data) {
-                    self.template = _.template(template_data);
+                .done(function(templateData) {
+                    self.template = _.template(templateData);
                     self.hydrate();
                 });
         },
@@ -124,12 +127,14 @@ var edx = edx || {};
             this.hydrate();
         },
         render: function() {
+            var html,
+                self;
             if (this.template !== null) {
-                var self = this;
+                self = this;
                 this.collection.each(function(item) {
                     var key = item.get('key');
                     var i;
-                    for (i = 0; i < self.allowance_types.length; i++) {
+                    for (i = 0; i < self.allowance_types.length; i += 1) {
                         if (key === self.allowance_types[i][0]) {
                             item.set('key_display_name', self.allowance_types[i][1]);
                             break;
@@ -139,7 +144,7 @@ var edx = edx || {};
                         item.set('key_display_name', key);
                     }
                 });
-                var html = this.template({proctored_exam_allowances: this.collection.toJSON()});
+                html = this.template({proctored_exam_allowances: this.collection.toJSON()});
                 this.$el.html(html);
             }
         },
@@ -147,7 +152,8 @@ var edx = edx || {};
             var self = this;
             self.proctoredExamCollection.fetch({
                 success: function() {
-                    var add_allowance_view = new edx.instructor_dashboard.proctoring.AddAllowanceView({
+                    // eslint-disable-next-line no-new
+                    new edx.instructor_dashboard.proctoring.AddAllowanceView({
                         course_id: self.course_id,
                         proctored_exams: self.proctoredExamCollection.toJSON(),
                         proctored_exam_allowance_view: self,
@@ -159,5 +165,6 @@ var edx = edx || {};
             event.preventDefault();
         }
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView = edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView =
+      edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView;
 }).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
@@ -1,6 +1,6 @@
 var edx = edx || {};
 
-(function (Backbone, $, _, gettext) {
+(function(Backbone, $, _, gettext) {
     'use strict';
 
     edx.instructor_dashboard = edx.instructor_dashboard || {};
@@ -24,23 +24,20 @@ var edx = edx || {};
         getDateFormat: function(date) {
             if (date) {
                 return new Date(date).toString('MMM dd, yyyy h:mmtt');
-            }
-            else {
+            } else {
                 return '---';
             }
-
         },
         getExamAttemptStatus: function(status) {
             if (status in examStatusReadableFormat) {
-                return examStatusReadableFormat[status]
-            }
-            else {
-                return status
+                return examStatusReadableFormat[status];
+            } else {
+                return status;
             }
         }
     };
     edx.instructor_dashboard.proctoring.ProctoredExamAttemptView = Backbone.View.extend({
-        initialize: function (options) {
+        initialize: function(options) {
             this.setElement($('.student-proctored-exam-container'));
             this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptCollection();
             this.tempate_url = '/static/proctoring/templates/student-proctored-exam-attempts.underscore';
@@ -52,7 +49,7 @@ var edx = edx || {};
             this.attempt_url = this.model.url;
             this.collection.url = this.initial_url + this.course_id;
             this.inSearchMode = false;
-            this.searchText = "";
+            this.searchText = '';
 
             /* re-render if the model changes */
             this.listenTo(this.collection, 'change', this.collectionChanged);
@@ -61,17 +58,17 @@ var edx = edx || {};
             this.loadTemplateData();
         },
         events: {
-            "click .remove-attempt": "onRemoveAttempt",
+            'click .remove-attempt': 'onRemoveAttempt',
             'click li > a.target-link': 'getPaginatedAttempts',
             'click .search-attempts > span.search': 'searchAttempts',
             'click .search-attempts > span.clear-search': 'clearSearch'
         },
         searchAttempts: function(event) {
             var searchText = $('#search_attempt_id').val();
-            if (searchText !== "") {
+            if (searchText !== '') {
                 this.inSearchMode = true;
                 this.searchText = searchText;
-                this.collection.url = this.initial_url + this.course_id + "/search/" + searchText;
+                this.collection.url = this.initial_url + this.course_id + '/search/' + searchText;
                 this.hydrate();
                 event.stopPropagation();
                 event.preventDefault();
@@ -79,20 +76,20 @@ var edx = edx || {};
         },
         clearSearch: function(event) {
             this.inSearchMode = false;
-            this.searchText = "";
+            this.searchText = '';
             this.collection.url = this.initial_url + this.course_id;
             this.hydrate();
             event.stopPropagation();
             event.preventDefault();
         },
         getPaginatedAttempts: function(event) {
-            var target = $(event.currentTarget);
-            this.collection.url = target.data('target-url');
+            var $target = $(event.currentTarget);
+            this.collection.url = $target.data('target-url');
             this.hydrate();
             event.stopPropagation();
             event.preventDefault();
         },
-        getCSRFToken: function () {
+        getCSRFToken: function() {
             var cookieValue = null;
             var name = 'csrftoken';
             if (document.cookie && document.cookie != '') {
@@ -108,18 +105,18 @@ var edx = edx || {};
             }
             return cookieValue;
         },
-        loadTemplateData: function () {
+        loadTemplateData: function() {
             var self = this;
-            $.ajax({url: self.tempate_url, dataType: "html"})
-                .error(function (jqXHR, textStatus, errorThrown) {
+            $.ajax({url: self.tempate_url, dataType: 'html'})
+                .error(function(jqXHR, textStatus, errorThrown) {
 
                 })
-                .done(function (template_data) {
+                .done(function(template_data) {
                     self.template = _.template(template_data);
                     self.hydrate();
                 });
         },
-        hydrate: function () {
+        hydrate: function() {
             /* This function will load the bound collection */
 
             /* add and remove a class when we do the initial loading */
@@ -127,17 +124,16 @@ var edx = edx || {};
             /* loading, like a spinner */
             var self = this;
             self.collection.fetch({
-                success: function () {
+                success: function() {
                     self.render();
                 }
             });
         },
-        collectionChanged: function () {
+        collectionChanged: function() {
             this.hydrate();
         },
-        render: function () {
+        render: function() {
             if (this.template !== null) {
-
                 var data_json = this.collection.toJSON()[0];
 
                 // calculate which pages ranges to display
@@ -178,9 +174,9 @@ var edx = edx || {};
                 _.extend(data, viewHelper);
                 var html = this.template(data);
                 this.$el.html(html);
-           }
+            }
         },
-        onRemoveAttempt: function (event) {
+        onRemoveAttempt: function(event) {
             event.preventDefault();
 
             // confirm the user's intent
@@ -189,16 +185,16 @@ var edx = edx || {};
             }
             $('body').css('cursor', 'wait');
             var $target = $(event.currentTarget);
-            var attemptId = $target.data("attemptId");
+            var attemptId = $target.data('attemptId');
 
             var self = this;
             self.model.url = this.attempt_url + attemptId;
-            self.model.fetch( {
+            self.model.fetch({
                 headers: {
-                    "X-CSRFToken": this.getCSRFToken()
+                    'X-CSRFToken': this.getCSRFToken()
                 },
                 type: 'DELETE',
-                success: function () {
+                success: function() {
                     // fetch the attempts again.
                     self.hydrate();
                     $('body').css('cursor', 'auto');

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
@@ -1,4 +1,4 @@
-var edx = edx || {};
+edx = edx || {};
 
 (function(Backbone, $, _) {
     'use strict';
@@ -6,7 +6,8 @@ var edx = edx || {};
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
     edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = Backbone.View.extend({
-        initialize: function(options) {
+        initialize: function() {
+            var self;
             this.setElement($('.student-review-dashboard-container'));
             this.tempate_url = '/static/proctoring/templates/dashboard.underscore';
             this.iframeHTML = null;
@@ -14,7 +15,7 @@ var edx = edx || {};
             this.context = {
                 dashboardURL: '/api/edx_proctoring/v1/instructor/' + this.$el.data('course-id')
             };
-            var self = this;
+            self = this;
 
             $('#proctoring-accordion').on('accordionactivate', function(event, ui) {
                 self.render(ui);
@@ -25,11 +26,11 @@ var edx = edx || {};
         loadTemplateData: function() {
             var self = this;
             $.ajax({url: self.tempate_url, dataType: 'html'})
-                .error(function(jqXHR, textStatus, errorThrown) {
+                .error(function() {
 
                 })
-                .done(function(template_html) {
-                    self.iframeHTML = _.template(template_html)(self.context);
+                .done(function(templateHtml) {
+                    self.iframeHTML = _.template(templateHtml)(self.context);
                 });
         },
         render: function(ui) {
@@ -39,5 +40,6 @@ var edx = edx || {};
             }
         }
     });
-    this.edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = edx.instructor_dashboard.proctoring.ProctoredExamDashboardView;
+    this.edx.instructor_dashboard.proctoring.ProctoredExamDashboardView =
+        edx.instructor_dashboard.proctoring.ProctoredExamDashboardView;
 }).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
@@ -1,12 +1,12 @@
 var edx = edx || {};
 
-(function (Backbone, $, _) {
+(function(Backbone, $, _) {
     'use strict';
 
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
     edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = Backbone.View.extend({
-        initialize: function (options) {
+        initialize: function(options) {
             this.setElement($('.student-review-dashboard-container'));
             this.tempate_url = '/static/proctoring/templates/dashboard.underscore';
             this.iframeHTML = null;
@@ -22,22 +22,22 @@ var edx = edx || {};
             /* Load the static template for rendering. */
             this.loadTemplateData();
         },
-        loadTemplateData: function () {
+        loadTemplateData: function() {
             var self = this;
-            $.ajax({url: self.tempate_url, dataType: "html"})
-                .error(function (jqXHR, textStatus, errorThrown) {
+            $.ajax({url: self.tempate_url, dataType: 'html'})
+                .error(function(jqXHR, textStatus, errorThrown) {
 
                 })
-                .done(function (template_html) {
+                .done(function(template_html) {
                     self.iframeHTML = _.template(template_html)(self.context);
                 });
         },
-        render: function (ui) {
+        render: function(ui) {
             if (ui.newPanel.eq(this.$el) && this.doRender && this.iframeHTML) {
                 this.$el.html(this.iframeHTML);
                 this.doRender = false;
             }
-        },
+        }
     });
     this.edx.instructor_dashboard.proctoring.ProctoredExamDashboardView = edx.instructor_dashboard.proctoring.ProctoredExamDashboardView;
 }).call(this, Backbone, $, _);

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -157,7 +157,8 @@ edx = edx || {};
                 self.timerTick % pingInterval === pingInterval / 2 &&
                 edx.courseware.proctored_exam.configuredWorkerURL
             ) {
-                edx.courseware.proctored_exam.pingApplication(pingInterval).catch(self.endExamForFailureState.bind(self));
+                edx.courseware.proctored_exam.pingApplication(pingInterval)
+                    .catch(self.endExamForFailureState.bind(self));
             }
             if (self.timerTick % self.poll_interval === 0) {
                 url = self.model.url + '/' + self.model.get('attempt_id');

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -64,6 +64,7 @@ edx = edx || {};
             }
         },
         modelChanged: function() {
+            var desktopApplicationJsUrl;
             // if we are a proctored exam, then we need to alert user that he/she
             // should not be navigating around the courseware
             var takingAsProctored = this.model.get('taking_as_proctored');
@@ -80,7 +81,7 @@ edx = edx || {};
                 // remove callback on unload event
                 $(window).unbind('beforeunload', this.unloadMessage);
             }
-            var desktopApplicationJsUrl = this.model.get('desktop_application_js_url');
+            desktopApplicationJsUrl = this.model.get('desktop_application_js_url');
             if (desktopApplicationJsUrl && !edx.courseware.proctored_exam.configuredWorkerURL) {
                 edx.courseware.proctored_exam.configuredWorkerURL = desktopApplicationJsUrl;
             }

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -1,14 +1,14 @@
 var edx = edx || {};
 
-(function (Backbone, $, _, gettext) {
+(function(Backbone, $, _, gettext) {
     'use strict';
 
     edx.courseware = edx.courseware || {};
     edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
 
     edx.courseware.proctored_exam.ProctoredExamView = Backbone.View.extend({
-        initialize: function (options) {
-            _.bindAll(this, "detectScroll");
+        initialize: function(options) {
+            _.bindAll(this, 'detectScroll');
             this.$el = options.el;
             this.timerBarTopPosition = this.$el.position().top;
             this.courseNavBarMarginTop = this.timerBarTopPosition - 3;
@@ -54,16 +54,14 @@ var edx = edx || {};
         },
         detectScroll: function(event) {
             if ($(event.currentTarget).scrollTop() > this.timerBarTopPosition) {
-                $(".proctored_exam_status").addClass('is-fixed');
-                $(".wrapper-course-material").css('margin-top', this.courseNavBarMarginTop + 'px');
+                $('.proctored_exam_status').addClass('is-fixed');
+                $('.wrapper-course-material').css('margin-top', this.courseNavBarMarginTop + 'px');
+            } else {
+                $('.proctored_exam_status').removeClass('is-fixed');
+                $('.wrapper-course-material').css('margin-top', '0');
             }
-            else {
-                $(".proctored_exam_status").removeClass('is-fixed');
-                $(".wrapper-course-material").css('margin-top', '0');
-            }
-
         },
-        modelChanged: function () {
+        modelChanged: function() {
             // if we are a proctored exam, then we need to alert user that he/she
             // should not be navigating around the courseware
             var taking_as_proctored = this.model.get('taking_as_proctored');
@@ -72,7 +70,7 @@ var edx = edx || {};
             var status = this.model.get('attempt_status');
             var in_courseware = document.location.href.indexOf('/courses/' + this.model.get('course_id') + '/courseware/') > -1;
 
-            if ( taking_as_proctored && time_left && in_courseware && status !== 'started'){
+            if (taking_as_proctored && time_left && in_courseware && status !== 'started') {
                 $(window).bind('beforeunload', this.unloadMessage);
             } else {
                 // remove callback on unload event
@@ -80,12 +78,12 @@ var edx = edx || {};
             }
             var desktopApplicationJsUrl = this.model.get('desktop_application_js_url');
             if (desktopApplicationJsUrl && !edx.courseware.proctored_exam.configuredWorkerURL) {
-              edx.courseware.proctored_exam.configuredWorkerURL = desktopApplicationJsUrl;
+                edx.courseware.proctored_exam.configuredWorkerURL = desktopApplicationJsUrl;
             }
 
             this.render();
         },
-        render: function () {
+        render: function() {
             if (this.template !== null) {
                 if (
                     this.model.get('in_timed_exam') &&
@@ -110,41 +108,40 @@ var edx = edx || {};
 
                     // Bind a click handler to the exam controls
                     var self = this;
-                    $('.exam-button-turn-in-exam').click(function(){
+                    $('.exam-button-turn-in-exam').click(function() {
                         $(window).unbind('beforeunload', self.unloadMessage);
 
                         $.ajax({
                             url: '/api/edx_proctoring/v1/proctored_exam/attempt/' + self.model.get('attempt_id'),
                             type: 'PUT',
                             data: {
-                              action: 'stop'
+                                action: 'stop'
                             },
                             success: function() {
-                              // change the location of the page to the active exam page
-                              // which will reflect the new state of the attempt
-                              location.href = self.model.get('exam_url_path');
+                                // change the location of the page to the active exam page
+                                // which will reflect the new state of the attempt
+                                location.href = self.model.get('exam_url_path');
                             }
                         });
                     });
-                }
-                else {
+                } else {
                     // remove callback on scroll event
                     $(window).unbind('scroll', this.detectScroll);
                 }
             }
             return this;
         },
-        reloadPage: function () {
-          location.reload();
+        reloadPage: function() {
+            location.reload();
         },
-        unloadMessage: function  () {
-            return gettext("Are you sure you want to leave this page? \n" +
-                "To pass your proctored exam you must also pass the online proctoring session review.");
+        unloadMessage: function() {
+            return gettext('Are you sure you want to leave this page? \n' +
+                'To pass your proctored exam you must also pass the online proctoring session review.');
         },
-        updateRemainingTime: function (self) {
+        updateRemainingTime: function(self) {
             var pingInterval = self.model.get('ping_interval');
-            self.timerTick ++;
-            self.secondsLeft --;
+            self.timerTick++;
+            self.secondsLeft--;
             if (
                 self.timerTick % pingInterval === pingInterval / 2 &&
                 edx.courseware.proctored_exam.configuredWorkerURL
@@ -161,8 +158,7 @@ var edx = edx || {};
                         clearInterval(self.timerId); // stop the timer once the time finishes.
                         $(window).unbind('beforeunload', self.unloadMessage);
                         location.reload();
-                    }
-                    else {
+                    } else {
                         self.secondsLeft = data.time_remaining_seconds;
                         self.accessibility_time_string = data.accessibility_time_string;
                     }
@@ -172,8 +168,8 @@ var edx = edx || {};
             var newState = self.model.getRemainingTimeState(self.secondsLeft);
 
             if (newState !== null && !self.$el.find('div.exam-timer').hasClass(newState)) {
-                self.$el.find('div.exam-timer').removeClass("warning critical");
-                self.$el.find('div.exam-timer').addClass("low-time " + newState);
+                self.$el.find('div.exam-timer').removeClass('warning critical');
+                self.$el.find('div.exam-timer').addClass('low-time ' + newState);
                 // refresh accessibility string
                 self.$el.find('.timer-announce').html(self.accessibility_time_string);
             }
@@ -186,7 +182,7 @@ var edx = edx || {};
                 self.reloadPage();
             }
         },
-        endExamForFailureState: function () {
+        endExamForFailureState: function() {
             var self = this;
             return $.ajax({
                 data: {
@@ -199,18 +195,18 @@ var edx = edx || {};
                     self.reloadPage();
                 }
             });
-      },
-        toggleTimerVisibility: function (event) {
-            var button = $(event.currentTarget);
-            var icon = button.find('i');
+        },
+        toggleTimerVisibility: function(event) {
+            var $button = $(event.currentTarget);
+            var icon = $button.find('i');
             var timer = this.$el.find('span#time_remaining_id b');
             if (timer.hasClass('timer-hidden')) {
                 timer.removeClass('timer-hidden');
-                button.attr('aria-pressed', 'false');
+                $button.attr('aria-pressed', 'false');
                 icon.removeClass('fa-eye').addClass('fa-eye-slash');
             } else {
                 timer.addClass('timer-hidden');
-                button.attr('aria-pressed', 'true');
+                $button.attr('aria-pressed', 'true');
                 icon.removeClass('fa-eye-slash').addClass('fa-eye');
             }
             event.stopPropagation();

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -1,4 +1,4 @@
-var edx = edx || {};
+edx = edx || {};
 
 (function(Backbone, $, _, gettext) {
     'use strict';
@@ -8,6 +8,8 @@ var edx = edx || {};
 
     edx.courseware.proctored_exam.ProctoredExamView = Backbone.View.extend({
         initialize: function(options) {
+            var controlsTemplateHtml,
+                templateHtml;
             _.bindAll(this, 'detectScroll');
             this.$el = options.el;
             this.timerBarTopPosition = this.$el.position().top;
@@ -27,16 +29,16 @@ var edx = edx || {};
             // get destroyed before onbeforeunload is called
             this.taking_as_proctored = false;
 
-            var template_html = $(this.templateId).text();
-            if (template_html !== null) {
+            templateHtml = $(this.templateId).text();
+            if (templateHtml !== null) {
                 /* don't assume this backbone view is running on a page with the underscore templates */
-                this.template = _.template(template_html);
+                this.template = _.template(templateHtml);
             }
 
-            var controls_template_html = $(this.examControlsTemplateId).text();
-            if (controls_template_html !== null) {
+            controlsTemplateHtml = $(this.examControlsTemplateId).text();
+            if (controlsTemplateHtml !== null) {
                 /* don't assume this backbone view is running on a page with the underscore templates */
-                this.controls_template = _.template(controls_template_html);
+                this.controls_template = _.template(controlsTemplateHtml);
             }
 
             /* re-render if the model changes */
@@ -64,13 +66,15 @@ var edx = edx || {};
         modelChanged: function() {
             // if we are a proctored exam, then we need to alert user that he/she
             // should not be navigating around the courseware
-            var taking_as_proctored = this.model.get('taking_as_proctored');
-            var time_left = this.model.get('time_remaining_seconds') > 0;
-            this.secondsLeft = this.model.get('time_remaining_seconds');
+            var takingAsProctored = this.model.get('taking_as_proctored');
+            var timeLeft = this.model.get('time_remaining_seconds') > 0;
             var status = this.model.get('attempt_status');
-            var in_courseware = document.location.href.indexOf('/courses/' + this.model.get('course_id') + '/courseware/') > -1;
+            var inCourseware = document.location.href.indexOf(
+                '/courses/' + this.model.get('course_id') + '/courseware/'
+            ) > -1;
+            this.secondsLeft = this.model.get('time_remaining_seconds');
 
-            if (taking_as_proctored && time_left && in_courseware && status !== 'started') {
+            if (takingAsProctored && timeLeft && inCourseware && status !== 'started') {
                 $(window).bind('beforeunload', this.unloadMessage);
             } else {
                 // remove callback on unload event
@@ -84,6 +88,8 @@ var edx = edx || {};
             this.render();
         },
         render: function() {
+            var html,
+                self;
             if (this.template !== null) {
                 if (
                     this.model.get('in_timed_exam') &&
@@ -93,7 +99,7 @@ var edx = edx || {};
                     // add callback on scroll event
                     $(window).bind('scroll', this.detectScroll);
 
-                    var html = this.template(this.model.toJSON());
+                    html = this.template(this.model.toJSON());
                     this.$el.html(html);
                     this.$el.show();
                     // only render the accesibility string the first time we render after
@@ -103,11 +109,11 @@ var edx = edx || {};
                         this.$el.find('.timer-announce').html(this.accessibility_time_string);
                         this.first_time_rendering = false;
                     }
-                    this.updateRemainingTime(this);
-                    this.timerId = setInterval(this.updateRemainingTime, 1000, this);
+                    this.updateRemainingTime();
+                    this.timerId = setInterval(this.updateRemainingTime.bind(this), 1000);
 
                     // Bind a click handler to the exam controls
-                    var self = this;
+                    self = this;
                     $('.exam-button-turn-in-exam').click(function() {
                         $(window).unbind('beforeunload', self.unloadMessage);
 
@@ -138,10 +144,14 @@ var edx = edx || {};
             return gettext('Are you sure you want to leave this page? \n' +
                 'To pass your proctored exam you must also pass the online proctoring session review.');
         },
-        updateRemainingTime: function(self) {
+        updateRemainingTime: function() {
+            var newState,
+                url,
+                queryString;
+            var self = this;
             var pingInterval = self.model.get('ping_interval');
-            self.timerTick++;
-            self.secondsLeft--;
+            self.timerTick += 1;
+            self.secondsLeft -= 1;
             if (
                 self.timerTick % pingInterval === pingInterval / 2 &&
                 edx.courseware.proctored_exam.configuredWorkerURL
@@ -149,8 +159,8 @@ var edx = edx || {};
                 edx.courseware.proctored_exam.pingApplication(pingInterval).catch(self.endExamForFailureState.bind(self));
             }
             if (self.timerTick % self.poll_interval === 0) {
-                var url = self.model.url + '/' + self.model.get('attempt_id');
-                var queryString = '?sourceid=in_exam&proctored=' + self.model.get('taking_as_proctored');
+                url = self.model.url + '/' + self.model.get('attempt_id');
+                queryString = '?sourceid=in_exam&proctored=' + self.model.get('taking_as_proctored');
                 $.ajax(url + queryString).success(function(data) {
                     if (data.status === 'error') {
                         // The proctoring session is in error state
@@ -164,8 +174,7 @@ var edx = edx || {};
                     }
                 });
             }
-            var oldState = self.$el.find('div.exam-timer').attr('class');
-            var newState = self.model.getRemainingTimeState(self.secondsLeft);
+            newState = self.model.getRemainingTimeState(self.secondsLeft);
 
             if (newState !== null && !self.$el.find('div.exam-timer').hasClass(newState)) {
                 self.$el.find('div.exam-timer').removeClass('warning critical');

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_add_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_add_allowance_spec.js
@@ -1,20 +1,20 @@
-describe('ProctoredExamAddAllowanceView', function () {
+describe('ProctoredExamAddAllowanceView', function() {
     var html = '';
     var allowancesHtml = '';
     var errorAddingAllowance = {
-        detail: "Cannot find user"
+        detail: 'Cannot find user'
     };
     var expectedProctoredAllowanceJson = [
         {
-            created: "2015-08-10T09:15:45Z",
+            created: '2015-08-10T09:15:45Z',
             id: 1,
-            modified: "2015-08-10T09:15:45Z",
-            key: "additional_time_granted",
-            value: "1",
+            modified: '2015-08-10T09:15:45Z',
+            key: 'additional_time_granted',
+            value: '1',
             proctored_exam: {
-                content_id: "i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c",
-                course_id: "edX/DemoX/Demo_Course",
-                exam_name: "Test Exam",
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Test Exam',
                 external_id: null,
                 id: 6,
                 is_active: true,
@@ -31,15 +31,15 @@ describe('ProctoredExamAddAllowanceView', function () {
 
     var expectedTimedAllowanceJson = [
         {
-            created: "2015-08-10T09:15:45Z",
+            created: '2015-08-10T09:15:45Z',
             id: 1,
-            modified: "2015-08-10T09:15:45Z",
-            key: "additional_time_granted",
-            value: "1",
+            modified: '2015-08-10T09:15:45Z',
+            key: 'additional_time_granted',
+            value: '1',
             proctored_exam: {
-                content_id: "i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c",
-                course_id: "edX/DemoX/Demo_Course",
-                exam_name: "Test Exam",
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Test Exam',
                 external_id: null,
                 id: 6,
                 is_active: true,
@@ -56,19 +56,19 @@ describe('ProctoredExamAddAllowanceView', function () {
 
     var proctoredExamJson = [
         {
-            exam_name: "Midterm Exam",
+            exam_name: 'Midterm Exam',
             is_proctored: true,
             is_practice: false,
             id: 5
         },
         {
-            exam_name: "Final Exam",
+            exam_name: 'Final Exam',
             is_proctored: false,
             is_practice: false,
             id: 6
         },
         {
-            exam_name: "Test Exam",
+            exam_name: 'Test Exam',
             is_proctored: true,
             is_practice: true,
             id: 7
@@ -80,8 +80,7 @@ describe('ProctoredExamAddAllowanceView', function () {
         ['review_policy_exception', gettext('Review Policy Exception')]
     ];
 
-    beforeEach(function () {
-
+    beforeEach(function() {
         // We have converted the edx_proctoring/static/proctoring/templates/add-new-allowance.underscore template
         // from http://www.howtocreate.co.uk/tutorials/jsexamples/syntax/prepareInline.html
 
@@ -93,7 +92,7 @@ describe('ProctoredExamAddAllowanceView', function () {
             '<%- gettext("Add Allowance") %>' +
             '</a> </span> </span>' +
             '<% var is_allowances = proctored_exam_allowances.length !== 0 %>' +
-            '<% if (is_allowances) { %>'+
+            '<% if (is_allowances) { %>' +
             '<div class="wrapper-content wrapper"> <section class="content"> <table class="allowance-table">' +
             '<thead><tr class="allowance-headings">' +
             '<th class="exam-name">Exam Name</th>' +
@@ -136,17 +135,17 @@ describe('ProctoredExamAddAllowanceView', function () {
 
         setFixtures('<div class="special-allowance-container" data-course-id="test_course_id"></div>');
         // load the underscore template response before calling the proctored exam allowance view.
-        this.server.respondWith("GET", "/static/proctoring/templates/add-new-allowance.underscore",
+        this.server.respondWith('GET', '/static/proctoring/templates/add-new-allowance.underscore',
             [
                 200,
-                {"Content-Type": "text/html"},
+                {'Content-Type': 'text/html'},
                 html
             ]
         );
-        this.server.respondWith("GET", "/static/proctoring/templates/course_allowances.underscore",
+        this.server.respondWith('GET', '/static/proctoring/templates/course_allowances.underscore',
             [
                 200,
-                {"Content-Type": "text/html"},
+                {'Content-Type': 'text/html'},
                 allowancesHtml
             ]
         );
@@ -155,12 +154,12 @@ describe('ProctoredExamAddAllowanceView', function () {
     afterEach(function() {
         this.server.restore();
     });
-    it("should render the proctored exam add allowance view properly", function () {
+    it('should render the proctored exam add allowance view properly', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredAllowanceJson)
             ]
@@ -182,17 +181,17 @@ describe('ProctoredExamAddAllowanceView', function () {
         expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Test Exam');
         expect(add_allowance_view.$el.find('#exam_type_label')).toExist();
         $('#proctored_exam').val('5');
-        $('#proctored_exam').trigger( "change" );
+        $('#proctored_exam').trigger('change');
         expect(add_allowance_view.$el.find('#exam_type_label').html()).toContain('Proctored Exam');
     });
 
 
-    it("should render the timed exam add allowance view properly", function () {
+    it('should render the timed exam add allowance view properly', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedTimedAllowanceJson)
             ]
@@ -214,17 +213,17 @@ describe('ProctoredExamAddAllowanceView', function () {
         expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Test Exam');
         expect(add_allowance_view.$el.find('#exam_type_label')).toExist();
         $('#proctored_exam').val('6');
-        $('#proctored_exam').trigger( "change" );
+        $('#proctored_exam').trigger('change');
         expect(add_allowance_view.$el.find('#exam_type_label').html()).toContain('Timed Exam');
     });
 
 
-    it("should add the proctored exam allowance", function () {
+    it('should add the proctored exam allowance', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify([])
             ]
@@ -252,7 +251,7 @@ describe('ProctoredExamAddAllowanceView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify([])
             ]
@@ -263,22 +262,22 @@ describe('ProctoredExamAddAllowanceView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredAllowanceJson)
             ]
         );
 
-        //select the form values
+        // select the form values
 
         $('#proctored_exam').val('Test Exam');
         $('#allowance_type').val('additional_time_granted');
         $('#allowance_value').val('1');
-        $("#user_info").val('testuser1');
+        $('#user_info').val('testuser1');
 
         // trigger the add allowance event.
         var spyEvent = spyOnEvent('form', 'submit');
-        $('form').trigger( "submit" );
+        $('form').trigger('submit');
 
         // process the deleted allowance requests.
         this.server.respond();
@@ -289,12 +288,12 @@ describe('ProctoredExamAddAllowanceView', function () {
         expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Additional Time (minutes)');
         expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Test Exam');
     });
-    it("should send error when adding proctored exam allowance", function () {
+    it('should send error when adding proctored exam allowance', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify([])
             ]
@@ -322,7 +321,7 @@ describe('ProctoredExamAddAllowanceView', function () {
             [
                 400,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(errorAddingAllowance)
             ]
@@ -333,22 +332,22 @@ describe('ProctoredExamAddAllowanceView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredAllowanceJson)
             ]
         );
 
-        //select the form values
+        // select the form values
         // invalid user_info returns error
         $('#proctored_exam').val('Test Exam');
         $('#allowance_type').val('additional_time_granted');
         $('#allowance_value').val('2');
-        $("#user_info").val('testuser112321');
+        $('#user_info').val('testuser112321');
 
         // trigger the add allowance event.
         var spyEvent = spyOnEvent('form', 'submit');
-        $('form').trigger( "submit" );
+        $('form').trigger('submit');
 
         // process the deleted allowance requests.
         this.server.respond();
@@ -356,18 +355,17 @@ describe('ProctoredExamAddAllowanceView', function () {
 
         expect(add_allowance_view.$el.find('.error-response').html()).toContain('Cannot find user');
 
-        //select the form values
+        // select the form values
         // empty value returns error
         $('#proctored_exam').val('Test Exam');
         $('#allowance_type').val('Additional Time (minutes)');
         $('#allowance_value').val('');
-        $("#user_info").val('testuser1');
+        $('#user_info').val('testuser1');
 
         // trigger the add allowance event.
         var spyEvent = spyOnEvent('form', 'submit');
-        $('form').trigger( "submit" );
+        $('form').trigger('submit');
 
         expect(add_allowance_view.$el.find('.error-message').html()).toContain('Required field');
-
     });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_add_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_add_allowance_spec.js
@@ -131,9 +131,9 @@ describe('ProctoredExamAddAllowanceView', function() {
             '<%= proctored_exam_allowance.value %>' +
             '</td>' +
             '<td>' +
-            '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"' +
-            'data-key-name="<%= proctored_exam_allowance.key %>"' +
-            'data-user-id="<%= proctored_exam_allowance.user.id %>"' +
+            '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>" ' +
+            'data-key-name="<%= proctored_exam_allowance.key %>" ' +
+            'data-user-id="<%= proctored_exam_allowance.user.id %>" ' +
             'class="remove_allowance" href="#">[x]</a>' +
             '</td></tr>' +
             '<% }); %>' +

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_add_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_add_allowance_spec.js
@@ -1,4 +1,6 @@
 describe('ProctoredExamAddAllowanceView', function() {
+    'use strict';
+
     var html = '';
     var allowancesHtml = '';
     var errorAddingAllowance = {
@@ -84,6 +86,7 @@ describe('ProctoredExamAddAllowanceView', function() {
         // We have converted the edx_proctoring/static/proctoring/templates/add-new-allowance.underscore template
         // from http://www.howtocreate.co.uk/tutorials/jsexamples/syntax/prepareInline.html
 
+        // eslint-disable-next-line no-useless-escape, max-len
         html = '<div class=\'modal-header\'><%- gettext(\"Add a New Allowance\") %><\/div>\n<form>\n    <h3 class=\'error-response\'><h3>\n    <table class=\'compact\'>\n        <tr>\n            <td>\n                <label><%- gettext(\"Special Exam\") %><\/label>\n            <\/td>\n            <td>\n                <select id=\'proctored_exam\'>\n                    <% _.each(proctored_exams, function(proctored_exam){ %>\n                    <option value=\"<%= proctored_exam.id %>\">\n                    <%- interpolate(gettext(\' %(exam_display_name)s \'), { exam_display_name: proctored_exam.exam_name }, true) %>\n                    <\/option>\n                    <% }); %>\n                <\/select>\n            <\/td>\n        <\/tr>\n        <tr>\n            <td>\n                <label><%- gettext(\"Exam Type\") %><\/label>\n            <\/td>\n            <td>\n                <label id=\'exam_type_label\'>\n                    <%- gettext(\"Timed Exam\") %>\n                <\/label>\n            <\/td>\n        <\/tr>\n        <tr>\n            <td>\n                <label><%- gettext(\"Allowance Type\") %><\/label>\n            <\/td>\n            <td>\n                <select id=\"allowance_type\">\n                    <% _.each(allowance_types, function(allowance_type){ %>\n                    <option value=\"<%= allowance_type[0] %>\">\n                        <%= allowance_type[1] %>\n                    <\/option>\n                    <% }); %>\n                <\/select>\n\n                <label id=\'timed_exam_allowance_type\'>\n                    <%- gettext(\"Additional Time (minutes)\") %>\n                <\/label>\n            <\/td>\n        <\/tr>\n        <tr>\n            <td>\n                <label id=\'allowance_value_label\'><%- gettext(\"Value\") %><\/label>\n            <\/td>\n            <td>\n                <input type=\"text\" id=\"allowance_value\" \/>\n                <label id=\'timed_exam_mins_label\'><%- gettext(\"minutes\") %><\/label>\n            <\/td>\n        <\/tr>\n        <tr>\n            <td>\n                <label><%- gettext(\"Username or Email\") %><\/label>\n            <\/td>\n            <td>\n                <input type=\"text\" id=\"user_info\" \/>\n            <\/td>\n        <\/tr>\n        <tr>\n            <td><\/td>\n            <td>\n                <input id=\'addNewAllowance\' type=\'submit\' value=\'Save\' \/>\n            <\/td>\n        <\/tr>\n    <\/table>\n<\/form>\n';
 
         allowancesHtml = '<span class="tip">' +
@@ -106,11 +109,13 @@ describe('ProctoredExamAddAllowanceView', function() {
             '<% _.each(proctored_exam_allowances, function(proctored_exam_allowance){ %>' +
             '<tr class="allowance-items">' +
             '<td>' +
-            '<%- interpolate(gettext(" %(exam_display_name)s "), { exam_display_name: proctored_exam_allowance.proctored_exam.exam_name }, true) %>' +
+            '<%- interpolate(gettext(" %(exam_display_name)s "),' +
+            '{ exam_display_name: proctored_exam_allowance.proctored_exam.exam_name }, true) %>' +
             '</td>' +
             '<% if (proctored_exam_allowance.user){ %>' +
             '<td>' +
-            '<%- interpolate(gettext(" %(username)s "), { username: proctored_exam_allowance.user.username }, true) %>' +
+            '<%- interpolate(gettext(" %(username)s "),' +
+            '{ username: proctored_exam_allowance.user.username }, true) %>' +
             '</td>' +
             '<td>' +
             '<%- interpolate(gettext(" %(email)s "), { email: proctored_exam_allowance.user.email }, true) %>' +
@@ -119,13 +124,17 @@ describe('ProctoredExamAddAllowanceView', function() {
             '<td>N/A</td><td>N/A</td>' +
             '<% } %>' +
             '<td>' +
-            '<%- interpolate(gettext(" %(allowance_name)s "), { allowance_name: proctored_exam_allowance.key_display_name }, true) %>' +
+            '<%- interpolate(gettext(" %(allowance_name)s "),' +
+            '{ allowance_name: proctored_exam_allowance.key_display_name }, true) %>' +
             '</td>' +
             '<td>' +
             '<%= proctored_exam_allowance.value %>' +
             '</td>' +
             '<td>' +
-            '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>" data-key-name="<%= proctored_exam_allowance.key %>" data-user-id="<%= proctored_exam_allowance.user.id %>"class="remove_allowance" href="#">[x]</a>' +
+            '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"' +
+            'data-key-name="<%= proctored_exam_allowance.key %>"' +
+            'data-user-id="<%= proctored_exam_allowance.user.id %>"' +
+            'class="remove_allowance" href="#">[x]</a>' +
             '</td></tr>' +
             '<% }); %>' +
             '</tbody></table></section></div>' +
@@ -155,6 +164,7 @@ describe('ProctoredExamAddAllowanceView', function() {
         this.server.restore();
     });
     it('should render the proctored exam add allowance view properly', function() {
+        var addAllowanceView;
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
@@ -166,7 +176,7 @@ describe('ProctoredExamAddAllowanceView', function() {
         );
 
         this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-        var add_allowance_view = new edx.instructor_dashboard.proctoring.AddAllowanceView({
+        addAllowanceView = new edx.instructor_dashboard.proctoring.AddAllowanceView({
             course_id: 'test_course_id',
             proctored_exams: proctoredExamJson,
             proctored_exam_allowance_view: this.proctored_exam_allowance,
@@ -176,17 +186,18 @@ describe('ProctoredExamAddAllowanceView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Midterm Exam');
-        expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Final Exam');
-        expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Test Exam');
-        expect(add_allowance_view.$el.find('#exam_type_label')).toExist();
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Midterm Exam');
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Final Exam');
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Test Exam');
+        expect(addAllowanceView.$el.find('#exam_type_label')).toExist();
         $('#proctored_exam').val('5');
         $('#proctored_exam').trigger('change');
-        expect(add_allowance_view.$el.find('#exam_type_label').html()).toContain('Proctored Exam');
+        expect(addAllowanceView.$el.find('#exam_type_label').html()).toContain('Proctored Exam');
     });
 
 
     it('should render the timed exam add allowance view properly', function() {
+        var addAllowanceView;
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
@@ -198,7 +209,7 @@ describe('ProctoredExamAddAllowanceView', function() {
         );
 
         this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-        var add_allowance_view = new edx.instructor_dashboard.proctoring.AddAllowanceView({
+        addAllowanceView = new edx.instructor_dashboard.proctoring.AddAllowanceView({
             course_id: 'test_course_id',
             proctored_exams: proctoredExamJson,
             proctored_exam_allowance_view: this.proctored_exam_allowance,
@@ -208,13 +219,13 @@ describe('ProctoredExamAddAllowanceView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Midterm Exam');
-        expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Final Exam');
-        expect(add_allowance_view.$el.find('#proctored_exam').html()).toContain('Test Exam');
-        expect(add_allowance_view.$el.find('#exam_type_label')).toExist();
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Midterm Exam');
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Final Exam');
+        expect(addAllowanceView.$el.find('#proctored_exam').html()).toContain('Test Exam');
+        expect(addAllowanceView.$el.find('#exam_type_label')).toExist();
         $('#proctored_exam').val('6');
         $('#proctored_exam').trigger('change');
-        expect(add_allowance_view.$el.find('#exam_type_label').html()).toContain('Timed Exam');
+        expect(addAllowanceView.$el.find('#exam_type_label').html()).toContain('Timed Exam');
     });
 
 
@@ -230,7 +241,8 @@ describe('ProctoredExamAddAllowanceView', function() {
         );
 
         this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-        var add_allowance_view = new edx.instructor_dashboard.proctoring.AddAllowanceView({
+        // eslint-disable-next-line no-new
+        new edx.instructor_dashboard.proctoring.AddAllowanceView({
             course_id: 'test_course_id',
             proctored_exams: proctoredExamJson,
             proctored_exam_allowance_view: this.proctored_exam_allowance,
@@ -241,10 +253,14 @@ describe('ProctoredExamAddAllowanceView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('testuser1@test.com');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('Additional Time (minutes)');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('Test Exam');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Additional Time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Test Exam');
 
         // add the proctored exam allowance
         this.server.respondWith('PUT', '/api/edx_proctoring/v1/proctored_exam/allowance',
@@ -276,19 +292,24 @@ describe('ProctoredExamAddAllowanceView', function() {
         $('#user_info').val('testuser1');
 
         // trigger the add allowance event.
-        var spyEvent = spyOnEvent('form', 'submit');
+        spyOnEvent('form', 'submit');
         $('form').trigger('submit');
 
         // process the deleted allowance requests.
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('testuser1');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('testuser1@test.com');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Additional Time (minutes)');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Test Exam');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Additional Time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Test Exam');
     });
     it('should send error when adding proctored exam allowance', function() {
+        var addAllowanceView;
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
@@ -300,7 +321,7 @@ describe('ProctoredExamAddAllowanceView', function() {
         );
 
         this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
-        var add_allowance_view = new edx.instructor_dashboard.proctoring.AddAllowanceView({
+        addAllowanceView = new edx.instructor_dashboard.proctoring.AddAllowanceView({
             course_id: 'test_course_id',
             proctored_exams: proctoredExamJson,
             proctored_exam_allowance_view: this.proctored_exam_allowance,
@@ -311,10 +332,14 @@ describe('ProctoredExamAddAllowanceView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('testuser1@test.com');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('Additional Time (minutes)');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('Test Exam');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Additional Time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Test Exam');
 
         // add the proctored exam allowance
         this.server.respondWith('PUT', '/api/edx_proctoring/v1/proctored_exam/allowance',
@@ -346,14 +371,14 @@ describe('ProctoredExamAddAllowanceView', function() {
         $('#user_info').val('testuser112321');
 
         // trigger the add allowance event.
-        var spyEvent = spyOnEvent('form', 'submit');
+        spyOnEvent('form', 'submit');
         $('form').trigger('submit');
 
         // process the deleted allowance requests.
         this.server.respond();
         this.server.respond();
 
-        expect(add_allowance_view.$el.find('.error-response').html()).toContain('Cannot find user');
+        expect(addAllowanceView.$el.find('.error-response').html()).toContain('Cannot find user');
 
         // select the form values
         // empty value returns error
@@ -363,9 +388,9 @@ describe('ProctoredExamAddAllowanceView', function() {
         $('#user_info').val('testuser1');
 
         // trigger the add allowance event.
-        var spyEvent = spyOnEvent('form', 'submit');
+        spyOnEvent('form', 'submit');
         $('form').trigger('submit');
 
-        expect(add_allowance_view.$el.find('.error-message').html()).toContain('Required field');
+        expect(addAllowanceView.$el.find('.error-message').html()).toContain('Required field');
     });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_allowance_spec.js
@@ -1,4 +1,6 @@
 describe('ProctoredExamAllowanceView', function() {
+    'use strict';
+
     var html = '';
     var expectedProctoredAllowanceJson = [
         {
@@ -46,26 +48,33 @@ describe('ProctoredExamAllowanceView', function() {
         '<% _.each(proctored_exam_allowances, function(proctored_exam_allowance){ %>' +
         '<tr class="allowance-items">' +
         '<td>' +
-        '<%- interpolate(gettext(" %(exam_display_name)s "), { exam_display_name: proctored_exam_allowance.proctored_exam.exam_name }, true) %>' +
+        '<%- interpolate(gettext(" %(exam_display_name)s "),' +
+        '{ exam_display_name: proctored_exam_allowance.proctored_exam.exam_name }, true) %>' +
         '</td>' +
         '<% if (proctored_exam_allowance.user){ %>' +
         '<td>' +
-        '<%- interpolate(gettext(" %(username)s "), { username: proctored_exam_allowance.user.username }, true) %>' +
+        '<%- interpolate(gettext(" %(username)s "),' +
+        '{ username: proctored_exam_allowance.user.username }, true) %>' +
         '</td>' +
         '<td>' +
-        '<%- interpolate(gettext(" %(email)s "), { email: proctored_exam_allowance.user.email }, true) %>' +
+        '<%- interpolate(gettext(" %(email)s "),' +
+        '{ email: proctored_exam_allowance.user.email }, true) %>' +
         '</td>' +
         '<% }else{ %>' +
         '<td>N/A</td><td>N/A</td>' +
         '<% } %>' +
         '<td>' +
-        '<%- interpolate(gettext(" %(allowance_name)s "), { allowance_name: proctored_exam_allowance.key_display_name }, true) %>' +
+        '<%- interpolate(gettext(" %(allowance_name)s "),' +
+        '{ allowance_name: proctored_exam_allowance.key_display_name }, true) %>' +
         '</td>' +
         '<td>' +
         '<%= proctored_exam_allowance.value %>' +
         '</td>' +
         '<td>' +
-        '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>" data-key-name="<%= proctored_exam_allowance.key %>" data-user-id="<%= proctored_exam_allowance.user.id %>"class="remove_allowance" href="#">[x]</a>' +
+        '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"' +
+        'data-key-name="<%= proctored_exam_allowance.key %>"' +
+        'data-user-id="<%= proctored_exam_allowance.user.id %>"' +
+        'class="remove_allowance" href="#">[x]</a>' +
         '</td></tr>' +
         '<% }); %>' +
         '</tbody></table></section></div>' +
@@ -98,13 +107,18 @@ describe('ProctoredExamAllowanceView', function() {
             ]
         );
 
-        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        this.proctored_exam_allowance =
+            new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
         this.server.respond();
         this.server.respond();
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('testuser1');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('testuser1@test.com');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Additional time (minutes)');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Test Exam');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Additional time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Test Exam');
     });
     //
     it('should remove the proctored exam allowance', function() {
@@ -118,15 +132,20 @@ describe('ProctoredExamAllowanceView', function() {
             ]
         );
 
-        this.proctored_exam_allowance = new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
+        this.proctored_exam_allowance =
+            new edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView();
 
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('testuser1');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('testuser1@test.com');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Additional time (minutes)');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Test Exam');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Additional time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .toContain('Test Exam');
 
         // delete the proctored exam allowance one by one
         this.server.respondWith('DELETE', '/api/edx_proctoring/v1/proctored_exam/allowance',
@@ -151,16 +170,20 @@ describe('ProctoredExamAllowanceView', function() {
         );
 
         // trigger the remove allowance event.
-        var spyEvent = spyOnEvent('.remove_allowance', 'click');
+        spyOnEvent('.remove_allowance', 'click');
         $('.remove_allowance').trigger('click');
 
         // process the deleted allowance requests.
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('testuser1@test.com');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('Additional time (minutes)');
-        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).not.toContain('Test Exam');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('testuser1@test.com');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Additional time (minutes)');
+        expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html())
+            .not.toContain('Test Exam');
     });
 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_allowance_spec.js
@@ -1,16 +1,16 @@
-describe('ProctoredExamAllowanceView', function () {
+describe('ProctoredExamAllowanceView', function() {
     var html = '';
     var expectedProctoredAllowanceJson = [
         {
-            created: "2015-08-10T09:15:45Z",
+            created: '2015-08-10T09:15:45Z',
             id: 1,
-            modified: "2015-08-10T09:15:45Z",
-            key: "Additional time (minutes)",
-            value: "1",
+            modified: '2015-08-10T09:15:45Z',
+            key: 'Additional time (minutes)',
+            value: '1',
             proctored_exam: {
-                content_id: "i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c",
-                course_id: "edX/DemoX/Demo_Course",
-                exam_name: "Test Exam",
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Test Exam',
                 external_id: null,
                 id: 17,
                 is_active: true,
@@ -25,14 +25,14 @@ describe('ProctoredExamAllowanceView', function () {
         }
     ];
 
-    beforeEach(function () {
+    beforeEach(function() {
         html = '<span class="tip">' +
         '<%- gettext("Allowances") %>' +
         '<span> <a id="add-allowance" href="#"  class="add blue-button">+' +
         '<%- gettext("Add Allowance") %>' +
         '</a> </span> </span>' +
         '<% var is_allowances = proctored_exam_allowances.length !== 0 %>' +
-        '<% if (is_allowances) { %>'+
+        '<% if (is_allowances) { %>' +
         '<div class="wrapper-content wrapper"> <section class="content"> <table class="allowance-table">' +
         '<thead><tr class="allowance-headings">' +
         '<th class="exam-name">Exam Name</th>' +
@@ -75,10 +75,10 @@ describe('ProctoredExamAllowanceView', function () {
         setFixtures('<div class="special-allowance-container" data-course-id="test_course_id"></div>');
 
         // load the underscore template response before calling the proctored exam allowance view.
-        this.server.respondWith("GET", "/static/proctoring/templates/course_allowances.underscore",
+        this.server.respondWith('GET', '/static/proctoring/templates/course_allowances.underscore',
             [
                 200,
-                {"Content-Type": "text/html"},
+                {'Content-Type': 'text/html'},
                 html
             ]
         );
@@ -87,12 +87,12 @@ describe('ProctoredExamAllowanceView', function () {
     afterEach(function() {
         this.server.restore();
     });
-    it("should render the proctored exam allowance view properly", function () {
+    it('should render the proctored exam allowance view properly', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredAllowanceJson)
             ]
@@ -107,12 +107,12 @@ describe('ProctoredExamAllowanceView', function () {
         expect(this.proctored_exam_allowance.$el.find('tr.allowance-items').html()).toContain('Test Exam');
     });
     //
-    it("should remove the proctored exam allowance", function () {
+    it('should remove the proctored exam allowance', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/test_course_id/allowance',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredAllowanceJson)
             ]
@@ -133,7 +133,7 @@ describe('ProctoredExamAllowanceView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify([])
             ]
@@ -144,7 +144,7 @@ describe('ProctoredExamAllowanceView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify([])
             ]
@@ -152,7 +152,7 @@ describe('ProctoredExamAllowanceView', function () {
 
         // trigger the remove allowance event.
         var spyEvent = spyOnEvent('.remove_allowance', 'click');
-        $('.remove_allowance').trigger( "click" );
+        $('.remove_allowance').trigger('click');
 
         // process the deleted allowance requests.
         this.server.respond();

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_allowance_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_allowance_spec.js
@@ -71,9 +71,9 @@ describe('ProctoredExamAllowanceView', function() {
         '<%= proctored_exam_allowance.value %>' +
         '</td>' +
         '<td>' +
-        '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>"' +
-        'data-key-name="<%= proctored_exam_allowance.key %>"' +
-        'data-user-id="<%= proctored_exam_allowance.user.id %>"' +
+        '<a data-exam-id="<%= proctored_exam_allowance.proctored_exam.id %>" ' +
+        'data-key-name="<%= proctored_exam_allowance.key %>" ' +
+        'data-user-id="<%= proctored_exam_allowance.user.id %>" ' +
         'class="remove_allowance" href="#">[x]</a>' +
         '</td></tr>' +
         '<% }); %>' +

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -1,4 +1,4 @@
-describe('ProctoredExamAttemptView', function () {
+describe('ProctoredExamAttemptView', function() {
     var html = '';
     var deletedProctoredExamAttemptJson = [{
         attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
@@ -21,22 +21,22 @@ describe('ProctoredExamAttemptView', function () {
         },
         proctored_exam_attempts: [{
             allowed_time_limit_mins: 1,
-            attempt_code: "20C32387-372E-48BD-BCAC-A2BE9DC91E09",
+            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
             completed_at: null,
-            created: "2015-08-10T09:15:45Z",
-            external_id: "40eceb15-bcc3-4791-b43f-4e843afb7ae8",
+            created: '2015-08-10T09:15:45Z',
+            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
             id: 43,
             is_sample_attempt: false,
             last_poll_ipaddr: null,
             last_poll_timestamp: null,
-            modified: "2015-08-10T09:15:45Z",
-            started_at: "2015-08-10T09:15:45Z",
-            status: "started",
+            modified: '2015-08-10T09:15:45Z',
+            started_at: '2015-08-10T09:15:45Z',
+            status: 'started',
             taking_as_proctored: true,
             proctored_exam: {
-                content_id: "i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c",
-                course_id: "edX/DemoX/Demo_Course",
-                exam_name: "Normal Exam",
+                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                course_id: 'edX/DemoX/Demo_Course',
+                exam_name: 'Normal Exam',
                 external_id: null,
                 id: 17,
                 is_active: true,
@@ -51,7 +51,7 @@ describe('ProctoredExamAttemptView', function () {
         }]
     }];
 
-    beforeEach(function () {
+    beforeEach(function() {
         html = '<div class="wrapper-content wrapper">' +
         '<% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>' +
         '<section class="content">' +
@@ -127,10 +127,10 @@ describe('ProctoredExamAttemptView', function () {
         setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id"></div>');
 
         // load the underscore template response before calling the proctored exam attemp view.
-        this.server.respondWith("GET", "/static/proctoring/templates/student-proctored-exam-attempts.underscore",
+        this.server.respondWith('GET', '/static/proctoring/templates/student-proctored-exam-attempts.underscore',
             [
                 200,
-                {"Content-Type": "text/html"},
+                {'Content-Type': 'text/html'},
                 html
             ]
         );
@@ -139,12 +139,12 @@ describe('ProctoredExamAttemptView', function () {
     afterEach(function() {
         this.server.restore();
     });
-    it("should render the proctored exam attempt view properly", function () {
+    it('should render the proctored exam attempt view properly', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredExamAttemptJson)
             ]
@@ -158,12 +158,12 @@ describe('ProctoredExamAttemptView', function () {
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
     });
 
-    it("should delete the proctored exam attempt", function () {
+    it('should delete the proctored exam attempt', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredExamAttemptJson)
             ]
@@ -182,7 +182,7 @@ describe('ProctoredExamAttemptView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify([])
             ]
@@ -194,19 +194,19 @@ describe('ProctoredExamAttemptView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(deletedProctoredExamAttemptJson)
             ]
         );
 
-        spyOn(window, "confirm").and.callFake(function() {
+        spyOn(window, 'confirm').and.callFake(function() {
             return true;
         });
 
         // trigger the remove attempt event.
         var spyEvent = spyOnEvent('.remove-attempt', 'click');
-        $('.remove-attempt').trigger( "click" );
+        $('.remove-attempt').trigger('click');
 
         // process the deleted attempt requests.
         this.server.respond();
@@ -216,12 +216,12 @@ describe('ProctoredExamAttemptView', function () {
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('Normal Exam');
     });
 
-    it("should search for the proctored exam attempt", function () {
+    it('should search for the proctored exam attempt', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredExamAttemptJson)
             ]
@@ -240,11 +240,11 @@ describe('ProctoredExamAttemptView', function () {
         $('#search_attempt_id').val(searchText);
 
         // search for the proctored exam attempt
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/'+searchText,
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/' + searchText,
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredExamAttemptJson)
             ]
@@ -252,7 +252,7 @@ describe('ProctoredExamAttemptView', function () {
 
         // trigger the search attempt event.
         var spyEvent = spyOnEvent('.search-attempts > span.search', 'click');
-        $('.search-attempts > span.search').trigger( "click" );
+        $('.search-attempts > span.search').trigger('click');
 
         // process the search attempt requests.
         this.server.respond();
@@ -261,12 +261,12 @@ describe('ProctoredExamAttemptView', function () {
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
     });
-    it("should clear the search for the proctored exam attempt", function () {
+    it('should clear the search for the proctored exam attempt', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredExamAttemptJson)
             ]
@@ -284,11 +284,11 @@ describe('ProctoredExamAttemptView', function () {
         $('#search_attempt_id').val(searchText);
 
         // search the proctored exam attempt
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/'+searchText,
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/' + searchText,
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(deletedProctoredExamAttemptJson)
             ]
@@ -296,7 +296,7 @@ describe('ProctoredExamAttemptView', function () {
 
         // trigger the search attempt event.
         var spyEvent = spyOnEvent('.search-attempts > span.search', 'click');
-        $('.search-attempts > span.search').trigger( "click" );
+        $('.search-attempts > span.search').trigger('click');
 
         // process the search attempt request.
         this.server.respond();
@@ -310,7 +310,7 @@ describe('ProctoredExamAttemptView', function () {
             [
                 200,
                 {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 },
                 JSON.stringify(expectedProctoredExamAttemptJson)
             ]
@@ -318,7 +318,7 @@ describe('ProctoredExamAttemptView', function () {
 
         // trigger the clear search event.
         var spyEvent = spyOnEvent('.search-attempts > span.clear-search', 'click');
-        $('.search-attempts > span.clear-search').trigger( "click" );
+        $('.search-attempts > span.clear-search').trigger('click');
 
         // process the reset attempt request.
         this.server.respond();

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -1,4 +1,6 @@
 describe('ProctoredExamAttemptView', function() {
+    'use strict';
+
     var html = '';
     var deletedProctoredExamAttemptJson = [{
         attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
@@ -57,9 +59,11 @@ describe('ProctoredExamAttemptView', function() {
         '<section class="content">' +
         '<div class="top-header">' +
         '<div class="search-attempts">' +
-        '<input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"' +
+         '<input type="text" id="search_attempt_id"' +
+         'placeholder="e.g johndoe or john.doe@gmail.com"' +
         '<% if (inSearchMode) { %> value="<%= searchText %>" <%} %>' +
-        '/> <span class="search"><span class="icon fa fa-search" aria-hidden="true"></span></span> <span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>' +
+        '/> <span class="search"><span class="icon fa fa-search" aria-hidden="true"></span></span>' +
+        '<span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>' +
         '</div>' +
         '<ul class="pagination">' +
         '<% if (!pagination_info.has_previous){ %>' +
@@ -67,17 +71,21 @@ describe('ProctoredExamAttemptView', function() {
         '<% } else { %>' +
         '<li>' +
         '<a class="target-link " data-target-url="' +
-        '<%- interpolate("%(attempt_url)s?page=%(count)s ", {attempt_url: attempt_url, count: pagination_info.current_page - 1}, true) %>' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: pagination_info.current_page - 1}, true) %>' +
         '"' +
         'href="#" aria-label="Previous">' +
         '<span aria-hidden="true">&laquo;</span> </a> </li> <% }%>' +
         '<% for(var n = 1; n <= pagination_info.total_pages; n++) { %>' +
         '<li> <a class="target-link <% if (pagination_info.current_page == n){ %> active <% } %>" data-target-url=" ' +
-        '<%- interpolate("%(attempt_url)s?page=%(count)s ", {attempt_url: attempt_url, count: n}, true) %>' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: n}, true) %>' +
         '"href="#"><%= n %> </a></li> <% } %>' +
-        '<% if (!pagination_info.has_next){ %> <li class="disabled"> <a aria-label="Next"> <span aria-hidden="true">&raquo;</span> </a></li>' +
+        '<% if (!pagination_info.has_next){ %>' +
+        '<li class="disabled"> <a aria-label="Next"> <span aria-hidden="true">&raquo;</span> </a></li>' +
         '<% } else { %> <li> <a class="target-link" href="#" aria-label="Next" data-target-url="' +
-        '<%- interpolate("%(attempt_url)s?page=%(count)s ",{attempt_url: attempt_url, count: pagination_info.current_page + 1}, true) %>' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: pagination_info.current_page + 1}, true) %>' +
         '" > <span aria-hidden="true">&raquo;</span></a> </li> <% }%> </ul><div class="clearfix"></div></div>' +
         '<table class="exam-attempts-table"> <thead><tr class="exam-attempt-headings">' +
         '<th class="username">Username</th>' +
@@ -95,7 +103,8 @@ describe('ProctoredExamAttemptView', function() {
         ' <%= proctored_exam_attempt.user.username %> ' +
         ' </td>' +
         '<td>' +
-        ' <%- interpolate(gettext(" %(exam_display_name)s "), { exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>' +
+        ' <%- interpolate(gettext(" %(exam_display_name)s "),' +
+        '{ exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>' +
         '</td>' +
         '<td>' +
         ' <%= proctored_exam_attempt.allowed_time_limit_mins %> ' +
@@ -205,7 +214,7 @@ describe('ProctoredExamAttemptView', function() {
         });
 
         // trigger the remove attempt event.
-        var spyEvent = spyOnEvent('.remove-attempt', 'click');
+        spyOnEvent('.remove-attempt', 'click');
         $('.remove-attempt').trigger('click');
 
         // process the deleted attempt requests.
@@ -217,6 +226,7 @@ describe('ProctoredExamAttemptView', function() {
     });
 
     it('should search for the proctored exam attempt', function() {
+        var searchText = 'testuser1';
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
             [
                 200,
@@ -236,11 +246,12 @@ describe('ProctoredExamAttemptView', function() {
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1  </td>');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
 
-        var searchText = 'testuser1';
         $('#search_attempt_id').val(searchText);
 
         // search for the proctored exam attempt
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/' + searchText,
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/' + searchText,
             [
                 200,
                 {
@@ -251,7 +262,7 @@ describe('ProctoredExamAttemptView', function() {
         );
 
         // trigger the search attempt event.
-        var spyEvent = spyOnEvent('.search-attempts > span.search', 'click');
+        spyOnEvent('.search-attempts > span.search', 'click');
         $('.search-attempts > span.search').trigger('click');
 
         // process the search attempt requests.
@@ -262,6 +273,7 @@ describe('ProctoredExamAttemptView', function() {
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
     });
     it('should clear the search for the proctored exam attempt', function() {
+        var searchText = 'invalid_search_text';
         this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
             [
                 200,
@@ -280,11 +292,12 @@ describe('ProctoredExamAttemptView', function() {
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1  </td>');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
 
-        var searchText = 'invalid_search_text';
         $('#search_attempt_id').val(searchText);
 
         // search the proctored exam attempt
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/' + searchText,
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id/search/' + searchText,
             [
                 200,
                 {
@@ -295,7 +308,7 @@ describe('ProctoredExamAttemptView', function() {
         );
 
         // trigger the search attempt event.
-        var spyEvent = spyOnEvent('.search-attempts > span.search', 'click');
+        spyOnEvent('.search-attempts > span.search', 'click');
         $('.search-attempts > span.search').trigger('click');
 
         // process the search attempt request.
@@ -317,7 +330,7 @@ describe('ProctoredExamAttemptView', function() {
         );
 
         // trigger the clear search event.
-        var spyEvent = spyOnEvent('.search-attempts > span.clear-search', 'click');
+        spyOnEvent('.search-attempts > span.clear-search', 'click');
         $('.search-attempts > span.clear-search').trigger('click');
 
         // process the reset attempt request.

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js
@@ -1,0 +1,10 @@
+/**
+ * Declarations of global variables that are created implicitly in files under test
+ *
+ * This is a kludge to workaround PhantomJS disliking implicit global
+ * creation without a `var` declaration, which we rely on for the
+ * order-agnostic global setting pattern we always do to namespace
+ * global variables.
+ */
+// eslint-disable-next-line no-unused-vars
+var edx;

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -102,7 +102,7 @@ describe('ProctoredExamView', function() {
         this.proctored_exam_view.model.set('ping_interval', 60);
         edx.courseware.proctored_exam.pingApplication = jasmine.createSpy().and.returnValue(Promise.resolve());
         edx.courseware.proctored_exam.configuredWorkerURL = 'nonempty/string.html';
-        this.proctored_exam_view.timerTick = this.proctored_exam_view.model.get('ping_interval') / 2 - 1;
+        this.proctored_exam_view.timerTick = (this.proctored_exam_view.model.get('ping_interval') / 2) - 1;
         this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
         expect(edx.courseware.proctored_exam.pingApplication).toHaveBeenCalled();
         delete edx.courseware.proctored_exam.pingApplication;

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -1,5 +1,8 @@
-describe('ProctoredExamView', function () {
-    beforeEach(function () {
+/* global ProctoredExamModel:false */
+describe('ProctoredExamView', function() {
+    'use strict';
+
+    beforeEach(function() {
         this.server = sinon.fakeServer.create();
         jasmine.clock().install();
         setFixtures(
@@ -14,7 +17,7 @@ describe('ProctoredExamView', function () {
             '<i class="fa fa-eye-slash" aria-hidden="true"></i></button>' +
             '</span> </span>' +
             '</div>' +
-            '</script>'+
+            '</script>' +
             '</div>'
         );
         this.model = new ProctoredExamModel({
@@ -23,7 +26,7 @@ describe('ProctoredExamView', function () {
             exam_display_name: 'Midterm',
             taking_as_proctored: true,
             exam_url_path: '/test_url',
-            time_remaining_seconds: 45, //2 * 60 + 15,
+            time_remaining_seconds: 45, // 2 * 60 + 15,
             low_threshold_sec: 30,
             attempt_id: 2,
             critically_low_threshold_sec: 15,
@@ -33,7 +36,7 @@ describe('ProctoredExamView', function () {
         this.proctored_exam_view = new edx.courseware.proctored_exam.ProctoredExamView(
             {
                 model: this.model,
-                el: $(".proctored_exam_status"),
+                el: $('.proctored_exam_status'),
                 proctored_template: '#proctored-exam-status-tpl'
             }
         );
@@ -45,16 +48,16 @@ describe('ProctoredExamView', function () {
         jasmine.clock().uninstall();
     });
 
-    it('renders items correctly', function () {
-        expect(this.proctored_exam_view.$el.find('a')).toHaveAttr('href',  this.model.get("exam_url_path"));
+    it('renders items correctly', function() {
+        expect(this.proctored_exam_view.$el.find('a')).toHaveAttr('href', this.model.get('exam_url_path'));
         expect(this.proctored_exam_view.$el.find('a')).toContainHtml(this.model.get('exam_display_name'));
     });
-    it('changes behavior when clock time decreases low threshold', function () {
+    it('changes behavior when clock time decreases low threshold', function() {
         this.proctored_exam_view.secondsLeft = 25;
         this.proctored_exam_view.render();
         expect(this.proctored_exam_view.$el.find('div.exam-timer')).toHaveClass('low-time warning');
     });
-    it('changes behavior when clock time decreases critically low threshold', function () {
+    it('changes behavior when clock time decreases critically low threshold', function() {
         this.proctored_exam_view.secondsLeft = 5;
         this.proctored_exam_view.render();
         expect(this.proctored_exam_view.$el.find('div.exam-timer')).toHaveClass('low-time critical');
@@ -68,28 +71,28 @@ describe('ProctoredExamView', function () {
         button.click();
         expect(timer).not.toHaveClass('timer-hidden');
     });
-    it("reload the page when the exam time finishes", function(){
-        this.proctored_exam_view.secondsLeft = -10;
+    it('reload the page when the exam time finishes', function() {
         var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        this.proctored_exam_view.secondsLeft = -10;
         this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
         expect(reloadPage).toHaveBeenCalled();
     });
-    it("resets the remaining exam time after the ajax response", function(){
+    it('resets the remaining exam time after the ajax response', function() {
+        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
         this.server.respondWith(
-            "GET",
-            "/api/edx_proctoring/v1/proctored_exam/attempt/" +
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/' +
             this.proctored_exam_view.model.get('attempt_id') +
             '?sourceid=in_exam&proctored=true',
             [
                 200,
-                {"Content-Type": "application/json"},
+                {'Content-Type': 'application/json'},
                 JSON.stringify({
                     time_remaining_seconds: -10
                 })
             ]
         );
-        this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval-1; // to make the ajax call.
-        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        this.proctored_exam_view.timerTick = this.proctored_exam_view.poll_interval - 1; // to make the ajax call.
         this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
         this.server.respond();
         this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -125,25 +125,27 @@ describe('ProctoredExamView', function() {
         });
         this.server.respond();
     });
-    it('does not reload the page after failure-state ajax call when server responds with no attempt id', function(done) {
-        // this case mimics current behavior of the server when the
-        // proctoring backend is configured to not block the user for a
-        // failed ping.
-        this.server.respondWith(
-            function(request) {
-                request.respond(200,
-                    {'Content-Type': 'application/json'},
-                    '{"exam_attempt_id": false}'
-                );
-            }
-        );
-        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
-        this.proctored_exam_view.endExamForFailureState().done(function() {
-            expect(reloadPage).not.toHaveBeenCalled();
-            done();
+    it('does not reload the page after failure-state ajax call when server responds with no attempt id',
+        function(done) {
+            var reloadPage;
+            // this case mimics current behavior of the server when the
+            // proctoring backend is configured to not block the user for a
+            // failed ping.
+            this.server.respondWith(
+                function(request) {
+                    request.respond(200,
+                        {'Content-Type': 'application/json'},
+                        '{"exam_attempt_id": false}'
+                    );
+                }
+            );
+            reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+            this.proctored_exam_view.endExamForFailureState().done(function() {
+                expect(reloadPage).not.toHaveBeenCalled();
+                done();
+            });
+            this.server.respond();
         });
-        this.server.respond();
-    });
 
     it('sets global variable when unset', function() {
         expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toBeUndefined();

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -109,6 +109,7 @@ describe('ProctoredExamView', function() {
         delete edx.courseware.proctored_exam.configuredWorkerURL;
     });
     it('reloads the page after failure-state ajax call', function(done) {
+        var reloadPage;
         this.server.respondWith(
             function(request) {
                 request.respond(200,
@@ -117,7 +118,7 @@ describe('ProctoredExamView', function() {
                 );
             }
         );
-        var reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
+        reloadPage = spyOn(this.proctored_exam_view, 'reloadPage');
         this.proctored_exam_view.endExamForFailureState().done(function() {
             expect(reloadPage).toHaveBeenCalled();
             done();

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_spec.js
@@ -98,8 +98,8 @@ describe('ProctoredExamView', function() {
         this.proctored_exam_view.updateRemainingTime(this.proctored_exam_view);
         expect(reloadPage).toHaveBeenCalled();
     });
-    it("calls external js global function on off-beat", function() {
-      this.proctored_exam_view.model.set('ping_interval', 60);
+    it('calls external js global function on off-beat', function() {
+        this.proctored_exam_view.model.set('ping_interval', 60);
         edx.courseware.proctored_exam.pingApplication = jasmine.createSpy().and.returnValue(Promise.resolve());
         edx.courseware.proctored_exam.configuredWorkerURL = 'nonempty/string.html';
         this.proctored_exam_view.timerTick = this.proctored_exam_view.model.get('ping_interval') / 2 - 1;
@@ -108,12 +108,12 @@ describe('ProctoredExamView', function() {
         delete edx.courseware.proctored_exam.pingApplication;
         delete edx.courseware.proctored_exam.configuredWorkerURL;
     });
-    it("reloads the page after failure-state ajax call", function(done) {
+    it('reloads the page after failure-state ajax call', function(done) {
         this.server.respondWith(
             function(request) {
                 request.respond(200,
-                                {"Content-Type": "application/json"},
-                                '{"exam_attempt_id": "abcde"}'
+                    {'Content-Type': 'application/json'},
+                    '{"exam_attempt_id": "abcde"}'
                 );
             }
         );
@@ -124,15 +124,15 @@ describe('ProctoredExamView', function() {
         });
         this.server.respond();
     });
-    it("does not reload the page after failure-state ajax call when server responds with no attempt id", function(done) {
+    it('does not reload the page after failure-state ajax call when server responds with no attempt id', function(done) {
         // this case mimics current behavior of the server when the
         // proctoring backend is configured to not block the user for a
         // failed ping.
         this.server.respondWith(
             function(request) {
                 request.respond(200,
-                                {"Content-Type": "application/json"},
-                                '{"exam_attempt_id": false}'
+                    {'Content-Type': 'application/json'},
+                    '{"exam_attempt_id": false}'
                 );
             }
         );
@@ -144,12 +144,12 @@ describe('ProctoredExamView', function() {
         this.server.respond();
     });
 
-    it("sets global variable when unset", function() {
+    it('sets global variable when unset', function() {
         expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toBeUndefined();
-        this.proctored_exam_view.model.set("desktop_application_js_url", "nonempty string");
+        this.proctored_exam_view.model.set('desktop_application_js_url', 'nonempty string');
         expect(window.edx.courseware.proctored_exam.configuredWorkerURL).not.toBeUndefined();
-        this.proctored_exam_view.model.set("desktop_application_js_url", "another nonempty string");
-        expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toEqual("nonempty string");
+        this.proctored_exam_view.model.set('desktop_application_js_url', 'another nonempty string');
+        expect(window.edx.courseware.proctored_exam.configuredWorkerURL).toEqual('nonempty string');
         delete window.edx.courseware.proctored_exam.configuredWorkerURL;
     });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,24 +1,25 @@
+/* eslint strict: "off" */
 var gulp = require('gulp');
 var karma = require('karma').server;
-var coverageOnOff = 'coverage';
+var path = require('path');
 
 /**
  * Run test once and exit
  */
-gulp.task('test', function (done) {
-  karma.start({
-    configFile: __dirname + '/karma.conf.js',
-    singleRun: true
-  }, done);
+gulp.task('test', function(done) {
+    karma.start({
+        configFile: path.join(__dirname, '/karma.conf.js'),
+        singleRun: true
+    }, done);
 });
 
 /**
  * Watch for file changes and re-run tests on each change
  */
-gulp.task('tdd', function (done) {
-  karma.start({
-    configFile: __dirname + '/karma.conf.js'
-  }, done);
+gulp.task('tdd', function(done) {
+    karma.start({
+        configFile: path.join(__dirname, '/karma.conf.js')
+    }, done);
 });
 
 gulp.task('default', ['tdd']);
@@ -27,9 +28,9 @@ gulp.task('default', ['tdd']);
 /**
  * Run test in debug mode
  */
-gulp.task('debug', function (done) {
-  karma.start({
-    configFile: __dirname + '/karma.conf.js',
-    singleRun: false
-  }, done);
+gulp.task('debug', function(done) {
+    karma.start({
+        configFile: path.join(__dirname, '/karma.conf.js'),
+        singleRun: false
+    }, done);
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,6 +34,7 @@ module.exports = function(config) {
 
         // patterns to load all files in child folders
         files: [
+            'edx_proctoring/static/proctoring/spec/proctored_exam_global_vars.js',
             'node_modules/babel-polyfill/dist/polyfill.js', // polyfills for e.g. Promises
             'edx_proctoring/static/proctoring/js/vendor/i18n.js',
             'edx_proctoring/static/proctoring/js/vendor/jquery.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
-
-//Add ability to turn coverage off when the tests are run in debug mode
+/* eslint strict: "off" */
+// Add ability to turn coverage off when the tests are run in debug mode
 var sourcePreprocessors = 'coverage';
 
 function isDebug(argument) {
@@ -11,82 +11,82 @@ if (process.argv.some(isDebug)) {
 
 
 module.exports = function(config) {
-  config.set({
+    config.set({
 
-    basePath: '',
+        basePath: '',
 
-    //plugins required for running the karma tests
-    plugins:[
-        'karma-jasmine',
-        'karma-jasmine-jquery',
-        'karma-jasmine-jquery',
-        'karma-chrome-launcher',
-        'karma-phantomjs-launcher',
-        'karma-coverage',
-        'karma-sinon'
-    ],
+        // plugins required for running the karma tests
+        plugins: [
+            'karma-jasmine',
+            'karma-jasmine-jquery',
+            'karma-jasmine-jquery',
+            'karma-chrome-launcher',
+            'karma-phantomjs-launcher',
+            'karma-coverage',
+            'karma-sinon'
+        ],
 
-    // start the browser
-    browsers: ['PhantomJS'],
+        // start the browser
+        browsers: ['PhantomJS'],
 
-    //frameworks to use
-    frameworks: ['jasmine-jquery', 'jasmine', 'sinon'],
+        // frameworks to use
+        frameworks: ['jasmine-jquery', 'jasmine', 'sinon'],
 
-    //patterns to load all files in child folders
-    files: [
-        'node_modules/babel-polyfill/dist/polyfill.js', // polyfills for e.g. Promises
-        'edx_proctoring/static/proctoring/js/vendor/i18n.js',
-        'edx_proctoring/static/proctoring/js/vendor/jquery.js',
-        'edx_proctoring/static/proctoring/js/vendor/underscore.js',
-        'edx_proctoring/static/proctoring/js/vendor/backbone.js',
-        'edx_proctoring/static/proctoring/js/vendor/date.js',
-        'edx_proctoring/static/proctoring/js/models/*.js',
-        'edx_proctoring/static/proctoring/js/collections/*.js',
-        'edx_proctoring/static/proctoring/js/views/*.js',
-        'edx_proctoring/static/proctoring/spec/*.js'
-    ],
+        // patterns to load all files in child folders
+        files: [
+            'node_modules/babel-polyfill/dist/polyfill.js', // polyfills for e.g. Promises
+            'edx_proctoring/static/proctoring/js/vendor/i18n.js',
+            'edx_proctoring/static/proctoring/js/vendor/jquery.js',
+            'edx_proctoring/static/proctoring/js/vendor/underscore.js',
+            'edx_proctoring/static/proctoring/js/vendor/backbone.js',
+            'edx_proctoring/static/proctoring/js/vendor/date.js',
+            'edx_proctoring/static/proctoring/js/models/*.js',
+            'edx_proctoring/static/proctoring/js/collections/*.js',
+            'edx_proctoring/static/proctoring/js/views/*.js',
+            'edx_proctoring/static/proctoring/spec/*.js'
+        ],
 
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-        'edx_proctoring/static/proctoring/js/models/*.js': sourcePreprocessors,
-        'edx_proctoring/static/proctoring/js/collections/*.js': sourcePreprocessors,
-        'edx_proctoring/static/proctoring/js/views/*.js': sourcePreprocessors
-    },
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+        preprocessors: {
+            'edx_proctoring/static/proctoring/js/models/*.js': sourcePreprocessors,
+            'edx_proctoring/static/proctoring/js/collections/*.js': sourcePreprocessors,
+            'edx_proctoring/static/proctoring/js/views/*.js': sourcePreprocessors
+        },
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage'],
+        // test results reporter to use
+        // possible values: 'dots', 'progress'
+        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ['progress', 'coverage'],
 
-    coverageReporter: {
-        dir:'build', subdir: 'coverage-js',
-        reporters:[
-            {type: 'html', subdir: 'coverage-js/html'},
-            {type: 'cobertura', file: 'coverage.xml'},
-            {type: 'text-summary'}
-        ]
-    },
+        coverageReporter: {
+            dir: 'build',
+            subdir: 'coverage-js',
+            reporters: [
+                {type: 'html', subdir: 'coverage-js/html'},
+                {type: 'cobertura', file: 'coverage.xml'},
+                {type: 'text-summary'}
+            ]
+        },
 
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-     // level of logging
-     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-     logLevel: config.LOG_INFO,
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
 
 
-     // enable / disable watching file and executing tests whenever any file changes
-     autoWatch: true,
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR ||
+        // config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
 
-     captureTimeout: 60000,
 
-     // Continuous Integration mode
-     // if true, Karma captures browsers, runs the tests and exits
-     singleRun: false
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
 
-  });
+        captureTimeout: 60000,
+
+        // Continuous Integration mode
+        // if true, Karma captures browsers, runs the tests and exits
+        singleRun: false
+
+    });
 };
-
-

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "babel-polyfill": "^6.26.0",
     "eslint": "^5.9.0",
+    "eslint-config-edx": "^4.0.4",
     "eslint-config-edx-es5": "^4.0.1",
     "gulp": "^3.9.0",
     "gulp-karma": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",
+    "eslint": "^5.9.0",
+    "eslint-config-edx-es5": "^4.0.1",
     "gulp": "^3.9.0",
     "gulp-karma": "0.0.1",
     "jasmine-core": "^2.8.0",


### PR DESCRIPTION
Sets up eslint for the JS in this repository!

- sets up two separate calls of eslint to correspond to pre- and post-ES6 style code in the `make lint-js` command
- sets up travis to disallow eslint errors from being merged in the future
- sets us off with a clean slate, fixing more than 1k errors!