### PR TITLE
fix doc signing for python 3

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.1.7'
+__version__ = '2.1.8'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -328,9 +328,9 @@ class SoftwareSecureBackendProvider(ProctoringBackendProvider):
             value = body_json[key]
             if isinstance(value, bool):
                 if value:
-                    value = b'true'
+                    value = 'true'
                 else:
-                    value = b'false'
+                    value = 'false'
             key = key.encode('utf8')
             if isinstance(value, (list, tuple)):
                 for idx, arr in enumerate(value):


### PR DESCRIPTION
The true/false values were including the `b` in the final string (e.g.
`reviewedExam:b'true'`).  This fix makes Python 3 match Python 2.7.