### PR TITLE
Allow blank fields for ProctoredExam in Django admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.12] - 2021-01-20
+~~~~~~~~~~~~~~~~~~~~~
+* Allow blank fields in Django admin for `external_id`, `due_date`, and `backend`
+  in proctored exams.
+
 [2.5.11] - 2021-01-19
 ~~~~~~~~~~~~~~~~~~~~~
 * Added ProctoredExam to django admin

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.5.11'
+__version__ = '2.5.12'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -27,6 +27,29 @@ from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.utils import locate_attempt_by_attempt_code
 
 
+class ProctoredExamForm(forms.ModelForm):
+    """
+    Admin form for reading/updating a Proctored Exam
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['external_id'].required = False
+        self.fields['due_date'].required = False
+        self.fields['backend'].required = False
+
+    class Meta:
+        model = ProctoredExam
+        fields = '__all__'
+
+
+class ProctoredExamAdmin(admin.ModelAdmin):
+    """
+    Admin panel for Proctored Exams
+    """
+    form = ProctoredExamForm
+    search_fields = ['course_id', 'exam_name']
+
+
 class ProctoredExamReviewPolicyAdmin(admin.ModelAdmin):
     """
     The admin panel for Review Policies
@@ -479,7 +502,7 @@ def prettify_course_id(course_id):
     return course_id.replace('+', ' ').replace('/', ' ').replace('course-v1:', '')
 
 
-admin.site.register(ProctoredExam)
+admin.site.register(ProctoredExam, ProctoredExamAdmin)
 admin.site.register(ProctoredExamStudentAttempt, ProctoredExamStudentAttemptAdmin)
 admin.site.register(ProctoredExamReviewPolicy, ProctoredExamReviewPolicyAdmin)
 admin.site.register(ProctoredExamSoftwareSecureReview, ProctoredExamSoftwareSecureReviewAdmin)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

This fixes an issue where `ProctoredExam` allows the fields `external_id`, `due_date`, and `backend` to be null in the database, but they cannot be left blank in Django admin.

**JIRA:**

[MST-609](https://openedx.atlassian.net/browse/MST-609)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.