### PR TITLE
refactor email templates to support overriding and template inheritance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,16 @@ In your lms.auth.json file, please add the following *secure* information::
 You will need to restart services after these configuration changes for them to
 take effect.
 
+Email Templates
+---------------
+
+edx-proctoring provides generic base email templates that are rendered and sent to learners based
+on changes to the status of a proctored exam attempt. They have been designed such that you may leverage Django template
+inheritance to customize their content to the proctoring backend. Because proctoring backend plugins are installed in edx-platform,
+you must create an overriding template in the edx-platform repository. The template path should be ``emails/proctoring/{backend}/{template_name}``.
+Note that your template can either completely override the base template in edx-proctoring, or it can extend the base template in order to leverage
+the existing content of the blocks within the base template, particularly if you only need to change a portion of the template.
+
 Debugging
 ------------
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -5,6 +5,6 @@ The exam proctoring subsystem for the Open edX platform.
 from __future__ import absolute_import
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.4.2'
+__version__ = '2.4.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
@@ -1,22 +1,28 @@
 {% load i18n %}
 
 <p>
+    {% block introduction %}
     {% blocktrans %}
         Hello {{ username }},
     {% endblocktrans %}
+    {% endblock %}
 </p>
 <p>
+    {% block status_information %}
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was reviewed and you
         met all proctoring requirements.
     {% endblocktrans %}
+    {% endblock %}
 </p>
 <p>
+    {% block contact_information %}
     {% blocktrans %}
     If you have any questions about your results, you can reach edX Support at 
         <a href="{{contact_url}}">
             {{ contact_url }}
         </a>.
     {% endblocktrans %}
+    {% endblock %}
 </p>

--- a/edx_proctoring/templates/emails/proctoring_attempt_submitted_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_submitted_email.html
@@ -1,11 +1,14 @@
 {% load i18n %}
 
 <p>
+    {% block introduction %}
     {% blocktrans %}
         Hello {{ username }},
     {% endblocktrans %}
+    {% endblock %}
 </p>
 <p>
+    {% block status_information %}
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was submitted
@@ -13,4 +16,5 @@
         rules were followed. You should receive an email with your exam
         status within 5 business days.
     {% endblocktrans %}
+    {% endblock %}
 </p>

--- a/edx_proctoring/templates/emails/proctoring_attempt_unsatisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_unsatisfactory_email.html
@@ -1,11 +1,14 @@
 {% load i18n %}
 
 <p>
+    {% block introduction %}
     {% blocktrans %}
         Hello {{ username }},
     {% endblocktrans %}
+    {% endblock %}
 </p>
 <p>
+    {% block status_information %}
     {% blocktrans %}
         Your proctored exam "{{ exam_name }}" in
         <a href="{{ course_url }}">{{ course_name }}</a> was reviewed and the
@@ -15,8 +18,10 @@
         or getting help from another person. As a result of the identified issue(s),
         you did not successfully meet the proctored exam requirements.
     {% endblocktrans %}
+    {% endblock %}
 </p>
 <p>
+    {% block contact_information %}
     {% blocktrans %}
         To appeal your proctored exam results, please reach out to edX Support with any relevant information
         about your exam at 
@@ -24,4 +29,5 @@
             {{ contact_url }}
         </a>.
     {% endblocktrans %}
+    {% endblock %}
 </p>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[MST-223](https://openedx.atlassian.net/browse/MST-223)

This refactors our email templates to support overriding key pieces of the templates by proctoring backend. The Django project that installs edx-proctoring (and the proctoring provider plugins) can override the entire template or leverage template inheritance to override certain blocks within the templates.