### PR TITLE
Gate onboarding exams with the same user permission as proctored exams

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '1.5.16'
+__version__ = '1.5.17'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1814,6 +1814,11 @@ def _get_onboarding_exam_view(exam, context, exam_id, user_id, course_id):
     """
     Returns a rendered view for onboarding exams, which for some backends establish a user's profile
     """
+    user = USER_MODEL.objects.get(id=user_id)
+
+    if not user.has_perm('edx_proctoring.can_take_proctored_exam', exam):
+        return None
+
     student_view_template = None
 
     attempt = get_exam_attempt(exam_id, user_id)

--- a/edx_proctoring/tests/__init__.py
+++ b/edx_proctoring/tests/__init__.py
@@ -3,6 +3,7 @@ Monkeypatches the default backends
 """
 from __future__ import absolute_import
 
+import contextlib
 import rules
 
 
@@ -20,6 +21,18 @@ def setup_test_backends():
     config.backends['mock'] = MockProctoringBackendProvider()
 
 
+@contextlib.contextmanager
+def mock_perm(perm='edx_proctoring.can_take_proctored_exam'):
+    """
+    Context manager for mocking a specific permission to return False inside the block
+    """
+    try:
+        rules.set_perm(perm, rules.always_false)
+        yield
+    finally:
+        rules.set_perm(perm, rules.always_true)
+
+
 def setup_test_perms():
     """
     Create missing permissions that would be defined in edx-platform,
@@ -30,11 +43,11 @@ def setup_test_perms():
     """
     try:
         rules.add_perm('accounts.can_retire_user', rules.is_staff)
-    except KeyError:
+    except KeyError:  # pragma: no cover
         pass
     try:
-        rules.add_perm('edx_proctoring.can_take_proctored_exam', rules.is_authenticated)
-    except KeyError:
+        rules.add_perm('edx_proctoring.can_take_proctored_exam', rules.always_true)
+    except KeyError:  # pragma: no cover
         pass
 
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -78,6 +78,7 @@ from edx_proctoring.models import (
 )
 from edx_proctoring.runtime import set_runtime_service, get_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.tests import mock_perm
 
 from .test_services import (
     MockCreditService,
@@ -1625,7 +1626,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         """
         set_runtime_service('credit', MockCreditService(enrollment_mode='verified'))
         exam_attempt = self._create_started_exam_attempt()
-        with patch('django.contrib.auth.models.User.is_authenticated', False):
+        with mock_perm('edx_proctoring.can_take_proctored_exam'):
             summary = get_attempt_status_summary(
                 self.user.id,
                 exam_attempt.proctored_exam.course_id,

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -30,6 +30,7 @@ from edx_proctoring.models import (
 )
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.tests import mock_perm
 
 from .test_services import MockCreditServiceWithCourseEndDate, MockCreditServiceNone
 from .utils import ProctoredExamTestCase
@@ -743,7 +744,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         to view proctored exams, this should return None
         (For edx-proctoring tests, only authenticated students have the permission)
         """
-        with patch('django.contrib.auth.models.User.is_authenticated', False):
+        with mock_perm('edx_proctoring.can_take_proctored_exam'):
             rendered_response = self.render_proctored_exam()
         self.assertIsNone(rendered_response)
 
@@ -768,7 +769,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         """
         Test that onboarding exams are gated by the same permission as proctored exams
         """
-        with patch('django.contrib.auth.models.User.is_authenticated', False):
+        with mock_perm('edx_proctoring.can_take_proctored_exam'):
             rendered_response = self.render_onboarding_exam()
         self.assertIsNone(rendered_response)
 

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -764,6 +764,14 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         rendered_response = self.render_onboarding_exam()
         self.assertIn('Proctoring onboarding exam', rendered_response)
 
+    def test_get_onboarding_no_perm(self):
+        """
+        Test that onboarding exams are gated by the same permission as proctored exams
+        """
+        with patch('django.contrib.auth.models.User.is_authenticated', False):
+            rendered_response = self.render_onboarding_exam()
+        self.assertIsNone(rendered_response)
+
     @ddt.data(
         (ProctoredExamStudentAttemptStatus.created,
          'Follow these steps to set up and start your proctored exam'),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[EDUCATOR-4137](https://openedx.atlassian.net/browse/EDUCATOR-4137)