### PR TITLE
Adding celery 5.0 testing using tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: python
 cache: pip
 python:
-- 3.5
 - 3.8
 
 services:
 - xvfb
 
 env:
-- TOXENV=django22-drf310
-- TOXENV=django22-drflatest
+- TOXENV=celery44-django22-drf310
+- TOXENV=celery44-django22-drflatest
+- TOXENV=celery50-django22-drf310
+- TOXENV=celery50-django22-drflatest
 - TOXENV=quality
 - TOXENV=pii_check
 - TOXENV=version_check
@@ -38,7 +39,7 @@ deploy:
   skip_existing: true
   on:
     tags: true
-    python: 3.5
+    python: 3.8
     condition: '$TOXENV=quality'
   password:
     secure: Xx0ya0JKOzPEX5fL389UQxiSnu46D/tVWwdgKXGT+g9GceQsxUWyshqC8uPF1KgKQfMynmC4C/XQOktfQj4LEv2EQPfnYP7Aog+swxS23jHevQYC7H0mlc5pyzTqfGbb5nr1gVtq2pjfsvC2RSgrZGigpCympyD1qKb6HBb3xcCpaUpLBMJFO+uUCIKYe6zJ0zxykW1Z66qE7igNyfvDqMbB/Sn6VO9PBrQOnTNnl4JyLer6gN+nztJTvpgwcKT7jUjtJtBDoTqj9ia/jJLGhAYNppCdLwmjNU1aN+e6X7J0HXBizOgqL7skWYAR1ygXwv027ZC3LJjiC6Ovww0rRzJdWe/OMJu5RzTYvXjgyBdjMdk3lYw5LaNoRuLfWkntV8ORYULsjl/g1RUJrXQ5u1KxeVPM9Fwb5toH1OmAMbuTpAmbYK8itWdU0TGiDsgLQABeNeW57DQIqE04YVG+kK1zg3OV7W6CgEVKXWciOugWJSdTtyoI5RBOuW1altKapee2/xwd49X5F5eac1AKsRc3U5DNxc0DCLR3NRmrHVBOD+yfI0F42MwngK9tbevDyZ9t1tf04ysu6hvzwES5goVp+85hHIyf+NIiKQpQQbKYWwIGcQuGlo7vHyOs9LJ5qHXQSzFZu8+l9qn3cCEd/cY7geh15yKOSVzv0J7yb84=
@@ -48,5 +49,5 @@ deploy:
     secure: Bs6z6iFpO86mav8qo3cDhcjDckNXDGfcbuZtSWbbrIFe9Q0VSVz046s9Yo7hHjjaRUSb6frlTC8lYRNDZ2m7TxXrh4vXHrHsr9ajcJXUZJCwqnnxIEFeHe02hD/7RPJ3xK7tkGCxd/2AUHEHXYylGOePDc/Ck/2VYmGQ0EijcfZeOJ5macZ65TP0Kwvf+IDOko++W94f3Ujglu+lWryBTR61Yaf7zt7fKQVgjxGQjb07F1ze39A00xkYYYbIDSrzjZeebs/pzCjZhrrkzTwReDItTxk9K7cEx5nlRvQul6Wj5USe1uBL5SodP2XCp3mi7XrB/LOt6kDEcdREUzqZUqB5n21VVey0JWihd579PIHFhTXDQpdSJNhOi86Mv8lj3v/XUTRaZBV+2OPVGKSRgmJ0Qv7BkQXOp8tzSN4AINrYD2bMod3jVaGcjg7MYUpJ7B2swWUSa0aLLUe1M2RYzfQ2CiGeN9jCdz8jmQie+HGc5CkaMFtoT1OUt1R7wuO2RNo8pYrP0KJTWpOCHlGn+5r17iDOPXoc/m6a5wN3sxMrARqF5A/PRv3uY/Nb+4bfTeczDZudpxVxGFxe85rahXjh7tSHX5JOiaOXDO9xWj2EBRKKeD4xbgRSBZvjnRrZ0f9ygZjuzFv86KixwYI3HFo21SJQmIaJIUSOoM+r1lQ=
   on:
     tags: true
