### PR TITLE
Don't allow transitions from ready_to_submit -> error.

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.2.7'
+__version__ = '2.2.8'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -159,9 +159,16 @@ edx = edx || {};
             var pingInterval = self.model.get('ping_interval');
             self.timerTick += 1;
             self.secondsLeft -= 1;
+
+            // AED 2020-02-21:
+            // If the learner is in a state where they've finished the exam
+            // and the attempt can be submitted (i.e. they are "ready_to_submit"),
+            // don't ping the proctoring app (which action could move
+            // the attempt into an error state).
             if (
                 self.timerTick % pingInterval === pingInterval / 2 &&
-                edx.courseware.proctored_exam.configuredWorkerURL
+                edx.courseware.proctored_exam.configuredWorkerURL &&
+                this.model.get('attempt_status') !== 'ready_to_submit'
             ) {
                 edx.courseware.proctored_exam.pingApplication(pingInterval)
                     .catch(self.endExamForFailureState.bind(self));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Many learners appear to be landing in error at the time when they go to attempt to submit their exam, because this takes a while (i.e. the app can take a bit to respond/close normally).  Learners can exacerbate this problem if they get impatient and try to close the app manually after the app has already been triggered to close itself by edX’s browser JS.  This PR attempts to make sure learners who’re going to end the exam don’t have a chance to move into the error state when they've already clicked "end" from the edX side.