### PR TITLE
EDUCATOR-3857 -- switching from proctored to timed

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -16,8 +16,6 @@ import six
 from django.utils.translation import ugettext as _, ugettext_noop
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.dispatch import receiver
-from django.db.models.signals import post_save
 from django.template import loader
 from django.urls import reverse, NoReverseMatch
 from django.core.mail.message import EmailMessage
@@ -199,30 +197,6 @@ def remove_review_policy(exam_id):
         raise ProctoredExamReviewPolicyNotFoundException
 
     exam_review_policy.delete()
-
-
-@receiver(post_save, sender=ProctoredExamReviewPolicy)
-@receiver(post_save, sender=ProctoredExam)
-def _save_exam_on_backend(sender, instance, **kwargs):  # pylint: disable=unused-argument
-    """
-    Save the exam to the backend provider when our model changes.
-    It also combines the review policy into the exam when saving to the backend
-    """
-    if sender == ProctoredExam:
-        exam_obj = instance
-        review_policy = ProctoredExamReviewPolicy.get_review_policy_for_exam(instance.id)
-    else:
-        exam_obj = instance.proctored_exam
-        review_policy = instance
-    if exam_obj.is_proctored:
-        exam = ProctoredExamSerializer(exam_obj).data
-        if review_policy:
-            exam['rule_summary'] = review_policy.review_policy
-        backend = get_backend_provider(exam)
-        external_id = backend.on_exam_saved(exam)
-        if external_id and external_id != exam_obj.external_id:
-            exam_obj.external_id = external_id
-            exam_obj.save()
 
 
 def get_review_policy_by_exam_id(exam_id):

--- a/edx_proctoring/apps.py
+++ b/edx_proctoring/apps.py
@@ -109,6 +109,7 @@ class EdxProctoringConfig(AppConfig):
         """
         Loads the available proctoring backends
         """
+        from edx_proctoring import signals  # pylint: disable=unused-variable
         config = settings.PROCTORING_BACKENDS
 
         self.backends = {}  # pylint: disable=W0201

--- a/edx_proctoring/backends/__init__.py
+++ b/edx_proctoring/backends/__init__.py
@@ -4,15 +4,16 @@ All supporting Proctoring backends
 from django.apps import apps
 
 
-def get_backend_provider(exam=None):
+def get_backend_provider(exam=None, name=None):
     """
     Returns an instance of the configured backend provider
+    Passing in an exam will return the backend for that exam
+    Passing in a name will return the named backend
     """
-    backend_name = None
     if exam:
         if 'is_proctored' in exam and not exam['is_proctored']:
             # timed exams don't have a backend
             return None
         elif exam['backend']:
-            backend_name = exam['backend']
-    return apps.get_app_config('edx_proctoring').get_backend(name=backend_name)
+            name = exam['backend']
+    return apps.get_app_config('edx_proctoring').get_backend(name=name)

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -212,6 +212,8 @@ class BackendChooserTests(TestCase):
         """
         backend = get_backend_provider({'backend': 'null'})
         self.assertIsInstance(backend, NullBackendProvider)
+        backend = get_backend_provider(name='test')
+        self.assertIsInstance(backend, TestBackendProvider)
 
     def test_backend_choices(self):
         """

