### PR TITLE
Do not allow exam re-entry

### DIFF
--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -133,6 +133,24 @@ class ProctoredExamStudentAttemptStatus(object):
         """
         return cls.is_completed_status(status) or cls.is_incomplete_status(status)
 
+    @classmethod
+    def is_pre_started_status(cls, status):
+        """
+        Returns a boolean if the status passed is prior to "started" state.
+        """
+        return status in [
+            cls.created, cls.download_software_clicked, cls.ready_to_start
+        ]
+
+    @classmethod
+    def is_in_progress_status(cls, status):
+        """
+        Returns a boolean if the status passed is "in progress".
+        """
+        return status in [
+            cls.started, cls.ready_to_submit
+        ]
+
 
 class ReviewStatus(object):
     """

--- a/edx_proctoring/tests/test_email.py
+++ b/edx_proctoring/tests/test_email.py
@@ -137,16 +137,15 @@ class ProctoredExamEmailTests(ProctoredExamTestCase):
         ProctoredExamStudentAttemptStatus.error,
     )
     @patch.dict('django.conf.settings.PROCTORING_SETTINGS', {'ALLOW_TIMED_OUT_STATE': True})
-    def test_email_not_sent(self, status):
+    def test_email_not_sent(self, to_status):
         """
         Assert that an email is not sent for the following attempt status codes.
         """
-
-        exam_attempt = self._create_started_exam_attempt()
+        exam_attempt = self._create_exam_attempt(self.proctored_exam_id)
         update_attempt_status(
             exam_attempt.proctored_exam_id,
             self.user.id,
-            status
+            to_status
         )
         self.assertEqual(len(mail.outbox), 0)
 

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -284,17 +284,17 @@ class ProctoredExamTestCase(LoggedInTestCase):
             is_active=False
         )
 
-    def _create_exam_attempt(self, exam_id, status='created'):
+    def _create_exam_attempt(self, exam_id, status=ProctoredExamStudentAttemptStatus.created):
         """
         Creates the ProctoredExamStudentAttempt object.
         """
-
         attempt = ProctoredExamStudentAttempt(
             proctored_exam_id=exam_id,
             user_id=self.user_id,
             external_id=self.external_id,
+            status=status,
             allowed_time_limit_mins=10,
-            status=status
+            taking_as_proctored=True,
         )
 
         if status in (ProctoredExamStudentAttemptStatus.started,
@@ -326,13 +326,7 @@ class ProctoredExamTestCase(LoggedInTestCase):
         else:
             exam_id = self.timed_exam_id
 
-        return ProctoredExamStudentAttempt.objects.create(
-            proctored_exam_id=exam_id,
-            user_id=self.user_id,
-            external_id=self.external_id,
-            allowed_time_limit_mins=10,
-            status='created'
-        )
+        return self._create_exam_attempt(exam_id, status=ProctoredExamStudentAttemptStatus.created)
 
     def _create_started_exam_attempt(self, started_at=None, is_proctored=True, is_sample_attempt=False):
         """


### PR DESCRIPTION
This PR adds a check to stop a user attempt the exam again. 

The change in `edx_proctoring/callbacks.py` => `start_exam_callback` applies when a user is kicked out of an exam and he tries to log back in by opening the PSI application again and passing through the interview process. 

The edge case this PR handles is when a user is kicked out and clicks the `Start System Check` button on LMS and download the application again.

[PROD-698](https://openedx.atlassian.net/browse/PROD-698)