### PR TITLE
Don't override the attempt_code

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -669,8 +669,6 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
             exam,
             context=context,
         )
-        if external_id:
-            attempt_code = external_id
 
     attempt = ProctoredExamStudentAttempt.create_exam_attempt(
         exam_id,

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -157,6 +157,8 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         url = self.create_exam_attempt_url.format(exam_id=exam['external_id'])
         payload = context
         payload['status'] = 'created'
+        # attempt code isn't needed in this API
+        payload.pop('attempt_code', False)
         log.debug('Creating exam attempt for %r at %r', exam['external_id'], url)
         response = self.session.post(url, json=payload)
         response = response.json()


### PR DESCRIPTION
I don't know why I was setting the attempt_code to the external_id returned from the backend. They are separate ids. 
