### PR TITLE
Add endpoint for onboarding status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.1] - 2020-12-10
+~~~~~~~~~~~~~~~~~~~~
+
+* Add endpoint to expose the learner's onboarding status
+
 [2.5.0] - 2020-12-09
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -408,6 +408,217 @@ class ProctoredExamViewTests(LoggedInTestCase):
         self.assertEqual(response_data['time_limit_mins'], proctored_exam.time_limit_mins)
 
 
+class TestStudentOnboardingStatusView(LoggedInTestCase):
+    """
+    Tests for StudentOnboardingStatusView
+    """
+    def setUp(self):
+        super(TestStudentOnboardingStatusView, self).setUp()
+        set_runtime_service('instructor', MockInstructorService(is_user_course_staff=False))
+        self.other_user = User.objects.create(username='otheruser', password='test')
+
+    def _create_onboarding_exam(self):
+        """
+        Create an onboarding exam
+        """
+        onboarding_exam = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+            is_proctored=True,
+            is_practice_exam=True,
+            backend='test',
+        )
+        return onboarding_exam
+
+    def _create_onboarding_exam_attempt(self, onboarding_exam, user):
+        """
+        Create an exam attempt related to the given onboarding exam
+        """
+        attempt_id = create_exam_attempt(onboarding_exam.id, user.id, True)
+        attempt = ProctoredExamStudentAttempt.objects.filter(id=attempt_id).first()
+        return attempt
+
+    def test_no_course_id(self):
+        response = self.client.get(reverse('edx_proctoring:user_onboarding.status'))
+        self.assertEqual(response.status_code, 400)
+        response_data = json.loads(response.content.decode('utf-8'))
+        message = 'Missing required query parameter course_id'
+        self.assertEqual(response_data['detail'], message)
+
+    def test_no_username(self):
+        onboarding_exam = self._create_onboarding_exam()
+        # Create the user's own attempt
+        own_attempt = self._create_onboarding_exam_attempt(onboarding_exam, self.user)
+        own_attempt.status = ProctoredExamStudentAttemptStatus.submitted
+        own_attempt.save()
+        # Create another user's attempt
+        other_attempt = self._create_onboarding_exam_attempt(onboarding_exam, self.other_user)
+        other_attempt.status = ProctoredExamStudentAttemptStatus.verified
+        other_attempt.save()
+        # Assert that the onboarding status returned is 'submitted'
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['onboarding_status'], ProctoredExamStudentAttemptStatus.submitted)
+
+    def test_unauthorized(self):
+        onboarding_exam = self._create_onboarding_exam()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?username={}&course_id={}'.format(self.other_user.username, onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 403)
+        response_data = json.loads(response.content.decode('utf-8'))
+        message = 'Must be a Staff User to Perform this request.'
+        self.assertEqual(response_data['detail'], message)
+
+    def test_staff_authorization(self):
+        self.user.is_staff = True
+        self.user.save()
+        onboarding_exam = self._create_onboarding_exam()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?username={}&course_id={}'.format(self.other_user.username, onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        # Should also work for course staff
+        set_runtime_service('instructor', MockInstructorService(is_user_course_staff=True))
+        self.user.is_staff = False
+        self.user.save()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?username={}&course_id={}'.format(self.other_user.username, onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_onboarding_exam(self):
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id=edX/DemoX/Demo_Course'
+        )
+        self.assertEqual(response.status_code, 404)
+        response_data = json.loads(response.content.decode('utf-8'))
+        message = 'There is no onboarding exam related to this course id.'
+        self.assertEqual(response_data['detail'], message)
+
+    def test_no_exam_attempts(self):
+        onboarding_exam = self._create_onboarding_exam()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertIsNone(response_data['onboarding_status'])
+        self.assertEqual(response_data['onboarding_link'], reverse(
+            'jump_to',
+            args=[onboarding_exam.course_id, onboarding_exam.content_id]
+        ))
+
+    def test_no_verified_attempts(self):
+        onboarding_exam = self._create_onboarding_exam()
+        # Create first attempt
+        attempt = self._create_onboarding_exam_attempt(onboarding_exam, self.user)
+        attempt.status = ProctoredExamStudentAttemptStatus.timed_out
+        attempt.save()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['onboarding_status'], ProctoredExamStudentAttemptStatus.timed_out)
+        self.assertEqual(response_data['onboarding_link'], reverse(
+            'jump_to',
+            args=[onboarding_exam.course_id, onboarding_exam.content_id]
+        ))
+        # Create second attempt and assert that most recent attempt is returned
+        attempt = self._create_onboarding_exam_attempt(onboarding_exam, self.user)
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['onboarding_status'], ProctoredExamStudentAttemptStatus.created)
+        self.assertEqual(response_data['onboarding_link'], reverse(
+            'jump_to',
+            args=[onboarding_exam.course_id, onboarding_exam.content_id]
+        ))
+
+    def test_get_verified_attempt(self):
+        onboarding_exam = self._create_onboarding_exam()
+        # Create first attempt
+        attempt = self._create_onboarding_exam_attempt(onboarding_exam, self.user)
+        attempt.status = ProctoredExamStudentAttemptStatus.verified
+        attempt.save()
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['onboarding_status'], ProctoredExamStudentAttemptStatus.verified)
+        self.assertEqual(response_data['onboarding_link'], reverse(
+            'jump_to',
+            args=[onboarding_exam.course_id, onboarding_exam.content_id]
+        ))
+        # Create second attempt and assert that verified attempt is still returned
+        attempt = self._create_onboarding_exam_attempt(onboarding_exam, self.user)
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(onboarding_exam.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['onboarding_status'], ProctoredExamStudentAttemptStatus.verified)
+        self.assertEqual(response_data['onboarding_link'], reverse(
+            'jump_to',
+            args=[onboarding_exam.course_id, onboarding_exam.content_id]
+        ))
+
+    def test_only_onboarding_exam(self):
+        # Create an onboarding exam, along with a practice exam and
+        # a proctored exam, all in the same course
+        onboarding_exam = self._create_onboarding_exam()
+        ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='practice_content',
+            exam_name='Practice Exam',
+            external_id='123aXqe4',
+            time_limit_mins=90,
+            is_active=True,
+            is_practice_exam=True,
+            backend='test',
+        )
+        ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='proctored_content',
+            exam_name='Proctored Exam',
+            external_id='123aXqe5',
+            time_limit_mins=90,
+            is_active=True,
+            is_proctored=True,
+            backend='test',
+        )
+        # Assert that the onboarding exam link is returned
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id=a/b/c'
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        onboarding_link = reverse('jump_to', args=['a/b/c', onboarding_exam.content_id])
+        self.assertEqual(response_data['onboarding_link'], onboarding_link)
+
+
 @ddt.ddt
 class TestStudentProctoredExamAttempt(LoggedInTestCase):
     """

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -84,6 +84,11 @@ urlpatterns = [
         name='proctored_exam.active_exams_for_user'
     ),
     url(
+        r'edx_proctoring/v1/user_onboarding/status$',
+        views.StudentOnboardingStatusView.as_view(),
+        name='user_onboarding.status'
+    ),
+    url(
         r'edx_proctoring/v1/instructor/{}$'.format(settings.COURSE_ID_PATTERN),
         views.InstructorDashboard.as_view(),
         name='instructor_dashboard_course'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,5 +1,18 @@
 
 
+from django.conf import settings
 from django.conf.urls import include, url
 
-urlpatterns = [url(r'^', include('edx_proctoring.urls', namespace='edx_proctoring'))]
+from edx_proctoring import views
+
+urlpatterns = [
+  url(r'^', include('edx_proctoring.urls', namespace='edx_proctoring')),
+  # Fake view to mock url pattern provided by edx_platform
+  url(
+        r'^courses/{}/jump_to/(?P<location>.*)$'.format(
+            settings.COURSE_ID_PATTERN,
+        ),
+        views.StudentOnboardingStatusView.as_view(),
+        name='jump_to',
+    )
+]


### PR DESCRIPTION
**Description:**

Adds endpoint to expose onboarding status to learner.

**JIRA:**

[MST-516](https://openedx.atlassian.net/browse/MST-516)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.