### PR TITLE
Skip Pypi deploy if already exists.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ deploy:
 - provider: pypi
   user: edx
   distributions: sdist bdist_wheel
+  skip_existing: true
   on:
     tags: true
     python: 3.5


### PR DESCRIPTION
It is causing builds to fail.

https://docs.travis-ci.com/user/deployment/pypi/#upload-artifacts-only-once