### PR TITLE
Changing prefix from b to u in migration files to fix type mismatch

### DIFF
--- a/edx_proctoring/migrations/0008_auto_20181116_1551.py
+++ b/edx_proctoring/migrations/0008_auto_20181116_1551.py
@@ -27,6 +27,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='proctoredexamreviewpolicy',
             name='review_policy',
-            field=models.TextField(default=b''),
+            field=models.TextField(default=u''),
         ),
     ]

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -130,7 +130,7 @@ class ProctoredExamReviewPolicy(TimeStampedModel):
     proctored_exam = models.ForeignKey(ProctoredExam, db_index=True)
 
     # policy that will be passed to reviewers
-    review_policy = models.TextField(default='')
+    review_policy = models.TextField(default=u'')
 
     def __str__(self):
         """ String representation """


### PR DESCRIPTION
            -The 'b' prefix before strings in migration files causes issues in python3
            - this commit replaces 'b' prefix with 'u' in migration files and adds 'u' prefix in relevant places in model.py
            - this should not cause any issues in python 2