### PR TITLE
Use the NPM module name for the worker

### DIFF
--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -83,7 +83,8 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         """
         Returns the url of the javascript bundle into which the provider's JS will be loaded
         """
-        package = self.__class__.__module__.split('.')[0]
+        # use the defined npm_module name, or else the python package name
+        package = getattr(self, 'npm_module', self.__class__.__module__.split('.')[0])
         js_url = ''
         try:
             bundle_chunks = get_files(package, config="WORKERS")


### PR DESCRIPTION
Backend worker javascript wasn't being added to the page, because of disagreement about the worker name.