### PR TITLE
MST-406 Do not create exam attempt on past due exams when taking as proctoring

### DIFF
--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.4.4'
+__version__ = '2.4.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -35,7 +35,8 @@ from edx_proctoring.exceptions import (
     ProctoredExamReviewPolicyNotFoundException,
     StudentExamAttemptAlreadyExistsException,
     StudentExamAttemptDoesNotExistsException,
-    StudentExamAttemptedAlreadyStarted
+    StudentExamAttemptedAlreadyStarted,
+    StudentExamAttemptOnPastDueProctoredExam
 )
 from edx_proctoring.models import (
     ProctoredExam,
@@ -706,7 +707,7 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
             )
         )
         log.error(log_msg)
-        return None
+        raise StudentExamAttemptOnPastDueProctoredExam
 
     if taking_as_proctored:
         external_id, force_status = _register_proctored_exam_attempt(

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -60,6 +60,12 @@ class StudentExamAttemptedAlreadyStarted(ProctoredBaseException):
     """
 
 
+class StudentExamAttemptOnPastDueProctoredExam(ProctoredBaseException):
+    """
+    Raised when trying to create attempt instance on past due proctored exam
+    """
+
+
 class UserNotFoundException(ProctoredBaseException):
     """
     Raised when the user not found.

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -502,6 +502,28 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
             self.assertLessEqual(minutes_before_past_due_date - 1, attempt['allowed_time_limit_mins'])
             self.assertLessEqual(attempt['allowed_time_limit_mins'], minutes_before_past_due_date)
 
+    @ddt.data(
+        True,
+        False
+    )
+    def test_exam_attempt_past_due_datettime(self, taking_as_proctored):
+        """
+        Testing creating the exam attempt while the exam due date is in the past
+        """
+        due_date = datetime.now(pytz.UTC) - timedelta(hours=1)
+
+        exam_id = self._create_exam_with_due_time(due_date=due_date)
+
+        attempt_id = create_exam_attempt(exam_id, self.user_id, taking_as_proctored=taking_as_proctored)
+
+        attempt = get_exam_attempt_by_id(attempt_id)
+
+        if taking_as_proctored:
+            self.assertIsNone(attempt)
+        else:
+            self.assertIsNotNone(attempt)
+            self.assertIsNone(attempt.get('external_id'))
+
     def test_create_an_exam_attempt(self):
         """
         Create an unstarted exam attempt.

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -66,6 +66,7 @@ from edx_proctoring.exceptions import (
     StudentExamAttemptAlreadyExistsException,
     StudentExamAttemptDoesNotExistsException,
     StudentExamAttemptedAlreadyStarted,
+    StudentExamAttemptOnPastDueProctoredExam,
     UserNotFoundException
 )
 from edx_proctoring.models import (
@@ -514,13 +515,20 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
 
         exam_id = self._create_exam_with_due_time(due_date=due_date)
 
-        attempt_id = create_exam_attempt(exam_id, self.user_id, taking_as_proctored=taking_as_proctored)
-
-        attempt = get_exam_attempt_by_id(attempt_id)
-
         if taking_as_proctored:
-            self.assertIsNone(attempt)
+            with self.assertRaises(StudentExamAttemptOnPastDueProctoredExam):
+                attempt_id = create_exam_attempt(
+                    exam_id,
+                    self.user_id,
+                    taking_as_proctored=taking_as_proctored
+                )
         else:
+            attempt_id = create_exam_attempt(
+                exam_id,
+                self.user_id,
+                taking_as_proctored=taking_as_proctored
+            )
+            attempt = get_exam_attempt_by_id(attempt_id)
             self.assertIsNotNone(attempt)
             self.assertIsNone(attempt.get('external_id'))
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@edx/masters-devs-cosmonauts Please review

This is the bug fix for [MST-406](https://openedx.atlassian.net/browse/MST-406).
We are not going to create an exam attempt if the exam is taking as proctored and past due.
We can return `None` attempt ID because everywhere we call `create_exam_attempt`, we would try to update its attempt status and then we would throw the proper exception case for frontend to handle.

Also refactored the function a bit for better readability