### PR TITLE
Revert Email Template Update

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.2.5'
+__version__ = '2.2.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1145,10 +1145,9 @@ def create_proctoring_attempt_status_email(user_id, exam_attempt_obj, course_nam
         course_name=course_name,
         username=user.username,
     )
-    contact_url = '{scheme}://{site_name}/support/contact_us'.format(
-        scheme=scheme,
-        site_name=constants.SITE_NAME
-    )
+
+    exam = get_exam_by_id(exam_attempt_obj.proctored_exam.id)
+    contact_email = get_integration_specific_email(get_backend_provider(exam))
 
     body = email_template.render({
         'username': user.username,
@@ -1157,8 +1156,8 @@ def create_proctoring_attempt_status_email(user_id, exam_attempt_obj, course_nam
         'exam_name': exam_name,
         'status': status,
         'platform': constants.PLATFORM_NAME,
+        'contact_email': contact_email,
         'support_email_subject': support_email_subject,
-        'contact_url': contact_url,
     })
 
     email = EmailMessage(

--- a/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
@@ -9,15 +9,15 @@
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was reviewed and you
-        met all proctoring requirements.
+        met all exam requirements.
     {% endblocktrans %}
 </p>
 <p>
     {% blocktrans %}
-        If you have any questions about your results, please <b>contact the course team</b>.
-        You can also reach {{platform}} Support at
-        <a href="{{contact_url}}">
-            {{ contact_url }}
+        If you have any questions about your results, contact {{ platform }}
+        support at
+        <a href="mailto:{{ contact_email }}?Subject={{ support_email_subject }}">
+            {{ contact_email }}
         </a>.
     {% endblocktrans %}
 </p>

--- a/edx_proctoring/templates/emails/proctoring_attempt_submitted_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_submitted_email.html
@@ -9,17 +9,17 @@
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was submitted
-        successfully and will now be reviewed to ensure all exam
-        rules were followed. You should receive an email with your exam
+        successfully and will now be reviewed to ensure all proctoring exam
+        rules were followed. You should receive an email with your updated exam
         status within 5 business days.
     {% endblocktrans %}
 </p>
 <p>
     {% blocktrans %}
-        If you have any questions about your exam, please <b>contact the course team</b>.
-        You can also reach {{ platform }} Support at
-        <a href="{{contact_url}}">
-            {{ contact_url }}
+        If you have any questions about proctoring, contact {{ platform }}
+        support at
+        <a href="mailto:{{ contact_email }}?Subject={{ support_email_subject }}">
+            {{ contact_email }}
         </a>.
     {% endblocktrans %}
 </p>

--- a/edx_proctoring/templates/emails/proctoring_attempt_unsatisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_unsatisfactory_email.html
@@ -9,19 +9,20 @@
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was reviewed and the
-        course team has identified one or more violations of the proctored exam rules. Examples
+        team identified one or more violations of the proctored exam rules. Examples
         of issues that may result in a rules violation include browsing
         the internet, blurry or missing photo identification, using a phone,
         or getting help from another person. As a result of the identified issue(s),
-        you did not successfully meet the proctored exam requirements.
+        you did not successfully meet the proctored
+        exam requirements.
     {% endblocktrans %}
 </p>
 <p>
     {% blocktrans %}
-        If you have any questions about your exam results, please <b>contact the course team</b>
-        for assistance. You can also reach {{platform}} Support at
-        <a href="{{contact_url}}">
-            {{ contact_url }}
+        If you have any questions about your results, contact {{ platform }}
+        support at
+        <a href="mailto:{{ contact_email }}?Subject={{ support_email_subject }}">
+            {{ contact_email }}
         </a>.
     {% endblocktrans %}
 </p>

--- a/edx_proctoring/tests/test_email.py
+++ b/edx_proctoring/tests/test_email.py
@@ -10,8 +10,8 @@ from mock import MagicMock, patch
 
 from django.core import mail
 
-from edx_proctoring.api import update_attempt_status
-from edx_proctoring.constants import SITE_NAME
+from edx_proctoring.api import get_integration_specific_email, update_attempt_status
+from edx_proctoring.backends import get_backend_provider
 from edx_proctoring.runtime import get_runtime_service, set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 
@@ -52,12 +52,12 @@ class ProctoredExamEmailTests(ProctoredExamTestCase):
         [
             ProctoredExamStudentAttemptStatus.verified,
             'Proctoring Results',
-            'was reviewed and you met all proctoring requirements',
+            'was reviewed and you met all exam requirements',
         ],
         [
             ProctoredExamStudentAttemptStatus.rejected,
             'Proctoring Results',
-            'the course team has identified one or more violations',
+            'the team identified one or more violations',
         ]
     )
     @ddt.unpack
@@ -176,23 +176,34 @@ class ProctoredExamEmailTests(ProctoredExamTestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     @ddt.data(
-        [ProctoredExamStudentAttemptStatus.submitted],
-        [ProctoredExamStudentAttemptStatus.verified],
-        [ProctoredExamStudentAttemptStatus.rejected],
+        [ProctoredExamStudentAttemptStatus.submitted, 'edx@example.com'],
+        [ProctoredExamStudentAttemptStatus.submitted, ''],
+        [ProctoredExamStudentAttemptStatus.submitted, None],
+        [ProctoredExamStudentAttemptStatus.verified, 'edx@example.com'],
+        [ProctoredExamStudentAttemptStatus.verified, ''],
+        [ProctoredExamStudentAttemptStatus.verified, None],
+        [ProctoredExamStudentAttemptStatus.rejected, 'edx@example.com'],
+        [ProctoredExamStudentAttemptStatus.rejected, ''],
+        [ProctoredExamStudentAttemptStatus.rejected, None],
     )
     @ddt.unpack
-    def test_correct_edx_support_url(self, status):
+    def test_correct_edx_email(self, status, integration_specific_email,):
         exam_attempt = self._create_started_exam_attempt()
+
+        test_backend = get_backend_provider(name='test')
+
+        test_backend.integration_specific_email = integration_specific_email
+
         update_attempt_status(
             exam_attempt.proctored_exam_id,
             self.user.id,
             status
         )
 
-        # Verify the edX support URL
-        contact_url = 'http://{site_name}/support/contact_us'.format(site_name=SITE_NAME)
+        # Verify the edX email
+        expected_email = get_integration_specific_email(test_backend)
         actual_body = self._normalize_whitespace(mail.outbox[0].body)
-        self.assertIn(u'You can also reach Open edX Support at '
-                      u'<a href="{contact_url}"> '
-                      u'{contact_url} </a>'.format(contact_url=contact_url),
+        self.assertIn(u'contact Open edX support at '
+                      u'<a href="mailto:{email}?Subject=Proctored exam Test Exam in edx demo for user tester"> '
+                      u'{email} </a>'.format(email=expected_email),
                       actual_body)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Revert the change that "Update the email with request from learner support so it goes to the right support channel. PROD-1073"

This reverts commit 4199bc7b24290386bfcb7d38e52f10d372790e80.

We need to revert this because we want the email message to be different between RPNOWv4 and Proctortrack. Currently, the change that is meant for Proctortrack are also sent to learners who are doing proctoring tests with PSI. 

@edx/masters-devs Please review