### PR TITLE
Fixed saving exams to backend when there's a due date set

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -266,8 +266,11 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             response = self.session.post(url, json=exam)
             data = response.json()
         except Exception as exc:  # pylint: disable=broad-except
-            # pylint: disable=no-member
-            content = exc.response.content if hasattr(exc, 'response') else response.content
+            if response:
+                # pylint: disable=no-member
+                content = exc.response.content if hasattr(exc, 'response') else response.content
+            else:
+                content = None
             log.exception('failed to save exam. %r', content)
             data = {}
         return data.get('id')

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -167,6 +167,12 @@ class RESTBackendTests(TestCase):
         self.assertEqual(external_id, None)
 
     @responses.activate
+    def test_bad_exam_save(self):
+        self.backend_exam['bad'] = object()
+        external_id = self.provider.on_exam_saved(self.backend_exam)
+        self.assertEqual(external_id, None)
+
+    @responses.activate
     def test_register_exam_attempt(self):
         context = {
             'attempt_code': '2',

--- a/edx_proctoring/serializers.py
+++ b/edx_proctoring/serializers.py
@@ -46,6 +46,13 @@ class ProctoredExamSerializer(serializers.ModelSerializer):
         )
 
 
+class ProctoredExamJSONSafeSerializer(ProctoredExamSerializer):
+    """
+    ProctoredExam serializer which will return dates as strings.
+    """
+    due_date = serializers.DateTimeField(required=False)
+
+
 class UserSerializer(serializers.ModelSerializer):
     """
     Serializer for the User Model.

--- a/edx_proctoring/signals.py
+++ b/edx_proctoring/signals.py
@@ -22,8 +22,8 @@ def check_for_category_switch(sender, instance, **kwargs):  # pylint: disable=un
     if instance.id:
         original = sender.objects.get(pk=instance.id)
         if original.is_proctored and instance.is_proctored != original.is_proctored:
-            from edx_proctoring.serializers import ProctoredExamSerializer
-            exam = ProctoredExamSerializer(instance).data
+            from edx_proctoring.serializers import ProctoredExamJSONSafeSerializer
+            exam = ProctoredExamJSONSafeSerializer(instance).data
             # from the perspective of the backend, the exam is now inactive.
             exam['is_active'] = False
             backend = get_backend_provider(name=exam['backend'])
@@ -44,8 +44,8 @@ def save_exam_on_backend(sender, instance, **kwargs):  # pylint: disable=unused-
         exam_obj = instance.proctored_exam
         review_policy = instance
     if exam_obj.is_proctored:
-        from edx_proctoring.serializers import ProctoredExamSerializer
-        exam = ProctoredExamSerializer(exam_obj).data
+        from edx_proctoring.serializers import ProctoredExamJSONSafeSerializer
+        exam = ProctoredExamJSONSafeSerializer(exam_obj).data
         if review_policy:
             exam['rule_summary'] = review_policy.review_policy
         backend = get_backend_provider(exam)


### PR DESCRIPTION
If there was a due date set on an exam, the `ProctoredExamSerializer` was not serializing the date into a string, causing `on_exam_saved` to fail silently. This meant that exams were not being saved on the backend, which would lead to an error like [EDUCATOR-4458](https://openedx.atlassian.net/browse/EDUCATOR-4458). 