### PR TITLE
EDUCATOR-3953 -- defining onboarding errors

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -104,11 +104,18 @@ Exam attempt endpoint
         "user_name": "Joe Smith"
     }
 
-The PS system should respond with an object containing at least the following fields::
+The PS server must respond with an object containing at least the following fields::
 
     {
         "id": "<some opaque id for the attempt>",
     }
+
+The PS server can block the user from taking a proctored exam if onboarding prerequistes haven't been met. Return an object with ``status`` set to one of the following:
+
+    * ``onboarding_missing``: The user has not completed an onboarding exam.
+    * ``onboarding_pending``: The user has taken an onboarding exam, but it is pending review.
+    * ``onboarding_failed``: The user failed the onboarding exam requirements.
+    * ``onboarding_expired``: The onboarding profile has expired, requiring the user to re-take an onboarding exam.
 
 ..
 

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -12,7 +12,11 @@ from webpack_loader.utils import get_files
 from webpack_loader.exceptions import BaseWebpackLoaderException, WebpackBundleLookupError
 
 from edx_proctoring.backends.backend import ProctoringBackendProvider
-from edx_proctoring.exceptions import BackendProviderCannotRegisterAttempt, BackendProviderCannotRetireUser
+from edx_proctoring.exceptions import (
+    BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRetireUser,
+    BackendProviderOnboardingException,
+)
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus, SoftwareSecureReviewStatus
 from edx_rest_api_client.client import OAuthAPIClient
 
@@ -173,6 +177,9 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             raise BackendProviderCannotRegisterAttempt(response.content)
         response = response.json()
         log.debug(response)
+        onboarding_status = response.get('status', None)
+        if onboarding_status in ProctoredExamStudentAttemptStatus.onboarding_errors:
+            raise BackendProviderOnboardingException(onboarding_status)
         return response['id']
 
     def start_exam_attempt(self, exam, attempt):

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -14,7 +14,7 @@ from edx_proctoring.backends import get_backend_provider
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.backends.null import NullBackendProvider
 from edx_proctoring.backends.mock import MockProctoringBackendProvider
-from edx_proctoring.exceptions import BackendProviderCannotRetireUser
+from edx_proctoring.exceptions import BackendProviderCannotRetireUser, BackendProviderOnboardingException
 
 # pragma pylint: disable=useless-super-delegation
 
@@ -26,11 +26,14 @@ class TestBackendProvider(ProctoringBackendProvider):
     last_exam = None
     has_dashboard = True
     last_retire_user = None
+    attempt_error = None
 
     def register_exam_attempt(self, exam, context):
         """
         Called when the exam attempt has been created but not started
         """
+        if self.attempt_error:
+            raise BackendProviderOnboardingException(self.attempt_error)
         return 'testexternalid'
 
     def start_exam_attempt(self, exam, attempt):

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -16,8 +16,9 @@ from edx_proctoring.backends.rest import BaseRestProctoringProvider
 from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
     BackendProviderCannotRetireUser,
-    BackendProviderOnboardingException
+    BackendProviderOnboardingException,
 )
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
 
 @ddt.ddt
@@ -203,12 +204,8 @@ class RESTBackendTests(TestCase):
             self.provider.register_exam_attempt(self.backend_exam, context)
 
     @ddt.data(
-        ['onboarding_missing'],
-        ['onboarding_pending'],
-        ['onboarding_failed'],
-        ['onboarding_expired'],
+        *ProctoredExamStudentAttemptStatus.onboarding_errors
     )
-    @ddt.unpack
     @responses.activate
     def test_attempt_failure_onboarding(self, failure_status):
         context = {

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -13,7 +13,11 @@ from django.test import TestCase
 from django.utils import translation
 
 from edx_proctoring.backends.rest import BaseRestProctoringProvider
-from edx_proctoring.exceptions import BackendProviderCannotRegisterAttempt, BackendProviderCannotRetireUser
+from edx_proctoring.exceptions import (
+    BackendProviderCannotRegisterAttempt,
+    BackendProviderCannotRetireUser,
+    BackendProviderOnboardingException
+)
 
 
 @ddt.ddt
@@ -197,6 +201,32 @@ class RESTBackendTests(TestCase):
         )
         with self.assertRaises(BackendProviderCannotRegisterAttempt):
             self.provider.register_exam_attempt(self.backend_exam, context)
