### PR TITLE
Add support for django-pipeline 1.6+

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/settings/common.py
+++ b/edx_proctoring/settings/common.py
@@ -1,8 +1,12 @@
-"Common Pluggable Django App settings"
+"""
+Common Pluggable Django App settings
+"""
 
 
 def plugin_settings(settings):
-    "Injects local settings into django settings"
+    """
+    Injects local settings into django settings
+    """
     settings.PROCTORING_SETTINGS = {}
     settings.PROCTORING_BACKENDS = {
         'DEFAULT': 'null',
@@ -26,7 +30,13 @@ def plugin_settings(settings):
             'proctoring/js/exam_action_handler.js'
         ]
     )
-    settings.PIPELINE_JS['proctoring'] = {
+    if hasattr(settings, 'PIPELINE'):
+        # django-pipeline 1.6+
+        js_setting = settings.PIPELINE['JAVASCRIPT']
+    else:
+        # earlier django-pipeline versions
+        js_setting = settings.PIPELINE_JS
+    js_setting['proctoring'] = {
         'source_filenames': proctoring_js,
         'output_filename': 'js/lms-proctoring.js',
     }


### PR DESCRIPTION
Add support for the new settings structured used in django-pipeline 1.6+ (needed in edx-platform for the Python 3 upgrade).  Maintaining compatibility with the old settings format for now to ease upgrading.