### PR TITLE
Proctoring - avoid multiple visits to download_software_clicked-land

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '1.5.17'
+__version__ = '1.5.18'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -120,8 +120,18 @@
     }
   );
 
-  function check_exam_started(e) {
+  function handle_start_exam(e) {
     e.preventDefault();
+    check_exam_started(function() {
+      // The proctoring setup is not yet complete.
+      // Show a modal indicating that the user is not done yet.
+      edx.courseware.proctored_exam.accessibleError(
+        gettext("Cannot Start Proctored Exam"),
+        gettext("You must complete the proctoring setup before you can start the exam.")
+      );
+    });
+  }
+  function check_exam_started(failureCallback) {
     var url = $('.instructions').data('exam-started-poll-url') + '?sourceid=instructions';
     $.ajax(url).success(function(data){
       if (data.status === 'ready_to_start') {
@@ -129,27 +139,18 @@
         // to reflect the new state (which will expose the test)
         location.reload();
       } else {
-          // The proctoring setup is not yet complete.
-          // Show a modal indicating that the user is not done yet.
-          edx.courseware.proctored_exam.accessibleError(
-              gettext("Cannot Start Proctored Exam"),
-              gettext("You must complete the proctoring setup before you can start the exam.")
-          );
+        failureCallback();
       }
     });
   }
 
-  $('.start-proctored-exam').click(check_exam_started);
-
-  $("#software_download_link").click(function (e) {
-    e.preventDefault();
+  function launchSystemCheck() {
     var url = $('.instructions').data('exam-started-poll-url');
-    var action = $(this).data('action');
+    var action = $('#software_download_link').data('action');
     // open the new tab in the click event with an empty URL but show the message.
     var newWindow = window.open("", "_blank");
     $(newWindow.document.body).html("<p>Please wait while you are being redirected...</p>");
 
-    var self = this;
     $.ajax({
       url: url,
       type: 'PUT',
@@ -162,6 +163,14 @@
     }).fail(function(){
       newWindow.close();
     });
+
+  }
+
+  $('.start-proctored-exam').click(handle_start_exam);
+
+  $("#software_download_link").click(function (e) {
+    e.preventDefault();
+    check_exam_started(launchSystemCheck);
   });
 {{backend_js|safe}}
 </script>

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -69,7 +69,7 @@
     </p>
     {% endif %}
     <div class="footer-sequence border-b-0 padding-b-0">
-      <a href="#" class="start-proctored-exam">{% trans "Start Proctored Exam" %}</a>
+      <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Proctored Exam" %}</button>
     </div>
   </div>
 </div>
@@ -88,7 +88,6 @@
 {% include 'proctored_exam/footer.html' %}
 
 <script type="text/javascript">
-
   $('.proctored-decline-exam').click(
     function(e) {
       e.preventDefault();
@@ -120,24 +119,18 @@
     }
   );
 
-  function handle_start_exam(e) {
-    e.preventDefault();
-    check_exam_started(function() {
-      // The proctoring setup is not yet complete.
-      // Show a modal indicating that the user is not done yet.
-      edx.courseware.proctored_exam.accessibleError(
-        gettext("Cannot Start Proctored Exam"),
-        gettext("You must complete the proctoring setup before you can start the exam.")
-      );
-    });
+  function setPrimacyOfButtons(systemCheckIsPrimary) {
+    var $primaryButton = systemCheckIsPrimary ? $('#software_download_link') : $('.js-start-proctored-exam');
+    var $secondaryButton = systemCheckIsPrimary ? $('.js-start-proctored-exam') : $('#software_download_link');
+    $primaryButton.removeClass('btn-secondary').addClass('btn-pl-primary');
+    $secondaryButton.removeClass('btn-pl-primary').addClass('btn-secondary');
   }
-  function check_exam_started(failureCallback) {
+
+  function check_exam_started(successCallback, failureCallback) {
     var url = $('.instructions').data('exam-started-poll-url') + '?sourceid=instructions';
     $.ajax(url).success(function(data){
       if (data.status === 'ready_to_start') {
-        // we've state transitioned, so refresh the page
-        // to reflect the new state (which will expose the test)
-        location.reload();
+        successCallback();
       } else {
         failureCallback();
       }
@@ -145,6 +138,7 @@
   }
 
   function launchSystemCheck() {
+    setPrimacyOfButtons(false);
     var url = $('.instructions').data('exam-started-poll-url');
     var action = $('#software_download_link').data('action');
     // open the new tab in the click event with an empty URL but show the message.
@@ -163,14 +157,35 @@
     }).fail(function(){
       newWindow.close();
     });
-
   }
 
-  $('.start-proctored-exam').click(handle_start_exam);
+  $('.js-start-proctored-exam').click(function(e) {
+    e.preventDefault();
+    check_exam_started(function() {
+      // we've state transitioned, so refresh the page
+      // to reflect the new state (which will expose the test)
+      location.reload();
+    }, function() {
+      // The proctoring setup is not yet complete.
+      // Show a modal indicating that the user is not done yet.
+      edx.courseware.proctored_exam.accessibleError(
+        gettext("Cannot Start Proctored Exam"),
+        gettext("You must complete the proctoring setup before you can start the exam.")
+      );
+      setPrimacyOfButtons(true);
+    });
+  });
 
   $("#software_download_link").click(function (e) {
     e.preventDefault();
-    check_exam_started(launchSystemCheck);
+    check_exam_started(function() {
+      // The proctoring setup is complete.
+      // Show a modal indicating that the user is ready to proceed.
+      edx.courseware.proctored_exam.accessibleError(
+        gettext("System Check Succeeded"),
+        gettext('Click "Start Proctored Exam" to proceed.')
+      );
+      setPrimacyOfButtons(false);
+    }, launchSystemCheck);
   });
-{{backend_js|safe}}
 </script>

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -4,7 +4,7 @@
   <div class="">
     <h3>
     {% blocktrans %}
-      Follow these steps to set up and start your proctored exam.
+      Set up and start your proctored exam.
     {% endblocktrans %}
     </h3>
     {% if backend_instructions %}
@@ -31,45 +31,57 @@
       {% endif %}
       <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
     {% else %}
-    <p>
-      {% blocktrans %}
-        1. Copy this unique exam code. You will be prompted to paste this code later before you start the exam.
-      {% endblocktrans %}
-    </p>
+      <h4>
+        {% blocktrans %}
+          Step 1
+        {% endblocktrans %}
+      </h4>
+      <p>
+        {% blocktrans %}
+          Copy this unique exam code. You will be prompted to paste this code later before you start the exam.
+        {% endblocktrans %}
+      </p>
     <p>
       <span class="proctored-exam-code">{{exam_code}}</span>
     </p>
     <p>
       {% blocktrans %}
-        Select the exam code, then copy it using Command+C (Mac) or Control+C (Windows).
+        Select the exam code, then copy it using Control + C (Windows) or Command + C (Mac).
+      {% endblocktrans %}
+    </p>
+      <h4>
+        {% blocktrans %}
+          Step 2
+        {% endblocktrans %}
+      </h4>
+    <p>
+      {% blocktrans %}
+        Start your system check now. A new window will open for this step and you will verify your identity.
       {% endblocktrans %}
     </p>
     <p>
       {% blocktrans %}
-        2. Click the button below to set up proctoring.
+        Make sure you:
       {% endblocktrans %}
     </p>
+    <ul>
+      <li>{% blocktrans %}Have a computer with a functioning webcam{% endblocktrans %}</li>
+      <li>{% blocktrans %}Have your valid photo ID (e.g. driver's license or passport) ready{% endblocktrans %}</li>
+    </ul>
     <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
-    <p>
-      {% blocktrans %}
-        A new window will open. You will run a system check before downloading the proctoring application.
-      {% endblocktrans %}
-    </p>
-    <p>
-      {% blocktrans %}
-        You will be asked to verify your identity as part of the proctoring exam set up.
-        Make sure you are on a computer with a webcam, and that you have valid photo identification
-        such as a driver's license or passport, before you continue.
-      {% endblocktrans %}
-    </p>
+      <h4>
+        {% blocktrans %}
+          Step 3
+        {% endblocktrans %}
+      </h4>
     <p>
         {% blocktrans %}
-          3. When you have finished setting up proctoring, start the exam.
+          When you've finished the system check and verified your identity, begin your exam.
         {% endblocktrans %}
     </p>
     {% endif %}
     <div class="footer-sequence border-b-0 padding-b-0">
-      <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Proctored Exam" %}</button>
+      <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Exam" %}</button>
     </div>
   </div>
 </div>

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 <div class="sequence proctored-exam instructions message-left-bar" data-exam-id="{{exam_id}}" data-exam-started-poll-url="{{exam_started_poll_url}}">
 
-  <div class="">
+  <div>
     <h3>
     {% blocktrans %}
-      Set up and start your proctored exam.
+      Set up and start your proctored exam
     {% endblocktrans %}
     </h3>
     {% if backend_instructions %}
@@ -30,6 +30,9 @@
         </p>
       {% endif %}
       <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
+      <div class="footer-sequence border-b-0 padding-b-0">
+        <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Exam" %}</button>
+      </div>
     {% else %}
       <h4>
         {% blocktrans %}
@@ -79,10 +82,8 @@
           When you've finished the system check and verified your identity, begin your exam.
         {% endblocktrans %}
     </p>
+    <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Exam" %}</button>
     {% endif %}
-    <div class="footer-sequence border-b-0 padding-b-0">
-      <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Exam" %}</button>
-    </div>
   </div>
 </div>
 {% include 'proctored_exam/error_modal.html' %}

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -58,7 +58,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         self.submitted_timed_exam_msg_with_due_date = 'After the due date has passed,'
         self.exam_time_expired_msg = 'You did not complete the exam in the allotted time'
         self.exam_time_error_msg = 'A technical error has occurred with your proctored exam'
-        self.chose_proctored_exam_msg = 'Follow these steps to set up and start your proctored exam'
+        self.chose_proctored_exam_msg = 'Set up and start your proctored exam'
         self.proctored_exam_optout_msg = 'Take this exam without proctoring'
         self.proctored_exam_completed_msg = 'Are you sure you want to end your proctored exam'
         self.proctored_exam_submitted_msg = 'You have submitted this proctored exam for review'
@@ -775,9 +775,9 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
 
     @ddt.data(
         (ProctoredExamStudentAttemptStatus.created,
-         'Follow these steps to set up and start your proctored exam'),
+         'Set up and start your proctored exam'),
         (ProctoredExamStudentAttemptStatus.download_software_clicked,
-         'Follow these steps to set up and start your proctored exam'),
+         'Set up and start your proctored exam'),
         (ProctoredExamStudentAttemptStatus.ready_to_start,
          'Proctored Exam Rules'),
         (ProctoredExamStudentAttemptStatus.error,
@@ -806,9 +806,9 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
 
     @ddt.data(
         (ProctoredExamStudentAttemptStatus.created,
-         'Follow these steps to set up and start your proctored exam'),
+         'Set up and start your proctored exam'),
         (ProctoredExamStudentAttemptStatus.download_software_clicked,
-         'Follow these steps to set up and start your proctored exam'),
+         'Set up and start your proctored exam'),
         (ProctoredExamStudentAttemptStatus.submitted,
          'You have submitted this practice proctored exam'),
         (ProctoredExamStudentAttemptStatus.error,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Working with Alyssa to close a UX hole re: the proctored exam flow's instructions page. Changes the CTAs on those pages to alternate which CTA is given primary treatment according to our best approximation of what the user's next step is. On user interaction, we validate whether the user is ready to proceed and, if the user's action was inappropriate for the step of the flow they're on, we guide them with error modals.