-    python: 3.5
+    python: 3.8
     condition: '$TOXENV=quality'

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,20 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --rebuild --upgrade -o requirements/quality.txt requirements/quality.in
 	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
 	# Let tox control the Django and djangorestframework versions for tests
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery44.txt
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
+	sed -i.tmp '/^amqp==/d' requirements/test.txt
+	sed -i.tmp '/^anyjson==/d' requirements/test.txt
+	sed -i.tmp '/^billiard==/d' requirements/test.txt
+	sed -i.tmp '/^celery==/d' requirements/test.txt
+	sed -i.tmp '/^kombu==/d' requirements/test.txt
+	sed -i.tmp '/^click-didyoumean==/d' requirements/test.txt
+	sed -i.tmp '/^click-repl==/d' requirements/test.txt
+	sed -i.tmp '/^click==/d' requirements/test.txt
+	sed -i.tmp '/^click==/d' requirements/test.txt
+	sed -i.tmp '/^prompt-toolkit==/d' requirements/test.txt
+	sed -i.tmp '/^vine==/d' requirements/test.txt
 	rm requirements/test.txt.tmp
 
 requirements: ## install development environment requirements

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,11 +7,11 @@
 amqp==2.6.1               # via kombu
 appdirs==1.4.4            # via fs
 billiard==3.6.3.0         # via celery
-celery==4.4.7             # via event-tracking
+celery==4.4.7             # via -c requirements/constraints.txt, event-tracking
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt
 django-crum==0.7.9        # via -r requirements/base.in, edx-django-utils
 django-ipware==3.0.2      # via -r requirements/base.in
 django-model-utils==4.1.1  # via -r requirements/base.in, edx-when
@@ -29,7 +29,6 @@ event-tracking==1.0.0     # via -r requirements/base.in
 fs==2.4.11                # via xblock
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via kombu
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==4.6.11             # via celery
 lxml==4.6.2               # via xblock
@@ -49,17 +48,15 @@ requests==2.25.0          # via edx-drf-extensions, edx-rest-api-client, pyjwkes
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, event-tracking, fs, pyjwkest, python-dateutil, stevedore, xblock
+six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, event-tracking, fs, pyjwkest, python-dateutil, xblock
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.4.1           # via django
-stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
-typing==3.7.4.3           # via fs
+stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
 urllib3==1.26.2           # via requests
 vine==1.3.0               # via amqp, celery
 web-fragments==0.3.2      # via xblock
 webob==1.8.6              # via xblock
 xblock==1.4.0             # via edx-when
-zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/celery44.txt
+++ b/requirements/celery44.txt
@@ -1,0 +1,5 @@
+amqp==2.6.1               # via kombu
+billiard==3.6.3.0         # via celery
+celery==4.4.7             # via -c requirements/constraints.txt, event-tracking
+kombu==4.6.11             # via celery
+vine==1.3.0               # via amqp, celery

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,0 +1,9 @@
+amqp==5.0.2               # via kombu
+billiard==3.6.3.0         # via celery
+celery==5.0.2             # via -c requirements/constraints.txt, event-tracking
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via celery, click-didyoumean, click-repl
+kombu==5.0.2              # via celery
+prompt-toolkit==3.0.8     # via click-repl
+vine==5.0.0               # via amqp, celery

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,7 @@ jsonfield2==3.0.3
 
 # Use latest LTS version
 Django<2.3
