### PR TITLE
Allow practice exam reset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Unreleased
 ~~~~~~~~~~
 
 * Fix unbound local variable issue in api.get_attempt_status_summary
+* Added new action to student exam attempt PUT allowing users
+  to reset a completed practice exam.
 
 [2.4.8] - 2020-10-19
 ~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.4.9] - 2020-11-17
+~~~~~~~~~~~~~~~~~~~~
+
 * Fix unbound local variable issue in api.get_attempt_status_summary
 * Added new action to student exam attempt PUT allowing users
   to reset a completed practice exam.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.4.8'
+__version__ = '2.4.9'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1224,7 +1224,7 @@ def reset_practice_exam(exam_id, user_id):
     Resets a completed practice exam attempt back to the created state.
     """
     log_msg = (
-        u'Resetting practice exam {exam_id} for user {user_id}'.format(
+        'Resetting practice exam {exam_id} for user {user_id}'.format(
             exam_id=exam_id,
             user_id=user_id,
         )
@@ -1232,9 +1232,10 @@ def reset_practice_exam(exam_id, user_id):
     log.info(log_msg)
 
     exam_attempt_obj = ProctoredExamStudentAttempt.objects.get_exam_attempt(exam_id, user_id)
-    exam = get_exam_by_id(exam_id)
     if exam_attempt_obj is None:
         raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
+
+    exam = get_exam_by_id(exam_id)
     if not exam['is_practice_exam']:
         msg = (
             'Failed to reset attempt status on exam_id {exam_id} for user_id {user_id}. '
@@ -1246,8 +1247,8 @@ def reset_practice_exam(exam_id, user_id):
         raise ProctoredExamIllegalStatusTransition(msg)
 
     # prevent a reset if the exam is currently in progress
-    in_incompleted_status = ProctoredExamStudentAttemptStatus.is_incomplete_status(exam_attempt_obj.status)
-    if in_incompleted_status:
+    attempt_in_progress = ProctoredExamStudentAttemptStatus.is_incomplete_status(exam_attempt_obj.status)
+    if attempt_in_progress:
         msg = (
             'Failed to reset attempt status on exam_id {exam_id} for user_id {user_id}. '
             'Attempt with status {status} is still in progress!'.format(

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1219,6 +1219,55 @@ def _get_email_template_paths(template_name, backend):
     return [base_template]
 
 
+def reset_practice_exam(exam_id, user_id):
+    """
+    Resets a completed practice exam attempt back to the created state.
+    """
+    log_msg = (
+        u'Resetting practice exam {exam_id} for user {user_id}'.format(
+            exam_id=exam_id,
+            user_id=user_id,
+        )
+    )
+    log.info(log_msg)
+
+    exam_attempt_obj = ProctoredExamStudentAttempt.objects.get_exam_attempt(exam_id, user_id)
+    exam = get_exam_by_id(exam_id)
+    if exam_attempt_obj is None:
+        raise StudentExamAttemptDoesNotExistsException('Error. Trying to look up an exam that does not exist.')
+    if not exam['is_practice_exam']:
+        msg = (
+            'Failed to reset attempt status on exam_id {exam_id} for user_id {user_id}. '
+            'Only practice exams may be reset!'.format(
+                exam_id=exam_id,
+                user_id=user_id,
+            )
+        )
+        raise ProctoredExamIllegalStatusTransition(msg)
+
+    # prevent a reset if the exam is currently in progress
+    in_incompleted_status = ProctoredExamStudentAttemptStatus.is_incomplete_status(exam_attempt_obj.status)
+    if in_incompleted_status:
+        msg = (
+            'Failed to reset attempt status on exam_id {exam_id} for user_id {user_id}. '
+            'Attempt with status {status} is still in progress!'.format(
+                exam_id=exam_id,
+                user_id=user_id,
+                status=exam_attempt_obj.status,
+            )
+        )
+        raise ProctoredExamIllegalStatusTransition(msg)
+
+    exam_attempt_obj.status = ProctoredExamStudentAttemptStatus.created
+    exam_attempt_obj.started_at = None
+    exam_attempt_obj.completed_at = None
+    exam_attempt_obj.allowed_time_limit_mins = None
+    exam_attempt_obj.save()
+
+    emit_event(exam, 'reset_practice_exam', attempt=_get_exam_attempt(exam_attempt_obj))
+
+    return exam_attempt_obj.id
+
 def remove_exam_attempt(attempt_id, requesting_user):
     """
     Removes an exam attempt given the attempt id. requesting_user is passed through to the instructor_service.

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1269,6 +1269,7 @@ def reset_practice_exam(exam_id, user_id):
 
     return exam_attempt_obj.id
 
