### PR TITLE
Backend-specific dashboard launches depend on the name field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 cache: pip
 python:
 - 2.7
+services:
+- xvfb
 env:
 - DJANGO_SETTINGS_MODULE=test_setting  TOXENV=django111-drf37
 - DJANGO_SETTINGS_MODULE=test_setting  TOXENV=django111-drf38
@@ -12,7 +14,6 @@ env:
 - TOXENV=translations
 before_install:
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 install:
 - pip install tox-travis
 - pip install -r requirements/test.txt

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.0.3'
+__version__ = '2.0.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -41,6 +41,8 @@ from edx_proctoring.backends.tests.test_software_secure import mock_response_con
 from edx_proctoring.runtime import set_runtime_service, get_runtime_service
 from edx_proctoring.urls import urlpatterns
 
+from mock_apps.models import Profile
+
 from .test_services import MockCreditService, MockInstructorService
 from .utils import LoggedInTestCase
 
@@ -2600,6 +2602,10 @@ class TestInstructorDashboard(LoggedInTestCase):
     """
     def setUp(self):
         super(TestInstructorDashboard, self).setUp()
+        profile = Profile()
+        profile.name = 'boo radley'
+        profile.user = self.user
+        profile.save()
         self.user.is_staff = True
         self.user.save()
         self.second_user = User(username='tester2', email='tester2@test.com')

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1040,7 +1040,7 @@ class InstructorDashboard(AuthenticatedAPIView):
             if backend:
                 user = {
                     'id': obscured_user_id(request.user.id, exam['backend']),
-                    'full_name': request.user.get_full_name(),
+                    'full_name': request.user.profile.name,
                     'email': request.user.email
                 }
 

--- a/mock_apps/apps.py
+++ b/mock_apps/apps.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+
+
+class MockAppsConfig(AppConfig):
+    name = 'mock_apps'

--- a/mock_apps/models.py
+++ b/mock_apps/models.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.auth import get_user_model
+from django.db import models
+
+class Profile(models.Model):
+    user = models.OneToOneField(get_user_model())
+    name = models.CharField(max_length=100)
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",

--- a/test_settings.py
+++ b/test_settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = (
     'edx_when',
     'rules.apps.AutodiscoverRulesConfig',
     'waffle',
+    'mock_apps',
 )
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
... being set and fail if there is none. We were drawing in this
information from the auth_user.first_name and .last_name fields, which
are deprecated on the edX platform.