### PR TITLE
[MST-593] Ignore history table when viewing onboarding status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.8] - 2021-01-12
+~~~~~~~~~~~~~~~~~~~~
+* Ignore the `ProctoredExamStudentAttemptHistory` table when viewing onboarding status.
+  This fixes a bug where the status would return `verified` even after all attempts had
+  been deleted.
+
 [2.5.7] - 2021-01-08
 ~~~~~~~~~~~~~~~~~~~~
 * Allow the creation of multiple exam attempts for a single user in a single exam, as long

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.7'
+__version__ = '2.5.8'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -4,7 +4,6 @@ Proctored Exams HTTP-based API endpoints
 
 import json
 import logging
-from itertools import chain
 
 import waffle
 from crum import get_current_request
@@ -361,9 +360,7 @@ class StudentOnboardingStatusView(ProctoredAPIView):
 
         data['onboarding_link'] = reverse('jump_to', args=[course_id, onboarding_exam.content_id])
 
-        recent_attempts = ProctoredExamStudentAttempt.objects.filter(**attempt_filters).order_by('-modified')
-        past_attempts = ProctoredExamStudentAttemptHistory.objects.filter(**attempt_filters).order_by('-modified')
-        attempts = list(chain(recent_attempts, past_attempts))
+        attempts = ProctoredExamStudentAttempt.objects.filter(**attempt_filters).order_by('-modified')
         if len(attempts) == 0:
             # If there are no attempts, return the data with 'onboarding_status' set to None
             return Response(data)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Ignore the `ProctoredExamStudentAttemptHistory` table when viewing onboarding status. This fixes a bug where the status would return `verified` even after all attempts had been deleted.

**JIRA:**

[MST-593](https://openedx.atlassian.net/browse/MST-593)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.