### PR TITLE
MST-530: Modify StudentProctoredExamAttempt PUT Endpoint to Add New ready_to_resume State to Support Resuming Exams

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[2.5.5] - 2021-01-05
+[2.5.6] - 2021-01-06
+* Updated the StudentProctoredExamAttempt view's PUT handler to allow for a 
+  new action "mark_ready_to_resume", which transitions exam attempts in the "error" state
+  to a "ready_to_resume" state.
+
+[2.5.5] - 2020-01-05
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Cover `Start System Check` button on the proctoring instruction page with the
   conditions software download link is provided by the proctoring provider,

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.5'
+__version__ = '2.5.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -65,6 +65,9 @@ class ProctoredExamStudentAttemptStatus:
     # the course end date has passed
     expired = 'expired'
 
+    # the learner is ready to resume their errored proctored exam
+    ready_to_resume = 'ready_to_resume'
+
     # the onboarding attempt has been reset
     onboarding_reset = 'onboarding_reset'
 
@@ -88,7 +91,7 @@ class ProctoredExamStudentAttemptStatus:
         """
         return status in [
             cls.declined, cls.timed_out, cls.submitted, cls.second_review_required,
-            cls.verified, cls.rejected, cls.error,
+            cls.verified, cls.rejected, cls.error, cls.ready_to_resume,
             cls.onboarding_missing, cls.onboarding_pending, cls.onboarding_failed, cls.onboarding_expired
         ]
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -384,22 +384,25 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
     /edx_proctoring/v1/proctored_exam/attempt
 
     Supports:
-        HTTP PUT: Stops an exam attempt.
+        HTTP PUT: Update an exam attempt's status.
         HTTP GET: Returns the status of an exam attempt.
         HTTP DELETE: Delete an exam attempt.
 
 
     HTTP PUT
-    Stops the existing exam attempt in progress
+    Updates the exam attempt status based on a provided action.
     PUT data : {
         ....
     }
 
-    **PUT data Parameters**
-        * exam_id: The unique identifier for the proctored exam attempt.
+    PUT Query Parameters
+        'attempt_id': The unique identifier for the proctored exam attempt.
+
+    PUT data Parameters
+        'action': The action to perform on the proctored exam attempt, specified by the `attempt_id` query paremeter.
 
     **Response Values**
-        * {'exam_attempt_id': ##}, The exam_attempt_id of the Proctored Exam Attempt..
+        * {'exam_attempt_id': ##}, The exam_attempt_id of the Proctored Exam Attempt.
 
 
     HTTP GET
@@ -453,7 +456,15 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
 
     def put(self, request, attempt_id):
         """
-        HTTP PUT handler. To stop an exam.
+        HTTP PUT handler to update exam attempt status based on an action.
+
+        Parameters:
+            request: The request object.
+            attempt_id: The attempt ID of the proctored exam attempt whose status should be changed.
+
+        Returns:
+            A Response object containing the `exam_attempt_id`.
+
         """
         attempt = get_exam_attempt_by_id(attempt_id)
 
@@ -534,6 +545,13 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
                 request.user.id,
                 ProctoredExamStudentAttemptStatus.declined
             )
+        elif action == 'mark_ready_to_resume':
+            exam_attempt_id = update_attempt_status(
+                attempt['proctored_exam']['id'],
+                request.user.id,
+                ProctoredExamStudentAttemptStatus.ready_to_resume
+            )
+
         data = {"exam_attempt_id": exam_attempt_id}
         return Response(data)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

This pull request updates the `StudentProctoredExamAttempt` view, augmenting the PUT request handler to allow for a new action: `mark_ready_to_resume`. This pull request also updates the Python proctoring API that is called by the aforementioned view to change an exam attempt's status to `ready_to_resume` when supplied the action `mark_ready_to_resume`, but only when the original status is `error`.

**JIRA:**

[MST-530](https://openedx.atlassian.net/browse/MST-530)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.