### PR TITLE
[MST-545] update StudentProctoredExamAttempt view's PUT handler to allow a staf…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.13] - 2021-01-20
+~~~~~~~~~~~~~~~~~~~~~
+* Allow staff users to modify another user's exam attempt status via the
+  the StudentProctoredExamAttempt view's PUT handler only when the action is
+  "mark_ready_to_resume" and the user ID is passed in via the request data.
+
 [2.5.12] - 2021-01-20
 ~~~~~~~~~~~~~~~~~~~~~
 * Allow blank fields in Django admin for `external_id`, `due_date`, and `backend`

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.12'
+__version__ = '2.5.13'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -406,6 +406,7 @@ class ProctoredExamAttemptForm(forms.ModelForm):
         (ProctoredExamStudentAttemptStatus.verified, _('Verified')),
         (ProctoredExamStudentAttemptStatus.rejected, _('Rejected')),
         (ProctoredExamStudentAttemptStatus.error, _('Error')),
+        (ProctoredExamStudentAttemptStatus.ready_to_resume, _('Ready To Resume')),
     ]
     if settings.DEBUG:
         STATUS_CHOICES.extend([

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.12",
+  "version": "2.5.13",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

* Allow staff users to modify another user's exam attempt status via the
  the StudentProctoredExamAttempt view's PUT handler only when the action is
  "mark_ready_to_resume" and the user ID is passed in via the request data.
* Update Django admin to allow selection of "mark_ready_to_resume" state in admin page for proctored exam attempts.

**JIRA:**

[MST-545](https://openedx.atlassian.net/browse/MST-545)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.