+
+
+# maintaining the production version.
+celery<5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,6 +11,7 @@ certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint, pip-tools
+colorama==0.4.4           # via twine
 diff-cover==4.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via virtualenv
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/dev.in, -r requirements/quality.in, edx-i18n-tools
@@ -19,18 +20,17 @@ edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.in
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via inflect, path, pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-inflect==3.0.2            # via jinja2-pluralize
+inflect==5.0.2            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
+keyring==21.5.0           # via twine
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 packaging==20.7           # via bleach, tox
 path.py==12.5.0           # via -r requirements/dev.in, edx-i18n-tools
-path==13.1.0              # via path.py
+path==15.0.1              # via path.py
 pip-tools==5.4.0          # via -r requirements/dev.in
 pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via diff-cover, tox
@@ -49,6 +49,7 @@ pyyaml==5.3.1             # via edx-i18n-tools
 readme-renderer==28.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.25.0          # via requests-toolbelt, twine
+rfc3986==1.4.0            # via twine
 six==1.15.0               # via astroid, bleach, edx-i18n-tools, edx-lint, pip-tools, readme-renderer, tox, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.4.1           # via django
@@ -56,14 +57,12 @@ toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.20.1               # via -r requirements/dev.in, tox-battery
 tqdm==4.54.1              # via twine
-twine==1.15.0             # via -r requirements/dev.in, -r requirements/quality.in
-typed-ast==1.4.1          # via astroid
+twine==3.2.0              # via -r requirements/dev.in, -r requirements/quality.in
 urllib3==1.26.2           # via requests
 virtualenv==20.2.2        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.36.1             # via -r requirements/dev.in
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,11 +10,11 @@ appdirs==1.4.4            # via fs
 babel==2.9.0              # via sphinx
 billiard==3.6.3.0         # via celery
 bleach==3.2.1             # via readme-renderer
-celery==4.4.7             # via event-tracking
+celery==4.4.7             # via -c requirements/constraints.txt, event-tracking
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via doc8, requests
-cryptography==3.2.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt
 django-crum==0.7.9        # via -r requirements/base.in, edx-django-utils
 django-ipware==3.0.2      # via -r requirements/base.in
 django-model-utils==4.1.1  # via -r requirements/base.in, edx-when
@@ -36,7 +36,6 @@ fs==2.4.11                # via xblock
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.1.1  # via kombu
 jinja2==2.11.2            # via sphinx
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==4.6.11             # via celery
@@ -63,7 +62,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 restructuredtext-lint==1.3.2  # via doc8
 rules==2.2                # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via bleach, cryptography, doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, event-tracking, fs, pockets, pyjwkest, python-dateutil, readme-renderer, sphinxcontrib-napoleon, stevedore, xblock
+six==1.15.0               # via bleach, cryptography, doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, event-tracking, fs, pockets, pyjwkest, python-dateutil, readme-renderer, sphinxcontrib-napoleon, xblock
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme
@@ -75,15 +74,13 @@ sphinxcontrib-napoleon==0.7  # via -r requirements/doc.in
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via django
-stevedore==1.32.0         # via doc8, edx-django-utils, edx-opaque-keys
-typing==3.7.4.3           # via fs
+stevedore==3.3.0          # via doc8, edx-django-utils, edx-opaque-keys
 urllib3==1.26.2           # via requests
 vine==1.3.0               # via amqp, celery
 web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach
 webob==1.8.6              # via xblock
 xblock==1.4.0             # via edx-when
-zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -10,11 +10,13 @@ certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
+colorama==0.4.4           # via twine
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/quality.in
 docutils==0.16            # via readme-renderer
 edx-lint==1.5.2           # via -r requirements/quality.in
 idna==2.10                # via requests
 isort==4.3.21             # via -r requirements/quality.in, pylint
+keyring==21.5.0           # via twine
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 packaging==20.7           # via bleach
@@ -31,12 +33,12 @@ pytz==2020.4              # via django
 readme-renderer==28.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.25.0          # via requests-toolbelt, twine
+rfc3986==1.4.0            # via twine
 six==1.15.0               # via astroid, bleach, edx-lint, readme-renderer
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.4.1           # via django
 tqdm==4.54.1              # via twine