--- a/edx_proctoring/signals.py
+++ b/edx_proctoring/signals.py
@@ -1,0 +1,106 @@
+"edx-proctoring signals"
+from django.db.models.signals import pre_save, post_save, pre_delete
+from django.dispatch import receiver
+from edx_proctoring import models
+from edx_proctoring.backends import get_backend_provider
+
+
+@receiver(post_save, sender=models.ProctoredExamReviewPolicy)
+@receiver(post_save, sender=models.ProctoredExam)
+def _save_exam_on_backend(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Save the exam to the backend provider when our model changes.
+    It also combines the review policy into the exam when saving to the backend
+    """
+    if sender == models.ProctoredExam:
+        exam_obj = instance
+        review_policy = models.ProctoredExamReviewPolicy.get_review_policy_for_exam(instance.id)
+    else:
+        exam_obj = instance.proctored_exam
+        review_policy = instance
+    if exam_obj.is_proctored:
+        from edx_proctoring.serializers import ProctoredExamSerializer
+        exam = ProctoredExamSerializer(exam_obj).data
+        if review_policy:
+            exam['rule_summary'] = review_policy.review_policy
+        backend = get_backend_provider(exam)
+        external_id = backend.on_exam_saved(exam)
+        if external_id and external_id != exam_obj.external_id:
+            exam_obj.external_id = external_id
+            exam_obj.save()
+
+
+# Hook up the pre_save signal to record creations in the ProctoredExamReviewPolicyHistory table.
+@receiver(pre_save, sender=models.ProctoredExamReviewPolicy)
+@receiver(pre_delete, sender=models.ProctoredExamReviewPolicy)
+def on_review_policy_changed(sender, instance, signal, **kwargs):  # pylint: disable=unused-argument
+    """
+    Archiving all changes made to the Review Policy.
+    Will only archive on update/delete, and not on new entries created.
+    """
+    if signal is pre_save:
+        if instance.id:
+            instance = sender.objects.get(id=instance.id)
+        else:
+            return
+    models.archive_model(models.ProctoredExamReviewPolicyHistory, instance, id='original_id')
+
+
+# Hook up the post_save signal to record creations in the ProctoredExamStudentAllowanceHistory table.
+@receiver(pre_save, sender=models.ProctoredExamStudentAllowance)
+@receiver(pre_delete, sender=models.ProctoredExamStudentAllowance)
+def on_allowance_saved(sender, instance, signal, **kwargs):  # pylint: disable=unused-argument
+    """
+    Archiving all changes made to the Student Allowance.
+    Will only archive on update/delete, and not on new entries created.
+    """
+
+    if signal is pre_save:
+        if instance.id:
+            instance = sender.objects.get(id=instance.id)
+        else:
+            return
+    models.archive_model(models.ProctoredExamStudentAllowanceHistory, instance, id='allowance_id')
+
+
+@receiver(pre_save, sender=models.ProctoredExamStudentAttempt)
+@receiver(pre_delete, sender=models.ProctoredExamStudentAttempt)
+def on_attempt_updated(sender, instance, signal, **kwargs):  # pylint: disable=unused-argument
+    """
+    Archive the exam attempt whenever the attempt status is about to be
+    modified. Make a new entry with the previous value of the status in the
+    ProctoredExamStudentAttemptHistory table.
+    """
+
+    if signal is pre_save:
+        if instance.id:
+            # on an update case, get the original
+            # and see if the status has changed, if so, then we need
+            # to archive it
+            original = sender.objects.get(id=instance.id)
+
+            if original.status != instance.status:
+                instance = original
+            else:
+                return
+        else:
+            return
+    models.archive_model(models.ProctoredExamStudentAttemptHistory, instance, id='attempt_id')
+
+
+# Hook up the signals to record updates/deletions in the ProctoredExamStudentAllowanceHistory table.
+@receiver(pre_save, sender=models.ProctoredExamSoftwareSecureReview)
+@receiver(pre_delete, sender=models.ProctoredExamSoftwareSecureReview)
+def on_review_saved(sender, instance, signal, **kwargs):  # pylint: disable=unused-argument
+    """
+    Archiving all changes made to the Review.
+    Will only archive on update/delete, and not on new entries created.
+    """
+    if signal is pre_save:
+        if instance.id:
+            # only for update cases
+            instance = sender.objects.get(id=instance.id)
+        else:
+            # don't archive on create
+            return
+    models.archive_model(models.ProctoredExamSoftwareSecureReviewHistory, instance, id='review_id')

--- a/edx_proctoring/signals.py
+++ b/edx_proctoring/signals.py
@@ -15,11 +15,9 @@ def check_for_category_switch(sender, instance, **kwargs):  # pylint: disable=un
         if original.is_proctored and instance.is_proctored != original.is_proctored:
             from edx_proctoring.serializers import ProctoredExamSerializer
             exam = ProctoredExamSerializer(instance).data
+            # from the perspective of the backend, the exam is now inactive.
             exam['is_active'] = False
-            exam['is_proctored'] = True
-            # we have to pretend that the exam is still proctored
-            # or else we get_backend_provider will return None
-            backend = get_backend_provider(exam)
+            backend = get_backend_provider(name=exam['backend'])
             backend.on_exam_saved(exam)
 
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -174,6 +174,16 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
 
         self.assertEqual(update_timed_exam.hide_after_due, True)
 
+    def test_switch_from_proctored_to_timed(self):
+        """
+        Test that switches an exam from proctored to timed.
+        The backend should be notified that the exam is inactive
+        """
+        proctored_exam = get_exam_by_id(self.proctored_exam_id)
+        update_exam(self.proctored_exam_id, is_proctored=False)
+        backend = get_backend_provider(proctored_exam)
+        self.assertEqual(backend.last_exam['is_active'], False)
+
     def test_update_non_existing_exam(self):
         """
         test to update the non-existing proctored exam


### PR DESCRIPTION
[EDUCATOR-3857](https://openedx.atlassian.net/browse/EDUCATOR-3857)

If a proctored exam switches to being a timed exam, the backend should be notified that the exam is now "inactive".