### PR TITLE
add external_id to error message

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.3.1'
+__version__ = '2.3.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -920,7 +920,13 @@ class ProctoredExamReviewCallback(ProctoredAPIView, BaseReviewCallback):
         """
         attempt = get_exam_attempt_by_external_id(external_id)
         if attempt is None:
-            raise StudentExamAttemptDoesNotExistsException('not found')
+            err_msg = (
+                u'Attempted to access external exam id {external_id} but '
+                u'it does not exist.'.format(
+                    external_id=external_id
+                )
+            )
+            raise StudentExamAttemptDoesNotExistsException(err_msg)
         if request.user.has_perm('edx_proctoring.can_review_attempt', attempt):
             self.make_review(attempt, request.data)
             resp = Response(data='OK')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
there were a few of these errors triggering alerts in newrelic, but there isn't enough info in them to actually try to debug, so let's add some more info to the error message