### PR TITLE
Set empty string as default value for full_name.

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -611,7 +611,7 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
         obs_user_id = obscured_user_id(user_id, exam['backend'])
 
         # get the name of the user, if the service is available
-        full_name = None
+        full_name = ''
         email = None
 
         credit_service = get_runtime_service('credit')

--- a/edx_proctoring/backends/tests/test_software_secure.py
+++ b/edx_proctoring/backends/tests/test_software_secure.py
@@ -28,6 +28,7 @@ from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import (
     MockCertificateService,
     MockCreditService,
+    MockCreditServiceNone,
     MockGradesService,
     MockInstructorService
 )
@@ -426,6 +427,26 @@ class SoftwareSecureTests(TestCase):
         """
 
         set_runtime_service('credit', MockCreditService())
+
+        exam_id = create_exam(
+            course_id='foo/bar/baz',
+            content_id='content',
+            exam_name='Sample Exam',
+            time_limit_mins=10,
+            is_proctored=True,
+            backend='software_secure',
+        )
+
+        with HTTMock(mock_response_content):
+            attempt_id = create_exam_attempt(exam_id, self.user.id, taking_as_proctored=True)
+            self.assertIsNotNone(attempt_id)
+
+    def test_full_name_without_credit_service(self):
+        """
+        Tests to make sure split doesn't raises AttributeError if credit service is down.
+        """
+
+        set_runtime_service('credit', MockCreditServiceNone())
 
         exam_id = create_exam(
             course_id='foo/bar/baz',


### PR DESCRIPTION
If credit service is down for some reason or credit state is missing, full_name is set to None and split raises error. Fixed by setting default value to an empty string.

PROD-1091