### PR TITLE
[MST-543] Update email templates to use a proctoring escalation email

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-* Replace Travis CI with Github Actions
+
+[2.6.0] - 2021-01-21
+~~~~~~~~~~~~~~~~~~~~~
+* Replace Travis CI with Github Actions.
+* If a course has a proctoring escalation email set, emails that are sent when an
+  exam attempt is verified or rejected will contain that email address rather than a
+  link to support.
 
 [2.5.13] - 2021-01-20
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.13'
+__version__ = '2.6.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/management/commands/tests/test_set_attempt_status.py
+++ b/edx_proctoring/management/commands/tests/test_set_attempt_status.py
@@ -13,7 +13,12 @@ from edx_proctoring.api import create_exam, get_current_exam_attempt
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
-from edx_proctoring.tests.test_services import MockCertificateService, MockCreditService, MockGradesService
+from edx_proctoring.tests.test_services import (
+    MockCertificateService,
+    MockCreditService,
+    MockGradesService,
+    MockInstructorService
+)
 from edx_proctoring.tests.utils import LoggedInTestCase
 
 
@@ -31,6 +36,7 @@ class SetAttemptStatusTests(LoggedInTestCase):
         set_runtime_service('credit', MockCreditService())
         set_runtime_service('grades', MockGradesService())
         set_runtime_service('certificates', MockCertificateService())
+        set_runtime_service('instructor', MockInstructorService())
         self.exam_id = create_exam(
             course_id='foo',
             content_id='bar',

--- a/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_satisfactory_email.html
@@ -19,9 +19,9 @@
 <p>
     {% block contact_information %}
     {% blocktrans %}
-    If you have any questions about your results, you can reach edX Support at 
+    If you have any questions about your results, you can reach out at 
         <a href="{{contact_url}}">
-            {{ contact_url }}
+            {{ contact_url_text }}
         </a>.
     {% endblocktrans %}
     {% endblock %}

--- a/edx_proctoring/templates/emails/proctoring_attempt_unsatisfactory_email.html
+++ b/edx_proctoring/templates/emails/proctoring_attempt_unsatisfactory_email.html
@@ -23,10 +23,10 @@
 <p>
     {% block contact_information %}
     {% blocktrans %}
-        To appeal your proctored exam results, please reach out to edX Support with any relevant information
+        To appeal your proctored exam results, please reach out with any relevant information
         about your exam at 
         <a href="{{contact_url}}">
-            {{ contact_url }}
+            {{ contact_url_text }}
         </a>.
     {% endblocktrans %}
     {% endblock %}

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -88,7 +88,8 @@ from .test_services import (
     MockCreditService,
     MockCreditServiceNone,
     MockCreditServiceWithCourseEndDate,
-    MockGradesService
+    MockGradesService,
+    MockInstructorService
 )
 from .utils import ProctoredExamTestCase
 
@@ -106,6 +107,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         """
         super().setUp()
         set_runtime_service('certificates', MockCertificateService())
+        set_runtime_service('instructor', MockInstructorService())
 
     def tearDown(self):
         """
@@ -113,6 +115,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         """
         super().tearDown()
         set_runtime_service('certificates', None)
+        set_runtime_service('instructor', None)
 
     def _add_allowance_for_user(self):
         """

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -124,6 +124,8 @@ class MockInstructorService:
         """
         self.is_user_course_staff = is_user_course_staff
         self.notifications = []
+        self.proctoring_escalation_email = None
+        self.proctoring_escalation_error = None
 
     # pylint: disable=unused-argument
     def delete_student_attempt(self, student_identifier, course_id, content_id, requesting_user):
@@ -146,6 +148,26 @@ class MockInstructorService:
         Mocked implementation of send_support_notification
         """
         self.notifications.append((course_id, exam_name, student_username, review_status, review_url))
+
+    def get_proctoring_escalation_email(self, course_key):  # pylint: disable=unused-argument
+        """
+        Get a mock return value for get_proctoring_escalation_email
+        """
+        if self.proctoring_escalation_error:
+            raise self.proctoring_escalation_error
+        return self.proctoring_escalation_email
+
+    def mock_proctoring_escalation_email(self, email):
+        """
+        Change the default return value for get_proctoring_escalation_email
+        """
+        self.proctoring_escalation_email = email
+
+    def mock_proctoring_escalation_email_error(self, error):
+        """
+        Mock an error that raises from get_proctoring_escalation_email
+        """
+        self.proctoring_escalation_error = error
 
 
 class TestProctoringService(unittest.TestCase):

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -64,6 +64,7 @@ class ProctoredExamsApiTests(LoggedInTestCase):
         """
         super().setUp()
         set_runtime_service('credit', MockCreditService())
+        set_runtime_service('instructor', MockInstructorService())
 
     def test_no_anonymous_access(self):
         """
@@ -99,6 +100,7 @@ class ProctoredExamViewTests(LoggedInTestCase):
         self.user.save()
         self.client.login_user(self.user)
         set_runtime_service('credit', MockCreditService())
+        set_runtime_service('instructor', MockInstructorService())
 
     def test_create_exam(self):
         """

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.13",
+  "version": "2.6.0",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

If a proctoring escalation email is given, this will replace the link to edX support in automated emails for verified and rejected proctored exam attempts.

**JIRA:**

[MST-543](https://openedx.atlassian.net/browse/MST-543)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.