### PR TITLE
UX enhancement for the proctoring instructions page.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Cover `Start System Check` button on the proctoring instruction page with the
+  conditions software download link is provided by the proctoring provider,
+  since some providers do not has that step in the onboarding process.
+
 [2.5.4] - 2020-12-17
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Minor template fix

--- a/edx_proctoring/templates/proctored_exam/instructions.html
+++ b/edx_proctoring/templates/proctored_exam/instructions.html
@@ -29,9 +29,11 @@
           {% endblocktrans %}
         </p>
       {% endif %}
-      <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
+      {% if software_download_url %}
+        <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
+      {% endif %}
       <div class="footer-sequence border-b-0 padding-b-0">
-        <button href="#" class="exam-action-button js-start-proctored-exam btn btn-secondary">{% trans "Start Exam" %}</button>
+        <button href="#" class="exam-action-button js-start-proctored-exam btn btn-{% if software_download_url %}secondary{% else %}primary{% endif %}">{% trans "Start Exam" %}</button>
       </div>
     {% else %}
       <h4>
@@ -72,7 +74,9 @@
       <li>{% blocktrans %}Have a computer with a functioning webcam{% endblocktrans %}</li>
       <li>{% blocktrans %}Have your valid photo ID (e.g. driver's license or passport) ready{% endblocktrans %}</li>
     </ul>
-    <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
+    {% if software_download_url %}
+      <button id="software_download_link" class="exam-action-button btn-pl-primary" data-action="click_download_software">{% trans "Start System Check" %}</button>
+    {% endif %}
       <h4>
         {% blocktrans %}
           Step 3
@@ -218,6 +222,6 @@
     $(this).focus();
   })
   .blur(function () {
-    $(this).text(gettext("Copy Exam Code")); 
+    $(this).text(gettext("Copy Exam Code"));
   });
 </script>

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -400,6 +400,18 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         )
         self.assertIsNotNone(rendered_response)
 
+    def test_proctoring_instruction_without_software_download_link(self):
+        """
+        Test for get_student_view proctored exam without software download link.
+
+        Other providers could have no onboarding step requires software download
+        Redundant `Start System Check` button is absent in that case.
+        """
+
+        self._create_unstarted_exam_attempt()
+        rendered_response = self.render_proctored_exam()
+        self.assertNotIn('id="software_download_link"', rendered_response)
+
     @ddt.data(False, True)
     def test_get_studentview_unstarted_exam(self, allow_proctoring_opt_out):
         """


### PR DESCRIPTION
**Description:**
Recently, other proctoring providers could have onboarding without
software download step, though `Start System Check` exists on the
page and confusing students.

Currently, the button for software downloading covered by conditions.

**Pre-Merge Checklist:**

- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.