### PR TITLE
Add PII Retirement Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ tramp
 *.swp
 *.swo
 
+# VS Code
+.vscode
+
 # Mac
 .DS_Store
 ._*

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,14 @@ In your lms.auth.json file, please add the following *secure* information::
 You will need to restart services after these configuration changes for them to
 take effect.
 
+Debugging
+------------
+
+To debug with PDB, run ``pytest`` with the ``-n0`` flag. This restricts the number
+of processes in a way that is compatible with ``pytest``
+
+    pytest -n0 [file-path]
+
 License
 -------
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -509,9 +509,8 @@ class ProctoredExamStudentAllowance(TimeStampedModel):
     Information about allowing a student additional time on exam.
 
     .. pii: allowances have a free-form text field which may be identifiable
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
     .. pii_types: other
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: local_api
     """
 
     # DONT EDIT THE KEYS - THE FIRST VALUE OF THE TUPLE - AS ARE THEY ARE STORED IN THE DATABASE
@@ -651,9 +650,8 @@ class ProctoredExamStudentAllowanceHistory(TimeStampedModel):
     but will record (for audit history) all entries that have been updated.
 
     .. pii: allowances have a free-form text field which may be identifiable
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
     .. pii_types: other
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: local_api
     """
 
     # what was the original id of the allowance

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -391,9 +391,8 @@ class ProctoredExamStudentAttemptHistory(TimeStampedModel):
     but will record (for audit history) all entries that have been updated.
 
     .. pii: new attempts log the student's name and IP
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
     .. pii_types: name, ip
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: local_api
     """
 
     user = models.ForeignKey(USER_MODEL, db_index=True, on_delete=models.CASCADE)
@@ -428,6 +427,7 @@ class ProctoredExamStudentAttemptHistory(TimeStampedModel):
     # the proctoring software
     is_sample_attempt = models.BooleanField(default=False)
 
+    # Note - this is currently unset
     student_name = models.CharField(max_length=255)
 
     # what review policy was this exam submitted under

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -126,10 +126,7 @@ class ProctoredExamReviewPolicy(TimeStampedModel):
     """
     This is how an instructor can set review policies for a proctored exam
 
-    .. pii: records who set a review policy in set_by_user
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
-    .. pii_types: id
-    .. pii_retirement: to_be_implemented
+    .. no_pii:
     """
 
     # who set this ProctoredExamReviewPolicy

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -298,9 +298,8 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
     Proctored Exam.
 
     .. pii: new attempts log the student's name and IP
-            retirement to be implemented in https://openedx.atlassian.net/browse/EDUCATOR-4776
     .. pii_types: name, ip
-    .. pii_retirement: to_be_implemented
+    .. pii_retirement: local_api
     """
     objects = ProctoredExamStudentAttemptManager()
 
@@ -340,6 +339,7 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
     # the proctoring software
     is_sample_attempt = models.BooleanField(default=False, verbose_name=ugettext_noop("Is Sample Attempt"))
 
+    # Note - this is currently unset
     student_name = models.CharField(max_length=255)
 
     # what review policy was this exam submitted under

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2943,23 +2943,25 @@ class TestUserRetirement(LoggedInTestCase):
         """ Retiring a user should delete their allowances and return a 204 """
         proctored_exam = self._create_proctored_exam()
         add_allowance_for_user(proctored_exam.id, self.user_to_retire.id, 'a_key', 30)
-        assert len(ProctoredExamStudentAllowance.objects.filter(user=self.user_to_retire.id)) == 1
 
         # Run the retirement command
         response = self.client.post(self.deletion_url)
         assert response.status_code == 204
 
-        assert len(ProctoredExamStudentAllowance.objects.filter(user=self.user_to_retire.id)) == 0
+        retired_allowance = ProctoredExamStudentAllowance \
+            .objects.filter(user=self.user_to_retire.id).first()
+        assert retired_allowance.value == ''
 
     def test_retire_user_allowances_history(self):
         """ Retiring a user should delete their allowances and return a 204 """
         proctored_exam = self._create_proctored_exam()
         add_allowance_for_user(proctored_exam.id, self.user_to_retire.id, 'a_key', 30)
         add_allowance_for_user(proctored_exam.id, self.user_to_retire.id, 'a_key', 60)
-        assert len(ProctoredExamStudentAllowanceHistory.objects.filter(user=self.user_to_retire.id)) == 1
 
         # Run the retirement command
         response = self.client.post(self.deletion_url)
         assert response.status_code == 204
 
