### PR TITLE
Refactored config dashboard url

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -195,7 +195,7 @@ The ``get_instructor_url`` method of the backend will return a URL on the PS end
 By default, this URL will be ``base_url + u'/api/v1/instructor/{client_id}/?jwt={jwt}'``. This URL template is specified by the ``instructor_url`` property.
 You may override this property to modify the URL template.
 
-The `JWT <https://jwt.io/>`_ contains the following data::
+The JWT_ will be signed with the client_secret configured for the backend, and the decoded token contains the following data::
 
     {
         "course_id": <course id>,
@@ -203,14 +203,13 @@ The `JWT <https://jwt.io/>`_ contains the following data::
         "iss": <issuer>,
         "jti": <JWT id>,
         "exp": <expiration time>
-
     }
 
-By default, ``get_instructor_url`` may return two URLS.
+By default, ``get_instructor_url`` returns this URL:
 
 1. /api/v1/instructor/{client_id}/?jwt={jwt}
 
-    This URL will provide information that can be used for three different dashboards.
+    This URL will provide information that can be used for four different dashboards.
     
     1. course instructor dashboard
         This dashboard is on the course level and may show an overview of proctored exams in a particular course. Note that the ``course_id`` will be 
@@ -224,10 +223,8 @@ By default, ``get_instructor_url`` may return two URLS.
         This dashboard is on the exam attempt level and may show violations for a particular proctored exam attempt. Note that the ``course_id``, ``exam_id``,
         and ``attempt_id`` will be contained in the JWT.
 
-2. /api/v1/instructor/{client_id}/?jwt={jwt}&config=true
-
-    This URL will link to a configuration dashboard for configuring proctored exam options. Note that the ``course_id``
-    and ``exam_id`` will be contained in the JWT.
+    4. exam configuration dashboard
+        This dashboard should be used for configuring proctored exam options. Note that the ``course_id``, ``exam_id``, and ``config=true`` will be contained in the JWT.
 
 If you wish to modify the aforementioned logic, override the ``get_instructor_url`` method of the ``edx_proctoring.backends.rest.BaseRestProctoringProvider`` class.
 

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1753,14 +1753,17 @@ def _get_proctored_exam_context(exam, attempt, user_id, course_id, is_practice_e
         'provider_name': provider.verbose_name,
     }
     if attempt:
-        provider_attempt = provider.get_attempt(attempt)
-        download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
+        context['exam_code'] = attempt['attempt_code']
+        if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
+                                 ProctoredExamStudentAttemptStatus.download_software_clicked):
+            # since this may make an http request, let's not include it on every page
+            provider_attempt = provider.get_attempt(attempt)
+            download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
 
-        context.update({
-            'exam_code': attempt['attempt_code'],
-            'backend_instructions': provider_attempt.get('instructions', None),
-            'software_download_url': download_url,
-        })
+            context.update({
+                'backend_instructions': provider_attempt.get('instructions', None),
+                'software_download_url': download_url,
+            })
     return context
 
 

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -262,13 +262,12 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         }
         if exam_id:
             token['exam_id'] = exam_id
+            if show_configuration_dashboard:
+                token['config'] = True
             if attempt_id:
                 token['attempt_id'] = attempt_id
         encoded = jwt.encode(token, self.client_secret)
         url = self.instructor_url.format(client_id=self.client_id, jwt=encoded)
-
-        if show_configuration_dashboard:
-            url += '&config=true'
 
         log.debug('Created instructor url for %r %r %r', course_id, exam_id, attempt_id)
         return url

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -333,7 +333,10 @@ class RESTBackendTests(TestCase):
             exam_id=exam_id,
             show_configuration_dashboard=True,
         )
-        self.assertIn('&config=true', config_url)
-        self.assertNotEqual(config_url, base_url)
-        self.assertNotEqual(config_url, exam_url)
-        self.assertNotEqual(config_url, attempt_url)
+        token = config_url.split('jwt=')[1]
+        decoded = jwt.decode(token,
+                             issuer=self.provider.client_id,
+                             key=self.provider.client_secret,
+                             algorithms=['HS256'])
+        self.assertTrue(decoded['config'])
+        self.assertEqual(decoded['exam_id'], exam_id)


### PR DESCRIPTION
The config option will now be included in the JWT sent to the backend, rather than in a query string.

Also: prevented attempt from being requested on every page