### PR TITLE
Don't run JS tests on every run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,18 @@ env:
 - DJANGO_SETTINGS_MODULE=test_setting  TOXENV=pii_check
 - TOXENV=version_check
 - TOXENV=translations
+- TOXENV=js_tests
+- TOXENV=js_lint
+
 
 matrix:
  exclude:
   - python: 2.7
     env: TOXENV=version_check
+  - python: 2.7
+    env: TOXENV=js_lint
+  - python: 2.7
+    env: TOXENV=js_tests
 
 before_install:
 - export DISPLAY=:99.0
@@ -34,9 +41,6 @@ install:
 
 script:
 - tox
-- npm install -g gulp-cli
-- npm install
-- make test-js lint-js
 
 after_success:
 - coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,24 @@ deps =
 commands =
     py.test -rfe --cov=edx_proctoring --cov-report=html --ds=test_settings {posargs:-n 3}
 
+[testenv:js_tests]
+whitelist_externals =
+    npm
+    make
+commands =
+    npm install -g gulp-cli
+    npm install
+    make test-js
+
+[testenv:js_lint]
+whitelist_externals =
+    npm
+    make
+commands =
+    npm install -g gulp-cli
+    npm install
+    make lint-js
+
 [testenv:docs]
 setenv =
     DJANGO_SETTINGS_MODULE = test_settings


### PR DESCRIPTION
The way the travis file was written, travis would run tox(which would run the python tests) and then it would run the js tests.

So the JS tests would be run 10 times.