### PR TITLE
allow status transitions from completed statuses to error

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '1.5.20'
+__version__ = '1.5.21'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -824,21 +824,6 @@ def update_attempt_status(exam_id, user_id, to_status,
         )
         raise ProctoredExamIllegalStatusTransition(err_msg)
 
-    # special case logic, if we are in a completed status we shouldn't allow
-    # for a transition to 'Error' state
-    if in_completed_status and to_status == ProctoredExamStudentAttemptStatus.error:
-        err_msg = (
-            'A status transition from {from_status} to {to_status} was attempted '
-            'on exam_id {exam_id} for user_id {user_id}. This is not '
-            'allowed!'.format(
-                from_status=from_status,
-                to_status=to_status,
-                exam_id=exam_id,
-                user_id=user_id
-            )
-        )
-        raise ProctoredExamIllegalStatusTransition(err_msg)
-
     # OK, state transition is fine, we can proceed
     exam_attempt_obj.status = to_status
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -1199,7 +1199,6 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         (ProctoredExamStudentAttemptStatus.verified, ProctoredExamStudentAttemptStatus.started),
         (ProctoredExamStudentAttemptStatus.rejected, ProctoredExamStudentAttemptStatus.started),
         (ProctoredExamStudentAttemptStatus.error, ProctoredExamStudentAttemptStatus.started),
-        (ProctoredExamStudentAttemptStatus.submitted, ProctoredExamStudentAttemptStatus.error),
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -414,7 +414,9 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
         elif action == 'error':
             backend = attempt['proctored_exam']['backend']
             waffle_name = PING_FAILURE_PASSTHROUGH_TEMPLATE.format(backend)
-            should_block_user = not (backend and waffle.switch_is_active(waffle_name))
+            should_block_user = not (backend and waffle.switch_is_active(waffle_name)) and (
+                not attempt['status'] == ProctoredExamStudentAttemptStatus.submitted
+            )
             if should_block_user:
                 exam_attempt_id = update_attempt_status(
                     attempt['proctored_exam']['id'],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
adds a separate mechanism to prevent submitted -> error transition from the JS ping check (since it may well happen if the learner has multiple tabs open each running our pinging JS)

Verified these transitions aren't prevented for existing RPNow integration via this splunk query (splunk is dumb and I can't share it as a report unfortunately): `index="prod-edx" source="/edx/var/log/lms/edx.log" | search "ProctoredExamIllegalStatusTransition: A status transition from" | rex field=_raw "ProctoredExamIllegalStatusTransition: A status transition from (?P<from_status>[a-z_]+) to (?P<to_status>[a-z_]+) was attempted" | fields from_status to_status | stats count(_raw) by from_status to_status`