+
+    @ddt.data(
+        ['onboarding_missing'],
+        ['onboarding_pending'],
+        ['onboarding_failed'],
+        ['onboarding_expired'],
+    )
+    @ddt.unpack
+    @responses.activate
+    def test_attempt_failure_onboarding(self, failure_status):
+        context = {
+            'attempt_code': '2',
+            'obs_user_id': 'abcdefghij',
+            'full_name': 'user name',
+            'lms_host': 'http://lms.com'
+        }
+        responses.add(
+            responses.POST,
+            url=self.provider.create_exam_attempt_url.format(exam_id=self.backend_exam['external_id']),
+            json={'status': failure_status},
+            status=200
+        )
+        with self.assertRaises(BackendProviderOnboardingException) as exc_manager:
+            self.provider.register_exam_attempt(self.backend_exam, context)
+        exception = exc_manager.exception
+        assert exception.status == failure_status
 
     @ddt.data(
         ['start_exam_attempt', 'start'],

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -77,6 +77,16 @@ class BackendProviderCannotRegisterAttempt(ProctoredBaseException):
     """
 
 
+class BackendProviderOnboardingException(ProctoredBaseException):
+    """
+    Raised when a back-end provider cannot register an attempt
+    because of missing/failed onboarding requirements
+    """
+    def __init__(self, status):
+        ProctoredBaseException.__init__(self, status)
+        self.status = status
+
+
 class ProctoredExamPermissionDenied(ProctoredBaseException):
     """
     Raised when the calling user does not have access to the requested object.

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -335,11 +335,12 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
     @classmethod
     def create_exam_attempt(cls, exam_id, user_id, student_name, attempt_code,
                             taking_as_proctored, is_sample_attempt, external_id,
-                            review_policy_id=None):
+                            review_policy_id=None, status=None):
         """
         Create a new exam attempt entry for a given exam_id and
         user_id.
         """
+        status = status or ProctoredExamStudentAttemptStatus.created
         return cls.objects.create(
             proctored_exam_id=exam_id,
             user_id=user_id,
@@ -348,7 +349,7 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
             taking_as_proctored=taking_as_proctored,
             is_sample_attempt=is_sample_attempt,
             external_id=external_id,
-            status=ProctoredExamStudentAttemptStatus.created,
+            status=status,
             review_policy_id=review_policy_id
         )  # pylint: disable=no-member
 

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -64,6 +64,18 @@ class ProctoredExamStudentAttemptStatus(object):
     # the course end date has passed
     expired = 'expired'
 
+    # onboarding failure states
+    # the user hasn't taken an onboarding exam
+    onboarding_missing = 'onboarding_missing'
+    # the onboarding exam is pending review
+    onboarding_pending = 'onboarding_pending'
+    # the user failed onboarding
+    onboarding_failed = 'onboarding_failed'
+    # the onboarding data expired
+    onboarding_expired = 'onboarding_expired'
+
+    onboarding_errors = (onboarding_missing, onboarding_pending, onboarding_failed, onboarding_expired)
+
     @classmethod
     def is_completed_status(cls, status):
         """
@@ -72,7 +84,8 @@ class ProctoredExamStudentAttemptStatus(object):
         """
         return status in [
             cls.declined, cls.timed_out, cls.submitted, cls.second_review_required,
-            cls.verified, cls.rejected, cls.error
+            cls.verified, cls.rejected, cls.error,
+            cls.onboarding_missing, cls.onboarding_pending, cls.onboarding_failed, cls.onboarding_expired
         ]
 
     @classmethod

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -64,7 +64,7 @@ from edx_proctoring.exceptions import (
     ProctoredExamPermissionDenied,
     AllowanceValueNotAllowedException,
     ProctoredExamReviewPolicyAlreadyExists,
-    ProctoredExamReviewPolicyNotFoundException
+    ProctoredExamReviewPolicyNotFoundException,
 )
 from edx_proctoring.models import (
     ProctoredExam,
@@ -543,6 +543,20 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
 
         attempt = get_exam_attempt_by_id(attempt_id)
         self.assertEqual(attempt['allowed_time_limit_mins'], self.default_time_limit + allowed_extra_time)
+
+    @ddt.data(
+        *ProctoredExamStudentAttemptStatus.onboarding_errors
+    )
+    def test_attempt_onboarding_error(self, onboarding_error):
+        """
+        Test that onboarding errors move the attempt to an errored state
+        """
+        test_backend = get_backend_provider(name='test')
+        test_backend.attempt_error = onboarding_error
+        attempt_id = create_exam_attempt(self.proctored_exam_id, self.user_id, taking_as_proctored=True)
+        attempt = get_exam_attempt_by_id(attempt_id)
+        assert attempt['status'] == onboarding_error
+        test_backend.attempt_error = None
 
     def test_no_existing_attempt(self):
         """


### PR DESCRIPTION
In order to exercise the various error workflows, mockprock should be changed to return onboarding errors based on some condition. 