### PR TITLE
Changed error response for retirement endpoint

### DIFF
--- a/edx_proctoring/tests/__init__.py
+++ b/edx_proctoring/tests/__init__.py
@@ -1,6 +1,9 @@
 """
 Monkeypatches the default backends
 """
+from __future__ import absolute_import
+
+import rules
 
 
 def setup_test_backends():
@@ -17,4 +20,13 @@ def setup_test_backends():
     config.backends['mock'] = MockProctoringBackendProvider()
 
 
+def setup_test_perms():
+    """
+    Create missing permissions that would be defined in edx-platform,
+    or elsewhere
+    """
+    rules.add_perm('accounts.can_retire_user', rules.is_staff)
+
+
 setup_test_backends()
+setup_test_perms()

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2677,7 +2677,7 @@ class TestBackendUserDeletion(LoggedInTestCase):
     def test_can_delete_user(self):
         deletion_url = reverse('edx_proctoring:backend_user_deletion_api', kwargs={'user_id': self.second_user.id})
 
-        response = self.client.delete(deletion_url)
+        response = self.client.post(deletion_url)
         assert response.status_code == 200
         data = response.json()
         # if there is no user data, then no deletion happens
@@ -2695,7 +2695,7 @@ class TestBackendUserDeletion(LoggedInTestCase):
         )
         create_exam_attempt(proctored_exam.id, self.second_user.id, True)
 
-        response = self.client.delete(deletion_url)
+        response = self.client.post(deletion_url)
         assert response.status_code == 200
         data = response.json()
         # if there is an attempt, we'll try to delete from the backend
@@ -2704,7 +2704,7 @@ class TestBackendUserDeletion(LoggedInTestCase):
         assert test_backend.last_retire_user is not None
 
         # running a second time will return a false status
-        response = self.client.delete(deletion_url)
+        response = self.client.post(deletion_url)
         assert response.status_code == 500
         data = response.json()
         assert len(data) == 1
@@ -2714,5 +2714,5 @@ class TestBackendUserDeletion(LoggedInTestCase):
         self.client.login_user(self.second_user)
         deletion_url = reverse('edx_proctoring:backend_user_deletion_api', kwargs={'user_id': self.user.id})
 
-        response = self.client.delete(deletion_url)
+        response = self.client.post(deletion_url)
         assert response.status_code == 403

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -91,7 +91,7 @@ urlpatterns = [
         name='instructor_dashboard_course'
     ),
     url(
-        r'edx_proctoring/v1/backend_user/(?P<user_id>[\d]+)/$',
+        r'edx_proctoring/v1/retire_backend_user/(?P<user_id>[\d]+)/$',
         views.BackendUserManagementAPI.as_view(),
         name='backend_user_deletion_api'
     ),

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1032,7 +1032,7 @@ class BackendUserManagementAPI(AuthenticatedAPIView):
     """
     Manage user information stored on the backends
     """
-    def delete(self, request, user_id):  # pylint: disable=unused-argument
+    def post(self, request, user_id):  # pylint: disable=unused-argument
         """
         Deletes all user data for the particular user_id
         from all configured backends

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,6 +12,7 @@ django-crum
 python-dateutil>=2.1
 django-webpack-loader>=0.6.0
 django-waffle
+rules
 
 # edX packages
 event-tracking>=0.2.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,6 +33,7 @@ python-dateutil==2.7.5
 pytz==2018.9
 requests==2.21.0          # via edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions
+rules==2.0.1
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.12.0               # via edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, stevedore
 slumber==0.7.1            # via edx-rest-api-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,6 +54,7 @@ pyyaml==3.13              # via edx-i18n-tools
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.8.0  # via twine
 requests==2.21.0          # via caniusepython3, requests-toolbelt, twine
+rules==2.0.1
 scandir==1.9.0            # via pathlib2
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.12.0               # via astroid, bleach, diff-cover, edx-i18n-tools, edx-lint, packaging, pathlib2, pip-tools, pydocstyle, pylint, readme-renderer, singledispatch, tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -48,6 +48,7 @@ readme-renderer==24.0
 requests==2.21.0          # via edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber, sphinx
 rest-condition==1.0.3     # via edx-drf-extensions
 restructuredtext-lint==1.2.2  # via doc8
+rules==2.0.1
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.12.0               # via bleach, doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, packaging, pockets, pyjwkest, python-dateutil, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 slumber==0.7.1            # via edx-rest-api-client

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -57,6 +57,7 @@ pytz==2018.9
 requests==2.21.0          # via edx-drf-extensions, edx-rest-api-client, httmock, pyjwkest, responses, slumber
 responses==0.10.5
 rest-condition==1.0.3     # via edx-drf-extensions
+rules==2.0.1
 scandir==1.9.0            # via pathlib2
 selenium==3.141.0
 semantic-version==2.6.0   # via edx-drf-extensions

--- a/test_settings.py
+++ b/test_settings.py
@@ -46,7 +46,13 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'rest_framework',
     'edx_proctoring',
+    'rules.apps.AutodiscoverRulesConfig',
 )
+
+AUTHENTICATION_BACKENDS = [
+    'rules.permissions.ObjectPermissionBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/


### PR DESCRIPTION
This changes the error response to a 500, so that the retirement pipeline will properly fail. 

It also checks the authenticated user against the retirement permission, which is defined in edx-platform [#19690](https://github.com/edx/edx-platform/pull/19690)