-        assert len(ProctoredExamStudentAllowanceHistory.objects.filter(user=self.user_to_retire.id)) == 0
+        retired_allowance_history = ProctoredExamStudentAllowanceHistory \
+            .objects.filter(user=self.user_to_retire.id).first()
+        assert retired_allowance_history.value == ''

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2847,3 +2847,30 @@ class TestBackendUserDeletion(LoggedInTestCase):
 
         response = self.client.post(deletion_url)
         assert response.status_code == 403
+
+
+class TestUserRetirement(LoggedInTestCase):
+    """
+    Tests for deleting user PII for proctoring
+    """
+    def setUp(self):
+        super(TestUserRetirement, self).setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.second_user = User(username='tester2', email='tester2@test.com')
+        self.second_user.save()
+        self.client.login_user(self.user)
+
+    def test_can_delete_user(self):
+        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.second_user.id})
+        response = self.client.post(deletion_url)
+        assert response.status_code == 204
+        # if there is no user data, then no deletion happens
+        assert response.data == {}
+
+    def test_no_access(self):
+        self.client.login_user(self.second_user)
+        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user.id})
+
+        response = self.client.post(deletion_url)
+        assert response.status_code == 403

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2866,20 +2866,8 @@ class TestUserRetirement(LoggedInTestCase):
         self.user_to_retire.save()
         self.client.login_user(self.user)
 
-    def test_can_delete_user_no_data(self):
-        """ 
-        Attempting to retire an unknown user or user with no proctored attempts
-        returns 204 but does not carry out a retirment
-        """
-        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user_to_retire.id})
-        response = self.client.post(deletion_url)
-
-        assert response.status_code == 204
-
-    def test_can_delete_user(self):
-        """ Retiring a user should obfuscate PII for all exam attempts and return a 204 status """
-        # Create an exam attempt
-        proctored_exam = ProctoredExam.objects.create(
+    def create_proctored_exam(self):
+        return ProctoredExam.objects.create(
             course_id='a/b/c',
             content_id='test_content',
             exam_name='Test Exam',
@@ -2889,14 +2877,31 @@ class TestUserRetirement(LoggedInTestCase):
             time_limit_mins=90,
             backend='test'
         )
+
+    def test_retire_no_access(self):
+        """ A user without retirement permissions should not be able to retire other users """
+        self.client.login_user(self.user_to_retire)
+        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user.id})
+
+        response = self.client.post(deletion_url)
+        assert response.status_code == 403
+
+    def test_retire_user_no_data(self):
+        """ 
+        Attempting to retire an unknown user or user with no proctored attempts
+        returns 204 but does not carry out a retirment
+        """
+        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user_to_retire.id})
+        response = self.client.post(deletion_url)
+
+        assert response.status_code == 204
+
+    def test_retire_user_exam_attempt(self):
+        """ Retiring a user should obfuscate PII for exam attempts and return a 204 status """
+        # Create an exam attempt
+        proctored_exam = self.create_proctored_exam()
         create_exam_attempt(proctored_exam.id, self.user_to_retire.id)
         attempt = ProctoredExamStudentAttempt.objects.filter(user_id=self.user_to_retire.id).first()
-
-        # Create a second attempt to archive the first to the history table
-        attempt.is_sample_attempt = True
-        attempt.save()
-        create_exam_attempt(proctored_exam.id, self.user_to_retire.id)
-        attempt_history = ProctoredExamStudentAttemptHistory.objects.filter(user_id=self.user_to_retire.id).first()
 
         # Run the retirement command
         deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user_to_retire.id})
@@ -2907,14 +2912,24 @@ class TestUserRetirement(LoggedInTestCase):
         assert retired_attempt.student_name != attempt.student_name
         assert retired_attempt.last_poll_ipaddr != attempt.last_poll_ipaddr
 
+    def test_retire_user_exam_attempt_history(self):
+        """ Retiring a user should obfuscate PII for exam attempt history and return a 204 status """
+        # Create an exam attempt
+        proctored_exam = self.create_proctored_exam()
+        create_exam_attempt(proctored_exam.id, self.user_to_retire.id)
+
+        # Archive this attempt so it appears in the history table
+        attempt = ProctoredExamStudentAttempt.objects.filter(user_id=self.user_to_retire.id).first()
+        attempt.is_sample_attempt = True
+        attempt.save()
+        create_exam_attempt(proctored_exam.id, self.user_to_retire.id)
+        attempt_history = ProctoredExamStudentAttemptHistory.objects.filter(user_id=self.user_to_retire.id).first()
+
+        # Run the retirement command
+        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user_to_retire.id})
+        response = self.client.post(deletion_url)
+        assert response.status_code == 204
+
         retired_attempt_history = ProctoredExamStudentAttemptHistory.objects.filter(user_id=self.user_to_retire.id).first()
         assert retired_attempt_history.student_name != attempt_history.student_name
         assert retired_attempt_history.last_poll_ipaddr != attempt_history.last_poll_ipaddr
