### PR TITLE
[MST-531] Allow creation of multiple active exam attempts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.7] - 2021-01-08
+~~~~~~~~~~~~~~~~~~~~
+* Allow the creation of multiple exam attempts for a single user in a single exam, as long
+  as the most recent attempt is `ready_to_resume` or `resumed`. When an exam is resumed, the
+  time remaining is saved to the new attempt and is used to calculate the expiration time.
+
 [2.5.6] - 2021-01-06
 ~~~~~~~~~~~~~~~~~~~~
 * Updated the StudentProctoredExamAttempt view's PUT handler to allow for a 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.6'
+__version__ = '2.5.7'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -361,7 +361,7 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
     @classmethod
     def create_exam_attempt(cls, exam_id, user_id, student_name, attempt_code,
                             taking_as_proctored, is_sample_attempt, external_id,
-                            review_policy_id=None, status=None):
+                            review_policy_id=None, status=None, time_remaining_seconds=None):
         """
         Create a new exam attempt entry for a given exam_id and
         user_id.
@@ -376,7 +376,8 @@ class ProctoredExamStudentAttempt(TimeStampedModel):
             is_sample_attempt=is_sample_attempt,
             external_id=external_id,
             status=status,
-            review_policy_id=review_policy_id
+            review_policy_id=review_policy_id,
+            time_remaining_seconds=time_remaining_seconds
         )  # pylint: disable=no-member
 
     def delete_exam_attempt(self):

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -68,6 +68,9 @@ class ProctoredExamStudentAttemptStatus:
     # the learner is ready to resume their errored proctored exam
     ready_to_resume = 'ready_to_resume'
 
+    # the exam has been resumed and new attempt has been created
+    resumed = 'resumed'
+
     # the onboarding attempt has been reset
     onboarding_reset = 'onboarding_reset'
 
@@ -91,7 +94,7 @@ class ProctoredExamStudentAttemptStatus:
         """
         return status in [
             cls.declined, cls.timed_out, cls.submitted, cls.second_review_required,
-            cls.verified, cls.rejected, cls.error, cls.ready_to_resume,
+            cls.verified, cls.rejected, cls.error, cls.ready_to_resume, cls.resumed,
             cls.onboarding_missing, cls.onboarding_pending, cls.onboarding_failed, cls.onboarding_expired
         ]
 
@@ -156,6 +159,15 @@ class ProctoredExamStudentAttemptStatus:
         """
         return status in [
             cls.started, cls.ready_to_submit
+        ]
+
+    @classmethod
+    def is_resume_status(cls, status):
+        """
+        Returns a boolean if the status passed is "resumed" or "ready to resume"
+        """
+        return status in [
+            cls.ready_to_resume, cls.resumed
         ]
 
 

--- a/edx_proctoring/tests/test_utils.py
+++ b/edx_proctoring/tests/test_utils.py
@@ -3,12 +3,52 @@ File that contains tests for the util methods.
 """
 
 import unittest
+from datetime import datetime
 from itertools import product
 
 import ddt
+import pytz
+from freezegun import freeze_time
 
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
-from edx_proctoring.utils import _emit_event, humanized_time, is_reattempting_exam
+from edx_proctoring.utils import _emit_event, get_time_remaining_for_attempt, humanized_time, is_reattempting_exam
+
+
+class TestGetTimeRemainingForAttempt(unittest.TestCase):
+    """
+    Class to test get_time_remaining_for_attempt
+    """
+    def setUp(self):
+        """
+        Initialize
+        """
+        super(TestGetTimeRemainingForAttempt, self).setUp()
+        self.now_utc = datetime.now(pytz.UTC)
+
+    def test_not_started(self):
+        """
+        Test to return 0 if the exam attempt has not been started.
+        """
+        attempt = {
+            'started_at': None,
+            'allowed_time_limit_mins': 10,
+            'time_remaining_seconds': None
+        }
+        time_remaining_seconds = get_time_remaining_for_attempt(attempt)
+        self.assertEqual(time_remaining_seconds, 0)
+
+    def test_get_time_remaining_started(self):
+        """
+        Test to get the time remaining on an attempt after the exam has started.
+        """
+        with freeze_time(self.now_utc):
+            attempt = {
+                'started_at': self.now_utc,
+                'allowed_time_limit_mins': 10,
+                'time_remaining_seconds': None
+            }
+            time_remaining_seconds = get_time_remaining_for_attempt(attempt)
+            self.assertEqual(time_remaining_seconds, 600)
 
 
 class TestHumanizedTime(unittest.TestCase):

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -274,7 +274,8 @@ class ProctoredExamTestCase(LoggedInTestCase):
             is_active=False
         )
 
-    def _create_exam_attempt(self, exam_id, status=ProctoredExamStudentAttemptStatus.created, is_practice_exam=False):
+    def _create_exam_attempt(self, exam_id, status=ProctoredExamStudentAttemptStatus.created,
+                             is_practice_exam=False, time_remaining_seconds=None):
         """
         Creates the ProctoredExamStudentAttempt object.
         """
@@ -286,6 +287,7 @@ class ProctoredExamTestCase(LoggedInTestCase):
             allowed_time_limit_mins=10,
             taking_as_proctored=True,
             is_sample_attempt=is_practice_exam,
+            time_remaining_seconds=time_remaining_seconds,
         )
 
         if status in (ProctoredExamStudentAttemptStatus.started,

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -45,6 +45,7 @@ def get_time_remaining_for_attempt(attempt):
 
     # need to adjust for allowances
     expires_at = attempt['started_at'] + timedelta(minutes=attempt['allowed_time_limit_mins'])
+
     now_utc = datetime.now(pytz.UTC)
 
     if expires_at > now_utc:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

The `create_exam_attempt` function has been modified to allow multiple active attempts, as long as all other active attempts are in the `ready_to_resume` or `resumed` state. This saves the remaining time left in the new attempt, which is used to calculate the remaining time instead of the initial time limit.

**JIRA:**

[MST-531](https://openedx.atlassian.net/browse/MST-531)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.