### PR TITLE
proctortrack-specific copy changes

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '1.5.2'
+__version__ = '1.5.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/backend.py
+++ b/edx_proctoring/backends/backend.py
@@ -14,6 +14,8 @@ class ProctoringBackendProvider(six.with_metaclass(abc.ABCMeta)):
     """
     verbose_name = u'Unknown'
     ping_interval = constants.DEFAULT_DESKTOP_APPLICATION_PING_INTERVAL_SECONDS
+    tech_support_email = ''
+    tech_support_phone = ''
     # whether this backend supports an instructor review/configuration dashboard
     has_dashboard = False
 

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -8,13 +8,31 @@
     {% endblocktrans %}
     </h3>
     {% if backend_instructions %}
-      {% for instruction in backend_instructions %}
-      <p>{{instruction|safe}}</p>
-      {% endfor %}
       <p>
-        <a href="#" id="software_download_link" data-action="click_download_software" target="_blank">{% trans "Start System Check" %}</a>
+        {% blocktrans %}
+          Note: As part of the proctored exam setup, you will be asked
+          to verify your identity. Before you begin, make sure you are
+          on a computer with a webcam, and that you have a valid form
+          of photo identification such as a driver’s license or
+          passport.
+        {% endblocktrans %}
       </p>
-
+      <ol>
+        {% for instruction in backend_instructions %}
+          <li>{{instruction|safe}}</li>
+        {% endfor %}
+      </ol>
+      {% if provider_tech_support_email and provider_tech_support_phone %}
+        <p>
+          {% blocktrans %}
+            If you have issues relating to proctoring, you can contact {{ provider_name }} technical support by emailing {{ provider_tech_support_email }}  or by calling {{ provider_tech_support_phone }}.
+          {% endblocktrans %}
+        </p>
+      {% endif %}
+      <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
+      <div class="footer-sequence border-b-0 padding-b-0">
+        <a href="#" class="start-proctored-exam">{% trans "Start Proctored Exam" %}</a>
+      </div>
     {% else %}
     <p>
       {% blocktrans %}
@@ -54,12 +72,12 @@
           3. When you have finished setting up proctoring, start the exam.
         {% endblocktrans %}
     </p>
-    {% endif %}
     <div>
         <button type="button" class="exam-action-button btn-pl-primary start-proctored-exam">
             {% trans "Start Proctored Exam" %}
         </button>
     </div>
+    {% endif %}
   </div>
 </div>
 {% include 'proctored_exam/error_modal.html' %}
@@ -109,7 +127,6 @@
     }
   );
 
-
   function check_exam_started() {
     var url = $('.instructions').data('exam-started-poll-url') + '?sourceid=instructions';
     $.ajax(url).success(function(data){
@@ -124,19 +141,6 @@
               gettext("Cannot Start Proctored Exam"),
               gettext("You must complete the proctoring setup before you can start the exam."),
           );
-      }
-    });
-  }
-
-  function poll_until_ready() {
-    var url = $('.instructions').data('exam-started-poll-url') + '?sourceid=instructions';
-    $.ajax(url).success(function(data){
-      if (data.status === 'ready_to_start') {
-        // we've state transitioned, so refresh the page
-        // to reflect the new state (which will expose the test)
-        location.reload();
-      } else {
-        setTimeout(poll_until_ready, 5000);
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[EDUCATOR-3842](https://openedx.atlassian.net/browse/EDUCATOR-3842)

separated out the copy changes which don't touch RPNow at all, since we're more confident they can go through immediately

see also: https://github.com/joshivj/edx-proctoring-proctortrack/pull/5