-
-    def test_no_access(self):
-        """ A user without retirement permissions should not be able to retire other users """
-        self.client.login_user(self.user_to_retire)
-        deletion_url = reverse('edx_proctoring:user_retirement_api', kwargs={'user_id': self.user.id})
-
-        response = self.client.post(deletion_url)
-        assert response.status_code == 403

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -2917,7 +2917,7 @@ class TestUserRetirement(LoggedInTestCase):
 
         retired_attempt = ProctoredExamStudentAttempt.objects.filter(user_id=self.user_to_retire.id).first()
         assert retired_attempt.student_name == ''
-        assert retired_attempt.last_poll_ipaddr == None
+        assert retired_attempt.last_poll_ipaddr is None
 
     def test_retire_user_exam_attempt_history(self):
         """ Retiring a user should obfuscate PII for exam attempt history and return a 204 status """
@@ -2937,7 +2937,7 @@ class TestUserRetirement(LoggedInTestCase):
         retired_attempt_history = ProctoredExamStudentAttemptHistory \
             .objects.filter(user_id=self.user_to_retire.id).first()
         assert retired_attempt_history.student_name == ''
-        assert retired_attempt_history.last_poll_ipaddr == None
+        assert retired_attempt_history.last_poll_ipaddr is None
 
     def test_retire_user_allowances(self):
         """ Retiring a user should delete their allowances and return a 204 """

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -95,6 +95,11 @@ urlpatterns = [
         views.BackendUserManagementAPI.as_view(),
         name='backend_user_deletion_api'
     ),
+    url(
+        r'edx_proctoring/v1/retire_user/(?P<user_id>[\d]+)/$',
+        views.UserRetirement.as_view(),
+        name='user_retirement_api'
+    ),
 
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1116,7 +1116,13 @@ class UserRetirement(AuthenticatedAPIView):
         """
         if not request.user.has_perm('accounts.can_retire_user'):
             return Response(status=403)
-        results = {}
-        code = 204
 
-        return Response(data=results, status=code)
+        code = 204
+        attempts = ProctoredExamStudentAttempt.objects.filter(user_id=user_id)
+
+        if attempts:
+            for attempt in attempts:
+                attempt.student_name = obscured_user_id(attempt.student_name)
+                attempt.last_poll_ipaddr = obscured_user_id(attempt.last_poll_ipaddr)
+                attempt.save()
+        return Response(status=code)

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -58,7 +58,8 @@ from edx_proctoring.models import (
     ProctoredExam,
     ProctoredExamSoftwareSecureComment,
     ProctoredExamSoftwareSecureReview,
-    ProctoredExamStudentAttempt
+    ProctoredExamStudentAttempt,
+    ProctoredExamStudentAttemptHistory
 )
 from edx_proctoring.runtime import get_runtime_service
 from edx_proctoring.serializers import ProctoredExamSerializer, ProctoredExamStudentAttemptSerializer
@@ -1116,13 +1117,20 @@ class UserRetirement(AuthenticatedAPIView):
         """
         if not request.user.has_perm('accounts.can_retire_user'):
             return Response(status=403)
-
         code = 204
-        attempts = ProctoredExamStudentAttempt.objects.filter(user_id=user_id)
 
+        attempts = ProctoredExamStudentAttempt.objects.filter(user_id=user_id)
         if attempts:
             for attempt in attempts:
                 attempt.student_name = obscured_user_id(attempt.student_name)
                 attempt.last_poll_ipaddr = obscured_user_id(attempt.last_poll_ipaddr)
                 attempt.save()
