### PR TITLE
add a log immediately after exam attempt registration on the backend …

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.3.2'
+__version__ = '2.3.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -690,6 +690,20 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
             )
             log.error(log_msg)
 
+    if not external_id and exam['backend'] == 'proctortrack' and taking_as_proctored:
+        # temporary logging added to better understand cases where we end up
+        # with exam attempts with NULL external_ids - a situation, that, theoretically,
+        # shouldn't be occurring (EDUCATOR-4948)
+        log_msg = (
+            u'Registered exam attempt with an external ID {external_id}'
+            u'in {exam_id} for user {user_id}'.format(
+                external_id=external_id,
+                exam_id=exam_id,
+                user_id=user_id,
+            )
+        )
+        log.error(log_msg)
+
     attempt = ProctoredExamStudentAttempt.create_exam_attempt(
         exam_id,
         user_id,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
…to log when an a null external id has been returned, with no exception