-twine==1.15.0             # via -r requirements/quality.in
-typed-ast==1.4.1          # via astroid
+twine==3.2.0              # via -r requirements/quality.in
 urllib3==1.26.2           # via requests
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,20 +4,16 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via kombu
 apipkg==1.5               # via execnet
 appdirs==1.4.4            # via fs
 attrs==20.3.0             # via pytest
-billiard==3.6.3.0         # via celery
 bok-choy==1.1.1           # via -r requirements/test.in
-celery==4.4.7             # via event-tracking
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.2              # via code-annotations
 code-annotations==0.10.2  # via -r requirements/test.in
 coverage==5.3             # via pytest-cov
-cryptography==3.2.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 django-crum==0.7.9        # via -r requirements/base.in, edx-django-utils
 django-ipware==3.0.2      # via -r requirements/base.in
@@ -39,21 +35,19 @@ future==0.18.2            # via pyjwkest
 httmock==1.4.0            # via -r requirements/test.in
 httpretty==1.0.3          # via -r requirements/test.in
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via kombu, path, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 jinja2==2.11.2            # via code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
-kombu==4.6.11             # via celery
 lazy==1.4                 # via bok-choy
-logilab-common==1.6.1     # via -r requirements/test.in
+logilab-common==1.8.0     # via -r requirements/test.in
 lxml==4.6.2               # via xblock
 markupsafe==1.1.1         # via jinja2, xblock
-mock==3.0.5               # via -r requirements/test.in
+mock==4.0.3               # via -r requirements/test.in
+mypy-extensions==0.4.3    # via logilab-common
 newrelic==5.22.1.152      # via edx-django-utils
 packaging==20.7           # via pytest
 path.py==12.5.0           # via edx-i18n-tools
-path==13.1.0              # via path.py
-pathlib2==2.3.5           # via pytest
+path==15.0.1              # via path.py
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -80,21 +74,19 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
 selenium==3.141.0         # via -r requirements/test.in, bok-choy
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via bok-choy, cryptography, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, event-tracking, fs, mock, pathlib2, pyjwkest, python-dateutil, responses, stevedore, xblock
+six==1.15.0               # via bok-choy, cryptography, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, event-tracking, fs, pyjwkest, python-dateutil, responses, xblock
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.4.1           # via django
-stevedore==1.32.0         # via code-annotations, edx-django-utils, edx-opaque-keys
+stevedore==3.3.0          # via code-annotations, edx-django-utils, edx-opaque-keys
 sure==1.2.7               # via -r requirements/test.in
 testfixtures==6.16.0      # via -r requirements/test.in
 text-unidecode==1.3       # via python-slugify
 toml==0.10.2              # via pytest
-typing==3.7.4.3           # via fs
+typing-extensions==3.7.4.3  # via logilab-common
 urllib3==1.26.2           # via requests, responses, selenium
-vine==1.3.0               # via amqp, celery
 web-fragments==0.3.2      # via xblock
 webob==1.8.6              # via xblock
 xblock==1.4.0             # via edx-when
-zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-        py35-django22-drf{310,latest},py38-django{22,30}-drf{310,latest}
+        py38-celery{44,50}-django{22,30}-drf{310,latest}
         docs,
         quality,
         version_check,
@@ -13,6 +13,8 @@ deps =
     django30: Django>=3.0,<3.1
     drf310: djangorestframework<3.11.0
     drflatest: djangorestframework
+    celery44: -r{toxinidir}/requirements/celery44.txt
+    celery50: -r{toxinidir}/requirements/celery50.txt
     -rrequirements/test.txt
 commands =
     python -Wd -m pytest {posargs:-n 3}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-2166

- Adding celery 5.0 testing using tox.
- Drop py3.5 testing
- execute make upgrade using py38 with celery<5 constraint.

In next PR I will execute the make upgrade with celery==5.0.2
