### PR TITLE
Ensure that the crypto key is in bytes.

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.1.6'
+__version__ = '2.1.7'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -54,6 +54,8 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
         self.exam_register_endpoint = exam_register_endpoint
         self.secret_key_id = secret_key_id
         self.secret_key = secret_key
+        if isinstance(crypto_key, six.text_type):
+            crypto_key = crypto_key.encode('utf-8')
         self.crypto_key = crypto_key
         self.timeout = 10
         self.software_download_url = software_download_url

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our crypto libraries expect this in bytes but it can come in as a string
which in python 3 is not bytes.