### PR TITLE
Add better exceptions when backends return 200 but don't send id

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -94,7 +94,7 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
                 )
             )
             log.error(err_msg)
-            raise BackendProviderCannotRegisterAttempt(err_msg)
+            raise BackendProviderCannotRegisterAttempt(err_msg, status)
 
         # get the external ID that Software Secure has defined
         # for this attempt

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -14,7 +14,11 @@ from edx_proctoring.backends import get_backend_provider
 from edx_proctoring.backends.backend import ProctoringBackendProvider
 from edx_proctoring.backends.null import NullBackendProvider
 from edx_proctoring.backends.mock import MockProctoringBackendProvider
-from edx_proctoring.exceptions import BackendProviderCannotRetireUser, BackendProviderOnboardingException
+from edx_proctoring.exceptions import (
+    BackendProviderCannotRetireUser,
+    BackendProviderOnboardingException,
+    BackendProviderSentNoAttemptID,
+)
 
 # pragma pylint: disable=useless-super-delegation
 
@@ -30,6 +34,7 @@ class TestBackendProvider(ProctoringBackendProvider):
     last_retire_user = None
     attempt_error = None
     last_attempt_remove = None
+    no_attempt_id_error = None
 
     def register_exam_attempt(self, exam, context):
         """
@@ -37,6 +42,8 @@ class TestBackendProvider(ProctoringBackendProvider):
         """
         if self.attempt_error:
             raise BackendProviderOnboardingException(self.attempt_error)
+        elif self.no_attempt_id_error:
+            raise BackendProviderSentNoAttemptID(self.no_attempt_id_error, http_status=200)
         return 'testexternalid'
 
     def start_exam_attempt(self, exam, attempt):

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -76,6 +76,17 @@ class BackendProviderCannotRegisterAttempt(ProctoredBaseException):
     Raised when a back-end provider cannot register an attempt
     """
 
+    def __init__(self, content, http_status):
+        super(BackendProviderCannotRegisterAttempt, self).__init__(self, content)
+        self.http_status = http_status
+
+
+class BackendProviderSentNoAttemptID(BackendProviderCannotRegisterAttempt):
+    """
+    Raised when a back-end provider returns a JSON without exam ID
+    in response to new exam attempt registration
+    """
+
 
 class BackendProviderOnboardingException(ProctoredBaseException):
     """
@@ -83,7 +94,7 @@ class BackendProviderOnboardingException(ProctoredBaseException):
     because of missing/failed onboarding requirements
     """
     def __init__(self, status):
-        ProctoredBaseException.__init__(self, status)
+        super(BackendProviderOnboardingException, self).__init__(self, status)
         self.status = status
 
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -57,6 +57,7 @@ from edx_proctoring.api import (
 )
 from edx_proctoring.constants import DEFAULT_CONTACT_EMAIL
 from edx_proctoring.exceptions import (
+    BackendProviderSentNoAttemptID,
     ProctoredExamAlreadyExists,
     ProctoredExamNotFoundException,
     StudentExamAttemptAlreadyExistsException,
@@ -559,6 +560,17 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         attempt = get_exam_attempt_by_id(attempt_id)
         assert attempt['status'] == onboarding_error
         test_backend.attempt_error = None
+
+    def test_attempt_without_attempt_id(self):
+        """
+        Test that the exam attempt is throwing exceptions when the attempt id is not included in the
+        API response from proctoring backend
+        """
+        test_backend = get_backend_provider(name='test')
+        test_backend.no_attempt_id_error = 'No id returned'
+        with self.assertRaises(BackendProviderSentNoAttemptID):
+            create_exam_attempt(self.proctored_exam_id, self.user_id, taking_as_proctored=True)
+        test_backend.no_attempt_id_error = None
 
     def test_no_existing_attempt(self):
         """

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When the proctor backend system do not send external system ID on exam attempt, but the API returns 200, handle and log better

This is related to an issue where the ProctorTrack system would turn 200 on `CreateExamAttempt` api call, then won't include the "attempt_id" in the response. We need better logging to provide evidence to Proctor track that they are not obeying the API contract.

@matthugs Please review