### PR TITLE
Eliminate the false promise of returning to exam content

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1725,7 +1725,7 @@ def _get_proctored_exam_context(exam, attempt, user_id, course_id, is_practice_e
         'is_sample_attempt': is_practice_exam,
         'has_due_date': has_due_date,
         'has_due_date_passed': has_due_date_passed(exam['due_date']),
-        'does_time_remain': _does_time_remain(attempt),
+        'able_to_reenter_exam': _does_time_remain(attempt) and not provider.should_block_access_to_exam_material(),
         'enter_exam_endpoint': reverse('edx_proctoring:proctored_exam.attempt.collection'),
         'exam_started_poll_url': reverse(
             'edx_proctoring:proctored_exam.attempt',

--- a/edx_proctoring/templates/proctored_exam/ready_to_submit.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_submit.html
@@ -6,7 +6,9 @@
     {% endblocktrans %}
   </h3>
   <ul>
-    <li> {% trans 'Make sure that you have selected "Submit" for each answer before you submit your exam.' %}</li>
+    {% if able_to_reenter_exam %}
+      <li> {% trans 'Make sure that you have selected "Submit" for each answer before you submit your exam.' %}</li>
+    {% endif %}
     <li> {% trans 'Once you click "Yes, end my proctored exam", the exam will be closed, and your proctoring session will be submitted for review.' %}</li>
   </ul>
   {% block additional_exhortation %}{% endblock %}
@@ -14,7 +16,7 @@
   <button type="button" name="submit-proctored-exam" class="exam-action-button btn btn-pl-primary btn-base" data-action="submit" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-loading-text="<span class='fa fa-circle-o-notch fa-spin'></span> {% trans 'Ending Exam' %}" data-cta-text="{{ end_exam }}">
     {{ end_exam }}
   </button>
-  {% if does_time_remain %}
+  {% if able_to_reenter_exam %}
     <button type="button" name="goback-proctored-exam" class="exam-action-button btn btn-secondary btn-base" data-action="start" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" style="box-shadow: none">
       {% blocktrans %}
         No, I'd like to continue working


### PR DESCRIPTION
When viewed from the "wrong" (i.e. non-RPNow) browser, the learner
can't really immediately get back into the content of their exam. This
eliminates the option of going back for learners who view the exam
this way (which may occur for learners who close RPNow out-of-sequence
with what's expected).

JIRA:EDUCATOR-4218