+
 def remove_exam_attempt(attempt_id, requesting_user):
     """
     Removes an exam attempt given the attempt id. requesting_user is passed through to the instructor_service.

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -780,7 +780,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         """
         If an attempt is in progress it may not be reset
         """
-        practice_attempt = self._create_exam_attempt(
+        self._create_exam_attempt(
             self.practice_exam_id,
             status=ProctoredExamStudentAttemptStatus.started
         )
@@ -791,7 +791,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         """
         Only practice exams may be reset
         """
-        exam_attempt = self._create_exam_attempt(
+        self._create_exam_attempt(
             self.proctored_exam_id,
             status=ProctoredExamStudentAttemptStatus.started
         )

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -45,6 +45,7 @@ from edx_proctoring.api import (
     remove_allowance_for_user,
     remove_exam_attempt,
     remove_review_policy,
+    reset_practice_exam,
     start_exam_attempt,
     start_exam_attempt_by_code,
     stop_exam_attempt,
@@ -755,6 +756,47 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
             # There is not an expected changed to the credit requirement table
             # given the attempt status
             self.assertEqual(len(credit_status['credit_requirement_status']), 0)
+
+    def test_reset_practice_exam(self):
+        """
+        Reset returns a user's exam attempt to the created state
+        """
+        with self.assertRaises(StudentExamAttemptDoesNotExistsException):
+            reset_practice_exam(self.practice_exam_id, self.user)
+
+        practice_attempt = self._create_exam_attempt(
+            self.practice_exam_id,
+            status=ProctoredExamStudentAttemptStatus.submitted
+        )
+        reset_practice_exam(self.practice_exam_id, self.user)
+
+        practice_attempt.refresh_from_db()
+        self.assertEqual(practice_attempt.status, ProctoredExamStudentAttemptStatus.created)
+        self.assertIsNone(practice_attempt.started_at)
+        self.assertIsNone(practice_attempt.completed_at)
+        self.assertIsNone(practice_attempt.allowed_time_limit_mins)
+
+    def test_reset_exam_in_progress(self):
+        """
+        If an attempt is in progress it may not be reset
+        """
+        practice_attempt = self._create_exam_attempt(
+            self.practice_exam_id,
+            status=ProctoredExamStudentAttemptStatus.started
+        )
+        with self.assertRaises(ProctoredExamIllegalStatusTransition):
+            reset_practice_exam(self.practice_exam_id, self.user)
+
+    def test_reset_non_practice_exam(self):
+        """
+        Only practice exams may be reset
+        """
+        exam_attempt = self._create_exam_attempt(
+            self.proctored_exam_id,
+            status=ProctoredExamStudentAttemptStatus.started
+        )
+        with self.assertRaises(ProctoredExamIllegalStatusTransition):
+            reset_practice_exam(self.proctored_exam_id, self.user_id)
 
     def test_stop_a_non_started_exam(self):
         """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -316,7 +316,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
 
     HTTP DELETE
         ** Scenarios **
-        Removes an exam attempt and resets progress. Limited to course staff 
+        Removes an exam attempt and resets progress. Limited to course staff
     """
 
     def get(self, request, attempt_id):
@@ -408,7 +408,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
                 request.user.id,
                 ProctoredExamStudentAttemptStatus.download_software_clicked
             )
-        elif action == 'reset_practice_exam':
+        elif action == 'reset_attempt':
             exam_attempt_id = reset_practice_exam(
                 attempt['proctored_exam']['id'],
                 request.user.id,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -38,6 +38,7 @@ from edx_proctoring.api import (
     mark_exam_attempt_as_ready,
     remove_allowance_for_user,
     remove_exam_attempt,
+    reset_practice_exam,
     start_exam_attempt,
     stop_exam_attempt,
     update_attempt_status,
@@ -402,6 +403,11 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
                 attempt['proctored_exam']['id'],
                 request.user.id,
                 ProctoredExamStudentAttemptStatus.download_software_clicked
+            )
+        elif action == 'reset_practice_exam':
+            exam_attempt_id = reset_practice_exam(
+                attempt['proctored_exam']['id'],
+                request.user.id,
             )
         elif action == 'error':
             backend = attempt['proctored_exam']['backend']

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -292,9 +292,9 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
     /edx_proctoring/v1/proctored_exam/attempt
 
     Supports:
-        HTTP POST: Starts an exam attempt.
         HTTP PUT: Stops an exam attempt.
         HTTP GET: Returns the status of an exam attempt.
+        HTTP DELETE: Delete an exam attempt.
 
 
     HTTP PUT
@@ -313,6 +313,10 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
     HTTP GET
         ** Scenarios **
         return the status of the exam attempt
+
+    HTTP DELETE
+        ** Scenarios **
+        Removes an exam attempt and resets progress. Limited to course staff 
     """
 
     def get(self, request, attempt_id):
@@ -357,7 +361,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
 
     def put(self, request, attempt_id):
         """
-        HTTP POST handler. To stop an exam.
+        HTTP PUT handler. To stop an exam.
         """
         attempt = get_exam_attempt_by_id(attempt_id)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

Adds a new action to exam attempt PUT to reset a practice exam back to the created state.

**JIRA:**

[MST-473](https://openedx.atlassian.net/browse/MST-473)

**Pre-Merge Checklist:**

- [x] ~Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.