### PR TITLE
Prevent negative exam durations

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1714,7 +1714,7 @@ def _calculate_allowed_mins(exam, user_id):
         if current_datetime + timedelta(minutes=allowed_time_limit_mins) > due_datetime:
             # e.g current_datetime=09:00, due_datetime=10:00 and allowed_mins=120(2hours)
             # then allowed_mins should be 60(1hour)
-            allowed_time_limit_mins = int((due_datetime - current_datetime).total_seconds() / 60)
+            allowed_time_limit_mins = max(int((due_datetime - current_datetime).total_seconds() / 60), 0)
 
     return allowed_time_limit_mins
 


### PR DESCRIPTION
In corner cases in which users hold onto an intermediate proctoring
session state over the deadline for starting an exam, it's possible
the time still remaining to them may flip into the red. In that case,
we want to normalize it back to 0, so the time displayed to course
teams doesn't seem physically impossible.

JIRA:EDUCATOR-3993