+
+        attempts_history = ProctoredExamStudentAttemptHistory.objects.filter(user_id=user_id)
+        if attempts_history:
+            for attempt_history in attempts_history:
+                attempt_history.student_name = obscured_user_id(attempt_history.student_name)
+                attempt_history.last_poll_ipaddr = obscured_user_id(attempt_history.last_poll_ipaddr)
+                attempt_history.save()
+
         return Response(status=code)

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1114,19 +1114,19 @@ class UserRetirement(AuthenticatedAPIView):
     Retire user personally-identifiable information (PII) for a user
     """
     def _retire_exam_attempts_user_info(self, user_id):
-        """ Obfuscate PII for exam attempts and exam history """
+        """ Remove PII for exam attempts and exam history """
         attempts = ProctoredExamStudentAttempt.objects.filter(user_id=user_id)
         if attempts:
             for attempt in attempts:
-                attempt.student_name = obscured_user_id(attempt.student_name)
-                attempt.last_poll_ipaddr = obscured_user_id(attempt.last_poll_ipaddr)
+                attempt.student_name = ''
+                attempt.last_poll_ipaddr = None
                 attempt.save()
 
         attempts_history = ProctoredExamStudentAttemptHistory.objects.filter(user_id=user_id)
         if attempts_history:
             for attempt_history in attempts_history:
-                attempt_history.student_name = obscured_user_id(attempt_history.student_name)
-                attempt_history.last_poll_ipaddr = obscured_user_id(attempt_history.last_poll_ipaddr)
+                attempt_history.student_name = ''
+                attempt_history.last_poll_ipaddr = None
                 attempt_history.save()
 
     def _retire_user_allowances(self, user_id):

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1130,9 +1130,19 @@ class UserRetirement(AuthenticatedAPIView):
                 attempt_history.save()
 
     def _retire_user_allowances(self, user_id):
-        """ Delete user allowances """
-        ProctoredExamStudentAllowance.objects.filter(user=user_id).delete()
-        ProctoredExamStudentAllowanceHistory.objects.filter(user=user_id).delete()
+        """ Clear user allowance values """
+        allowances = ProctoredExamStudentAllowance.objects.filter(user=user_id)
+
+        if allowances:
+            for allowance in allowances:
+                allowance.value = ''
+                allowance.save()
+
+        allowances_history = ProctoredExamStudentAllowanceHistory.objects.filter(user=user_id)
+        if allowances_history:
+            for allowance_history in allowances_history:
+                allowance_history.value = ''
+                allowance_history.save()
 
     def post(self, request, user_id):  # pylint: disable=unused-argument
         """ Obfuscates all PII for a given user_id """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1132,17 +1132,14 @@ class UserRetirement(AuthenticatedAPIView):
     def _retire_user_allowances(self, user_id):
         """ Clear user allowance values """
         allowances = ProctoredExamStudentAllowance.objects.filter(user=user_id)
-
-        if allowances:
-            for allowance in allowances:
-                allowance.value = ''
-                allowance.save()
+        for allowance in allowances:
+            allowance.value = ''
+            allowance.save()
 
         allowances_history = ProctoredExamStudentAllowanceHistory.objects.filter(user=user_id)
-        if allowances_history:
-            for allowance_history in allowances_history:
-                allowance_history.value = ''
-                allowance_history.save()
+        for allowance_history in allowances_history:
+            allowance_history.value = ''
+            allowance_history.save()
 
     def post(self, request, user_id):  # pylint: disable=unused-argument
         """ Obfuscates all PII for a given user_id """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1104,3 +1104,19 @@ class BackendUserManagementAPI(AuthenticatedAPIView):
                         code = 500
                 seen.add(backend_name)
         return Response(data=results, status=code)
+
+
+class UserRetirement(AuthenticatedAPIView):
+    """
+    Retire user personally-identifiable information (PII) for a user
+    """
+    def post(self, request, user_id):  # pylint: disable=unused-argument
+        """
+        Obfuscates all PII for a given user_id
+        """
+        if not request.user.has_perm('accounts.can_retire_user'):
+            return Response(status=403)
+        results = {}
+        code = 204
+
+        return Response(data=results, status=code)

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -58,6 +58,8 @@ from edx_proctoring.models import (
     ProctoredExam,
     ProctoredExamSoftwareSecureComment,
     ProctoredExamSoftwareSecureReview,
+    ProctoredExamStudentAllowance,
+    ProctoredExamStudentAllowanceHistory,
     ProctoredExamStudentAttempt,
     ProctoredExamStudentAttemptHistory
 )
@@ -1132,5 +1134,15 @@ class UserRetirement(AuthenticatedAPIView):
                 attempt_history.student_name = obscured_user_id(attempt_history.student_name)
                 attempt_history.last_poll_ipaddr = obscured_user_id(attempt_history.last_poll_ipaddr)
                 attempt_history.save()
+
+        allowances = ProctoredExamStudentAllowance.objects.filter(user=user_id)
+        if allowances:
+            for allowance in allowances:
+                allowance.delete()
+
+        allowances_history = ProctoredExamStudentAllowanceHistory.objects.filter(user=user_id)
+        if allowances_history:
+            for allowance_history in allowances_history:
+                allowance_history.delete()
 
         return Response(status=code)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
JIRA: [EDUCATOR-4776](https://openedx.atlassian.net/browse/EDUCATOR-4776)
Linked PR: https://github.com/edx/tubular/pull/411

## Changelog
- Exposes new endpoint at `edx_proctoring/v1/retire_user/<user_id>/`
- Add personally-identifiable information (PII) retirement code to do the following
   - Obfuscate/hash user names and IP addresses logged with proctored exam attempts
   - Delete student allowance records

FYI @edx/masters-devs 