### PR TITLE
Update proctoring error message for inactive account

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,17 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.4.8] - 2020-10-19
+~~~~~~~~~~~~~~~~~~~~
+
+* Created a separate error message for inactive users. Refined the
+  existing error message to only show for network error or service disruption.
+
 
 [2.4.7] - 2020-10-06
 ~~~~~~~~~~~~~~~~~~~~
 
-* Removed the rpnowv4_flow waffle flag to cleanup code  
+* Removed the rpnowv4_flow waffle flag to cleanup code
 
 For details of changes prior to this release, please see
 the `GitHub commit history`_.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.4.7'
+__version__ = '2.4.8'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/practice_exam/entrance.html
+++ b/edx_proctoring/templates/practice_exam/entrance.html
@@ -74,10 +74,11 @@
         ).fail(function(){
           enableClickEvent();
           var msg = gettext(
-            "There has been a problem starting your exam.\n\n" +
-            "Possible reasons are that your account has not been fully activated,\n" +
-            "you have are experiencing a network connection problem, or there has been\n" +
-            "a service disruption. Please check these and try again."
+            "There has been a problem starting your exam.\n\n " +
+            "Possible reasons are that you are experiencing a network connection problem, " +
+            "or there has been a service disruption. Please make sure that you are connected to a stable " +
+            "connection, and try to find a location with higher bandwidth if possible. " +
+            "We also recommend restarting your device before attempting proctoring again."
           );
           alert(msg);
         });

--- a/edx_proctoring/templates/proctored_exam/footer.html
+++ b/edx_proctoring/templates/proctored_exam/footer.html
@@ -25,10 +25,11 @@
     ).fail(function(){
       enableClickEvent(selector);
       var msg = gettext(
-        "There has been a problem starting your exam.\n\n" +
-        "Possible reasons are that your account has not been fully activated,\n" +
-        "you have are experiencing a network connection problem, or there has been\n" +
-        "a service disruption. Check your account or network connection and try again."
+        "There has been a problem starting your exam.\n\n " +
+        "Possible reasons are that you are experiencing a network connection problem, " +
+        "or there has been a service disruption. Please make sure that you are connected to a stable " +
+        "connection, and try to find a location with a higher bandwidth if possible. " +
+        "We also recommend restarting your device before attempting proctoring again."
       );
       alert(msg);
     });

--- a/edx_proctoring/templates/proctored_exam/inactive_account.html
+++ b/edx_proctoring/templates/proctored_exam/inactive_account.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+<div class="failure sequence proctored-exam" data-exam-id="{{exam_id}}">
+  <h3>
+    {% blocktrans %}
+      You have not activated your account.
+    {% endblocktrans %}
+  </h3>
+
+  <p>
+    {% blocktrans %}
+      Your {{platform_name}} account has not yet been activated. To take the proctored exam,
+      you are required to activate your account.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% blocktrans %}
+      Please check your registered email's Inbox and Spam folders for an activation email from
+      {{platform_name}}.
+    {% endblocktrans %}
+    {% if reset_link %}
+      {% blocktrans %}
+        If you cannot find this email, you can <a href="{{reset_link}}" target="_blank">reset your password</a> to
+        activate your account.
+      {% endblocktrans %}
+    {% else %}
+      {% blocktrans %}
+        If you cannot find this email, you can reset your password to activate your account.
+      {% endblocktrans %}
+    {% endif %}
+  </p>
+  <p>
+    {% blocktrans %}
+      If you continue to have trouble please contact <a href="{{link_urls.contact_us}}" target="_blank">
+      {{platform_name}} Support</a>.
+    {% endblocktrans %}
+  </p>
+</div>
+{% include 'proctored_exam/footer.html' %}

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -63,6 +63,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         self.footer_msg = 'About Proctored Exams'
         self.timed_footer_msg = 'Can I request additional time to complete my exam?'
         self.wait_deadline_msg = "The result will be visible after"
+        self.inactive_account_msg = "You have not activated your account"
 
     def _render_exam(self, content_id, context_overrides=None):
         """
@@ -1277,3 +1278,18 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         exam_attempt.save()
         rendered_response = self.render_proctored_exam()
         assert onboarding_status in rendered_response
+
+    @ddt.data(
+        render_onboarding_exam,
+        render_practice_exam,
+        render_proctored_exam,
+    )
+    def test_inactive_account_interstitial(self, render_exam):
+        """
+        Test that the correct interstitial is shown for an inactive account
+        """
+        self.user.is_active = False
+        self.user.save()
+
+        rendered_response = render_exam(self)
+        self.assertIn(self.inactive_account_msg, rendered_response)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## [MST-401](https://openedx.atlassian.net/browse/MST-401)

@edx/masters-devs-cosmonauts 

Updated error messaging for inactive accounts, and added new interstitial for users with inactive accounts. This change prevents users from entering a proctored exam if their account has not been activated. 

Example of what new interstitial looks like: 

(Your Platform Name Here will be replaced with whatever platform name is defined in Settings)
![Screen Shot 2020-10-19 at 12 13 15 PM](https://user-images.githubusercontent.com/46360176/96477450-824a2b00-1204-11eb-8785-df49aec5a530.png)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.