### PR TITLE
Fix authoring doc link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,4 +146,4 @@ Have a question about this repository, or about Open edX in general?  Please
 refer to this `list of resources`_ if you need any assistance.
 
 .. _list of resources: https://open.edx.org/getting-help
-.. _Including Proctored Exams In Your Course: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/credit_courses/proctored_exams.html
+.. _Including Proctored Exams In Your Course: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/proctored_exams/index.html


### PR DESCRIPTION
Fixes proctored document [link](https://github.com/edx/edx-proctoring#documentation) in README