### PR TITLE
add check to ensure versions match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,13 @@ env:
 # - DJANGO_SETTINGS_MODULE=test_setting  TOXENV=django111-drflatest
 - DJANGO_SETTINGS_MODULE=test_setting  TOXENV=quality
 - DJANGO_SETTINGS_MODULE=test_setting  TOXENV=pii_check
+- TOXENV=version_check
 - TOXENV=translations
+
+matrix:
+ exclude:
+  - python: 2.7
+    env: TOXENV=version_check
 
 before_install:
 - export DISPLAY=:99.0

--- a/edx_proctoring/scripts/version_check.py
+++ b/edx_proctoring/scripts/version_check.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""
+Scripts to ensure that the Python and npm versions match.
+"""
+import json
+import sys
+from edx_proctoring import __version__ as python_version
+
+with open('package.json') as json_file:
+    data = json.load(json_file)
+    if data['version'] != python_version:
+        print("\n\n\n")
+        print("ERROR: Version mismatch. Please update version in edx_proctoring/__init__.py or edx_proctoring/package.json.\n")  # noqa E501 line too long
+        sys.exit(1)
+    else:
+        print("Version check success!")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
         py36-django111-drflatest,
         docs,
         quality,
+        version_check,
         pii_check,
         translations
 
@@ -16,7 +17,7 @@ deps =
     drflatest: djangorestframework
     -rrequirements/test.txt
 commands =
-    py.test -rfe --cov=edx_proctoring --cov-report=html --ds=test_settings -n 3 {posargs}
+    py.test -rfe --cov=edx_proctoring --cov-report=html --ds=test_settings {posargs:-n 3}
 
 [testenv:docs]
 setenv =
@@ -47,6 +48,12 @@ deps =
 commands =
     pylint edx_proctoring
     pycodestyle edx_proctoring
+
+[testenv:version_check]
+deps =
+    -r{toxinidir}/requirements/base.txt
+commands =
+    {toxinidir}/edx_proctoring/scripts/version_check.py
 
 [testenv:pii_check]
 whitelist_externals =


### PR DESCRIPTION
Comments state that the python and npm version should match. However,
comments are easy to miss. Adds a script to check.