### PR TITLE
block onboarding entrance after exam due date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.5] - 2021-01-05
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Cover `Start System Check` button on the proctoring instruction page with the
   conditions software download link is provided by the proctoring provider,
   since some providers do not has that step in the onboarding process.
@@ -21,6 +23,7 @@ Unreleased
 * Added `time_remaining_seconds` field to the exam attempt model in order to
   allow the remaining time on an exam attempt to be saved after it enters an
   error state.
+* Fix bug allowing learners access to onboarding setup after exam due date.
 
 [2.5.4] - 2020-12-17
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.4'
+__version__ = '2.5.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1996,7 +1996,11 @@ def _get_onboarding_exam_view(exam, context, exam_id, user_id, course_id):
     if not user.is_active:
         student_view_template = 'proctored_exam/inactive_account.html'
     elif not attempt_status:
-        student_view_template = 'onboarding_exam/entrance.html'
+        # if exam due date has passed, then we can't take the exam
+        if is_exam_passed_due(exam, user_id):
+            student_view_template = 'proctored_exam/expired.html'
+        else:
+            student_view_template = 'onboarding_exam/entrance.html'
     elif attempt_status == ProctoredExamStudentAttemptStatus.started:
         # when we're taking the exam we should not override the view
         return None

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -705,7 +705,11 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         )
         self.assertIn(self.wait_deadline_msg, rendered_response)
 
-    def test_proctored_exam_attempt_with_past_due_datetime(self):
+    @ddt.data(
+        False,
+        True,
+    )
+    def test_proctored_exam_attempt_with_past_due_datetime(self, is_onboarding_exam):
         """
         Test for get_student_view for proctored exam with past due datetime
         """
@@ -713,7 +717,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         due_date = datetime.now(pytz.UTC) + timedelta(days=1)
 
         # exam is created with due datetime which has already passed
-        self._create_exam_with_due_time(due_date=due_date)
+        self._create_exam_with_due_time(due_date=due_date, is_practice_exam=is_onboarding_exam)
 
         # due_date is exactly after 24 hours, if student arrives after 2 days
         # then he can not attempt the proctored exam
@@ -740,7 +744,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
                 content_id=self.content_id_for_exam_with_due_date,
                 context={
                     'is_proctored': True,
-                    'is_practice_exam': True,
+                    'is_practice_exam': is_onboarding_exam,
                     'display_name': self.exam_name,
                     'default_time_limit_mins': self.default_time_limit,
                     'due_date': due_date,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

Learners had been gaining access to onboarding setup steps after an exam has already passed its due date. This would cause incomplete data on the Proctortrack side and errors creating the exam attempt on the edX side.

**JIRA:**

[MST-254](https://openedx.atlassian.net/browse/MST-254)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.