### PR TITLE
Added logic to account for enrollment when returning onboarding status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.6.2] - 2021-01-25
+~~~~~~~~~~~~~~~~~~~~~
+* Update endpoint that returns onboarding exam status to account for
+  users enrollment mode.
+
 [2.6.1] - 2021-01-25
 ~~~~~~~~~~~~~~~~~~~~~
 * Add a dropdown component.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.6.1'
+__version__ = '2.6.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -355,6 +355,15 @@ class StudentOnboardingStatusView(ProctoredAPIView):
                 status=404,
                 data={'detail': _('There is no onboarding exam related to this course id.')}
             )
+
+        user = get_user_model().objects.get(username=(username or request.user.username))
+
+        if not user.has_perm('edx_proctoring.can_take_proctored_exam', onboarding_exam):
+            return Response(
+                status=404,
+                data={'detail': _('There is no exam accessible to this user.')}
+            )
+
         # Also filter attempts by the course_id
         attempt_filters['proctored_exam__course_id'] = course_id
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

@edx/masters-devs-cosmonauts 
The onboarding status endpoint does not currently take into account if a user is in an enrollment mode that is eligible for proctored exams. Now this endpoint should return a 404 when a user does not have the proper permissions to take proctored exams.

**JIRA:**

[MST-579](https://openedx.atlassian.net/browse/MST-579)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.