### PR TITLE
In python 3 unicode strings don't auto coerce to bytes.

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.0.8'
+__version__ = '2.0.9'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -229,8 +229,8 @@ def obscured_user_id(user_id, *extra):
     Any extra information can be added to the hash
     """
     obs_hash = hmac.new(settings.SECRET_KEY.encode('ascii'), digestmod=hashlib.sha1)
-    obs_hash.update(user_id.encode('utf-8'))
-    obs_hash.update(b''.join(ext.encode('utf-8') for ext in extra))
+    obs_hash.update(six.text_type(user_id).encode('utf-8'))
+    obs_hash.update(b''.join(six.text_type(ext).encode('utf-8') for ext in extra))
     return obs_hash.hexdigest()
 
 

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -229,8 +229,8 @@ def obscured_user_id(user_id, *extra):
     Any extra information can be added to the hash
     """
     obs_hash = hmac.new(settings.SECRET_KEY.encode('ascii'), digestmod=hashlib.sha1)
-    obs_hash.update(six.text_type(user_id))
-    obs_hash.update(u''.join(six.text_type(ext) for ext in extra))
+    obs_hash.update(user_id.encode('utf-8'))
+    obs_hash.update(b''.join(ext.encode('utf-8') for ext in extra))
     return obs_hash.hexdigest()
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We have to explictily pass byte objects to hashing functions because
that's what the want to hash.