### PR TITLE
Add reviewed_by field to API

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -178,10 +178,11 @@ The following fields are optional::
 
     {
         "start": 123,
-        "stop": 144
+        "stop": 144,
+        "reviewed_by": "user@example.com"
     }
 
-(Start and stop are seconds relative to the start of the recorded proctoring session.)
+Start and stop are seconds relative to the start of the recorded proctoring session. ``reviewed_by`` must be included whenever a specific edX user (e.g. a member of a course team) initiated the review.
 
 
 Instructor Dashboard

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '1.5.4'
+__version__ = '1.5.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -11,6 +11,8 @@ import jwt
 from webpack_loader.utils import get_files
 from webpack_loader.exceptions import BaseWebpackLoaderException, WebpackBundleLookupError
 
+from django.contrib.auth.models import User
+
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.exceptions import BackendProviderCannotRegisterAttempt
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus, SoftwareSecureReviewStatus
@@ -199,6 +201,11 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         Called when the reviewing 3rd party service posts back the results
         """
         # REST backends should convert the payload into the expected data structure
+        if payload.get('reviewed_by', False):
+            try:
+                payload['reviewed_by'] = User.objects.get(email=payload['reviewed_by'])
+            except User.DoesNotExist:
+                payload['reviewed_by'] = None
         return payload
 
     def on_exam_saved(self, exam):

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -170,7 +170,8 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
         converted = {
             'status': review_status,
             'comments': comments,
-            'payload': payload
+            'payload': payload,
+            'reviewed_by': None,
         }
         return converted
 

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -10,6 +10,7 @@ from mock import patch
 
 from django.test import TestCase
 from django.utils import translation
+from django.contrib.auth.models import User
 
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import BackendProviderCannotRegisterAttempt
@@ -218,9 +219,10 @@ class RESTBackendTests(TestCase):
         status = self.provider.stop_exam_attempt(self.backend_exam['external_id'], attempt_id)
         self.assertEqual(status, 'stop')
 
-    @responses.activate
     def test_on_review_callback(self):
-        # on_review_callback should just return the payload
+        """
+        on_review_callback should just return the payload when called without review author
+        """
         attempt = {
             'id': 1,
             'external_id': 'abcd',
@@ -229,11 +231,47 @@ class RESTBackendTests(TestCase):
         payload = {
             'status': 'verified',
             'comments': [
-                {'comment': 'something happend', 'status': 'ok'}
+                {'comment': 'something happened', 'status': 'ok'}
             ]
         }
         new_payload = self.provider.on_review_callback(attempt, payload)
         self.assertEqual(payload, new_payload)
+
+    def test_on_review_callback_with_reviewer(self):
+        """
+        on_review_callback should find a user if an email is provided
+        """
+        person = User(
+            username='tester',
+            email='someone@example.com'
+        )
+        person.save()
+        attempt = {
+            'id': 1,
+            'external_id': 'abcd',
+            'user': 1
+        }
+
+        def payload_with_email(email):
+            """
+            generic payload with variable email
+            """
+            return {
+                'status': 'verified',
+                'comments': [
+                    {'comment': 'something happened', 'status': 'ok'},
+                ],
+                'reviewed_by': email,
+            }
+
+        payload = payload_with_email('someone@example.com')
+        new_payload = self.provider.on_review_callback(attempt, payload)
+        self.assertEqual(new_payload['reviewed_by'], person)
+
+        payload = payload_with_email('nonexistent+person@example.com')
+        new_payload = self.provider.on_review_callback(attempt, payload)
+
+        self.assertEqual(new_payload['reviewed_by'], None)
 
     def test_get_javascript(self):
         self.assertEqual(self.provider.get_javascript(), '')

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -840,12 +840,10 @@ class BaseReviewCallback(object):
         review.review_status = SoftwareSecureReviewStatus.from_standard_status.get(backend_review['status'])
 
         review.attempt_code = attempt_code
-        review.raw_data = json.dumps(backend_review)
+        review.raw_data = json.dumps(data)
         review.student_id = attempt['user']['id']
         review.exam_id = attempt['proctored_exam']['id']
-        # set reviewed_by to None because it was reviewed by our 3rd party
-        # service provider, not a user in our database
-        review.reviewed_by = None
+        review.reviewed_by = backend_review.get('reviewed_by', None)
 
         review.save()
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The old Software Secure logic requires two things to get an exam attempt into the "rejected" state:
1. The status used must be "suspicious", and
2. The review must have a user associated with it

We need to ask V. to do the former. This allows the latter.

[EDUCATOR-3890](https://openedx.atlassian.net/browse/EDUCATOR-3890)