### PR TITLE
[MST-545] add dropdown menu to Instructor Dashboard Proctored Exam Attempts pan…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,21 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.6.1] - 2021-01-25
+~~~~~~~~~~~~~~~~~~~~~
+* Add a dropdown component.
+* If the "data-enable-exam-resume-proctoring-improvements" data attribute on the element of the ProctoredExamAttemptView
+  Backbone is true,
+
+  * use the dropdown menu component on the Instructor Dashboard Proctored Exam Attempt panel for proctored exam attempts in the error state, providing the following options:
+    
+    * Resume, which transitions the exam attempt into the ready_to_resume state.
+    * Reset, which behaves the same as the previous reset functionality, originally exposed via the [x] link.
+  * change the [x] link to Reset for exam attempts in other states.
+
+* If the "data-enable-exam-resume-proctoring-improvements" data attribute on the element of the ProctoredExamAttemptView Backbone is
+  false there is no change.
+
 [2.6.0] - 2021-01-21
 ~~~~~~~~~~~~~~~~~~~~~
 * Replace Travis CI with Github Actions.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.6.0'
+__version__ = '2.6.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/settings/common.py
+++ b/edx_proctoring/settings/common.py
@@ -29,7 +29,8 @@ def plugin_settings(settings):
             'proctoring/js/views/proctored_exam_info.js',
             'proctoring/js/views/proctored_exam_instructor_launch.js',
             'proctoring/js/proctored_app.js',
-            'proctoring/js/exam_action_handler.js'
+            'proctoring/js/exam_action_handler.js',
+            'proctoring/js/dropdown.js'
         ]
     )
     if hasattr(settings, 'PIPELINE'):

--- a/edx_proctoring/static/proctoring/js/dropdown.js
+++ b/edx_proctoring/static/proctoring/js/dropdown.js
@@ -1,0 +1,96 @@
+// This dropdown component was borrowed from
+// https://github.com/edx/edx-platform/blob/master/lms/static/js/dashboard/dropdown.js.
+// It has been slightly modified to fit the needs of the edx-proctoring library.
+edx = edx || {};
+
+(function($) {
+    'use strict';
+
+    var keyCodes = {
+        TAB: 9,
+        ESCAPE: 27,
+        SPACE: 32,
+        ARROWUP: 38,
+        ARROWDOWN: 40
+    };
+
+    edx.dashboard = edx.dashboard || {};
+    edx.dashboard.dropdown = {};
+
+    edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu = function(event) {
+        var $target = $(event.currentTarget),
+            dashboardIndex = $target.data().dashboardIndex,
+            $dropdown = $($target.data('dropdownSelector') || '#actions-dropdown-' + dashboardIndex),
+            $dropdownButton = $($target.data('dropdownButtonSelector') || '#actions-dropdown-link-' + dashboardIndex),
+            ariaExpandedState = ($dropdownButton.attr('aria-expanded') === 'true'),
+            menuItems = $dropdown.find('a');
+
+        var catchKeyPress = function(object, keyPressEvent) {
+            // get currently focused item
+            var $focusedItem = $(':focus');
+
+            // get the index of the currently focused item
+            var focusedItemIndex = menuItems.index($focusedItem);
+
+            // var to store next focused item index
+            var itemToFocusIndex;
+
+            // if space or escape key pressed
+            if (keyPressEvent.which === keyCodes.SPACE || keyPressEvent.which === keyCodes.ESCAPE) {
+                $dropdownButton.click();
+                keyPressEvent.preventDefault();
+            } else if (keyPressEvent.which === keyCodes.AWRROWUP ||
+                (keyPressEvent.which === keyCodes.TAB && keyPressEvent.shiftKey)) {
+                // if up arrow key pressed or shift+tab
+                // if first item go to last
+                if (focusedItemIndex === 0 || focusedItemIndex === -1) {
+                    menuItems.last().focus();
+                } else {
+                    itemToFocusIndex = focusedItemIndex - 1;
+                    menuItems.get(itemToFocusIndex).focus();
+                }
+                keyPressEvent.preventDefault();
+            } else if (keyPressEvent.which === keyCodes.ARROWDOWN || keyPressEvent.which === keyCodes.TAB) {
+                // if down arrow key pressed or tab key
+                // if last item go to first
+                if (focusedItemIndex === menuItems.length - 1 || focusedItemIndex === -1) {
+                    menuItems.first().focus();
+                } else {
+                    itemToFocusIndex = focusedItemIndex + 1;
+                    menuItems.get(itemToFocusIndex).focus();
+                }
+                keyPressEvent.preventDefault();
+            }
+        };
+
+        // Toggle the visibility control for the selected element and set the focus
+        $dropdown.toggleClass('is-visible');
+        if ($dropdown.hasClass('is-visible')) {
+            $dropdown.attr('tabindex', -1);
+            $dropdown.focus();
+        } else {
+            $dropdown.removeAttr('tabindex');
+            $dropdownButton.focus();
+        }
+
+        // Inform the ARIA framework that the dropdown has been expanded
+        $dropdownButton.attr('aria-expanded', !ariaExpandedState);
+
+        // catch keypresses when inside dropdownMenu (we want to catch spacebar;
+        // escape; up arrow or shift+tab; and down arrow or tab)
+        $dropdown.on('keydown', function(e) {
+            catchKeyPress($(this), e);
+        });
+    };
+
+    edx.dashboard.dropdown.bindToggleButtons = function(selector) {
+        $(selector).bind(
+            'click',
+            edx.dashboard.dropdown.toggleExamAttemptActionDropdownMenu
+        );
+    };
+
+    $(document).ready(function() {
+        edx.dashboard.dropdown.bindToggleButtons('.action-more');
+    });
+}(jQuery));

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_instructor_launch.js
@@ -9,7 +9,7 @@ edx = edx || {};
         initialize: function() {
             var self = this;
             this.setElement($('.student-review-dashboard-container'));
-            this.tempate_url = '/static/proctoring/templates/dashboard.underscore';
+            this.template_url = '/static/proctoring/templates/dashboard.underscore';
             this.iframeHTML = null;
             this.doRender = true;
             this.context = {
@@ -24,7 +24,7 @@ edx = edx || {};
         },
         loadTemplateData: function() {
             var self = this;
-            $.ajax({url: self.tempate_url, dataType: 'html'})
+            $.ajax({url: self.template_url, dataType: 'html'})
                 .done(function(templateHtml) {
                     self.iframeHTML = _.template(templateHtml)(self.context);
                 });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -13,45 +13,49 @@ describe('ProctoredExamAttemptView', function() {
         }
 
     }];
-    var expectedProctoredExamAttemptJson = [{
-        attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
-        pagination_info: {
-            current_page: 1,
-            has_next: false,
-            has_previous: false,
-            total_pages: 1
-        },
-        proctored_exam_attempts: [{
-            allowed_time_limit_mins: 1,
-            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
-            completed_at: null,
-            created: '2015-08-10T09:15:45Z',
-            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
-            id: 43,
-            is_sample_attempt: false,
-            last_poll_ipaddr: null,
-            last_poll_timestamp: null,
-            modified: '2015-08-10T09:15:45Z',
-            started_at: '2015-08-10T09:15:45Z',
-            status: 'started',
-            taking_as_proctored: true,
-            proctored_exam: {
-                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
-                course_id: 'edX/DemoX/Demo_Course',
-                exam_name: 'Normal Exam',
-                external_id: null,
-                id: 17,
-                is_active: true,
-                is_practice_exam: false,
-                is_proctored: true,
-                time_limit_mins: 1
-            },
-            user: {
-                username: 'testuser1',
-                email: 'testuser1@test.com'
-            }
-        }]
-    }];
+    function getExpectedProctoredExamAttemptWithAttemptStatusJson(status) {
+        return (
+            [{
+                attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
+                pagination_info: {
+                    current_page: 1,
+                    has_next: false,
+                    has_previous: false,
+                    total_pages: 1
+                },
+                proctored_exam_attempts: [{
+                    allowed_time_limit_mins: 1,
+                    attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                    completed_at: null,
+                    created: '2015-08-10T09:15:45Z',
+                    external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                    id: 43,
+                    is_sample_attempt: false,
+                    last_poll_ipaddr: null,
+                    last_poll_timestamp: null,
+                    modified: '2015-08-10T09:15:45Z',
+                    started_at: '2015-08-10T09:15:45Z',
+                    status: status,
+                    taking_as_proctored: true,
+                    proctored_exam: {
+                        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                        course_id: 'edX/DemoX/Demo_Course',
+                        exam_name: 'Normal Exam',
+                        external_id: null,
+                        id: 17,
+                        is_active: true,
+                        is_practice_exam: false,
+                        is_proctored: true,
+                        time_limit_mins: 1
+                    },
+                    user: {
+                        username: 'testuser1',
+                        email: 'testuser1@test.com'
+                    }
+                }]
+            }]
+        );
+    }
 
     beforeEach(function() {
         html = '<div class="wrapper-content wrapper">' +
@@ -96,7 +100,8 @@ describe('ProctoredExamAttemptView', function() {
         '</tr></thead>' +
         '<% if (is_proctored_attempts) { %>' +
         '<tbody>' +
-        '<% _.each(proctored_exam_attempts, function(proctored_exam_attempt){ %><tr class="allowance-items">' +
+        '<% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){' +
+        '%><tr class="allowance-items">' +
         '<td>' +
         ' <%= proctored_exam_attempt.user.username %> ' +
         ' </td>' +
@@ -117,8 +122,40 @@ describe('ProctoredExamAttemptView', function() {
         ' <% if (proctored_exam_attempt.status){ %> <%= proctored_exam_attempt.status %> <% } else { %> N/A  <% } %> ' +
         '</td>' +
         '<td>' +
-        ' <% if (proctored_exam_attempt.status){ %> ' +
-        '<a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>  </td>' +
+        '<% if (proctored_exam_attempt.status){ %> ' +
+        '<% if (enable_exam_resume_proctoring_improvements) { %>' +
+        '<% if (proctored_exam_attempt.status == "error") { %>' +
+        '<div class="wrapper-action-more">' +
+        '<button class="action action-more" type="button" id="actions-dropdown-link-<%= dashboard_index %>"' +
+        'aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-<%= dashboard_index %>"' +
+        'data-dashboard-index="<%= dashboard_index %>">' +
+        '<span class="fa fa-cog" aria-hidden="true"></span>' +
+        '</button>' +
+        '<div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">' +
+        '<ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>"' +
+        'aria-label="<%- gettext("Available Actions") %>" role="menu">' +
+        '<li class="actions-item" role="menuitem">' +
+        '<a href="#" class="action resume-attempt"' +
+        'data-attempt-id="<%= proctored_exam_attempt.id %>" data-user-id="<%= proctored_exam_attempt.user.id %>" >' +
+        '<%- gettext("Resume") %>' +
+        '</a>' +
+        '</li>' +
+        '<li class="actions-item" id="actions-item-email-settings-<%= dashboard_index %>" role="menuitem">' +
+        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >' +
+        '<%- gettext("Reset") %>' +
+        '</a>' +
+        '</li>' +
+        '</ul>' +
+        '</div>' +
+        '</div>' +
+        '<% } else { %>' +
+        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >' +
+        '<%- gettext("Reset") %>' +
+        '</a>' +
+        '<% } %>' +
+        '<% } else { %>' +
+        '<a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>' +
+        '<% } %>' +
         ' <% } else { %>N/A <% } %>' +
         '</tr>' +
         ' <% }); %> ' +
@@ -153,7 +190,7 @@ describe('ProctoredExamAttemptView', function() {
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(expectedProctoredExamAttemptJson)
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
             ]
         );
         this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
@@ -172,7 +209,7 @@ describe('ProctoredExamAttemptView', function() {
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(expectedProctoredExamAttemptJson)
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
             ]
         );
         this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
@@ -231,7 +268,7 @@ describe('ProctoredExamAttemptView', function() {
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(expectedProctoredExamAttemptJson)
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
             ]
         );
 
@@ -255,7 +292,7 @@ describe('ProctoredExamAttemptView', function() {
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(expectedProctoredExamAttemptJson)
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
             ]
         );
 
@@ -278,7 +315,7 @@ describe('ProctoredExamAttemptView', function() {
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(expectedProctoredExamAttemptJson)
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
             ]
         );
         this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
@@ -323,7 +360,7 @@ describe('ProctoredExamAttemptView', function() {
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(expectedProctoredExamAttemptJson)
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('started'))
             ]
         );
 
@@ -337,5 +374,85 @@ describe('ProctoredExamAttemptView', function() {
         // after resetting the attempts, selector matches the existing attempts
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+    });
+    it('should mark exam attempt "ready_to_resume" on resume', function() {
+        // enable the dropdown via the enable-exam-resume-proctoring-improvements data attribute
+        setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id" ' +
+            'data-enable-exam-resume-proctoring-improvements="True"></div>');
+
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('error'))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
+
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1  </td>');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('error');
+
+        expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).not.toHaveLength(0);
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
+
+        this.server.respondWith('PUT', '/api/edx_proctoring/v1/proctored_exam/attempt/43',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
+
+        // again fetch the results after the proctored exam attempt is marked ready_to_resume
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('ready_to_resume'))
+            ]
+        );
+
+        spyOn(window, 'confirm').and.callFake(function() {
+            return true;
+        });
+
+        // click the gear button to open the action dropdown
+        spyOnEvent('.action-more', 'click');
+        $('.action-more').trigger('click');
+
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find(
+            '.actions-dropdown .actions-dropdown-list .actions-item .action'
+        )[0].text).toContain('Resume');
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
+        + '.actions-item .action')[1].text).toContain('Reset');
+
+        // trigger the resume attempt event.
+        spyOnEvent('.resume-attempt', 'click');
+        $('.resume-attempt').trigger('click');
+
+        expect(window.confirm.calls.argsFor(0)[0]).toEqual(
+            'Are you sure you want to resume this student\'s exam attempt?'
+        );
+
+        // process the resume attempt requests.
+        this.server.respond();
+        this.server.respond();
+
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('ready_to_resume');
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
     });
 });

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
@@ -1,4 +1,63 @@
 <div class="wrapper-content wrapper">
+    <style>
+        .actions-dropdown {
+            display: none;
+            position: absolute;
+            top: ($baseline*2);
+            right: 0;
+            z-index: 10;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1)
+        }
+
+        .actions-dropdown.is-visible {
+            display: block;
+            pointer-events: auto;
+        }
+
+        .wrapper-action-more .action-more, .wrapper-action-more .action-more:hover, .wrapper-action-more .action-more:focus {
+            background-image: none;
+            background-color: rgba(0, 0, 0, 0);
+            box-shadow: none;
+        }
+
+        .wrapper-action-more .action-more {
+            border: 1px solid transparent;
+        }
+        
+        .wrapper-action-more .action-more:hover, .wrapper-action-more .action-more:focus  {
+            border: 1px solid #e4e4e4;
+        }
+
+        .actions-dropdown-list {
+            list-style: none;
+            margin: 0;
+            text-indent: 0;
+
+            border-radius: 3px;
+            border: 1px solid #c8c8c8;
+            padding: 10px;
+            background: white;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+        }
+
+        .actions-drop-down-list li {
+            margin: 0;
+            padding: 0;
+        }
+
+        a.action {
+            text-decoration: none !important;
+        }
+
+        a.action:hover {
+            text-decoration: underline !important;
+        }
+
+        .actions-item:not(:last-child) {
+            margin-bottom: 10px;
+        }
+
+    </style>
     <% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>
         <div class="content exam-attempts-content">
             <div class="top-header">
@@ -91,7 +150,7 @@
                 </thead>
                 <% if (is_proctored_attempts) { %>
                 <tbody>
-                    <% _.each(proctored_exam_attempts, function(proctored_exam_attempt){ %>
+                    <% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){ %>
                         <tr class="allowance-items">
                             <td>
                                 <%- interpolate(gettext(' %(username)s '), { username: proctored_exam_attempt.user.username }, true) %>
@@ -111,8 +170,36 @@
                             <% } %>
                             </td>
                             <td>
-                             <% if (proctored_exam_attempt.status){ %>
-                                <a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>
+                                <% if (proctored_exam_attempt.status){ %>
+                                    <% if (enable_exam_resume_proctoring_improvements) { %>
+                                        <% if (proctored_exam_attempt.status == "error" ) { %>
+                                            <div class="wrapper-action-more">
+                                                <button class="action action-more" type="button" id="actions-dropdown-link-<%= dashboard_index %>" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-<%= dashboard_index %>" data-dashboard-index="<%= dashboard_index %>">
+                                                    <span class="fa fa-cog" aria-hidden="true"></span>
+                                                </button>
+                                                <div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">
+                                                    <ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>" aria-label="<%- gettext("Available Actions") %>" role="menu">
+                                                        <li class="actions-item" role="menuitem">
+                                                            <a href="#" class="action resume-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" data-user-id="<%= proctored_exam_attempt.user.id %>" >
+                                                                <%- gettext("Resume") %>
+                                                            </a>
+                                                        </li>
+                                                        <li class="actions-item" role="menuitem">
+                                                            <a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >
+                                                                <%- gettext("Reset") %>
+                                                            </a>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        <% } else { %>
+                                            <a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >
+                                                <%- gettext("Reset") %>
+                                            </a>
+                                        <% } %>
+                                    <% } else { %>
+                                        <a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>
+                                    <% } %>
                             </td>
                             <% } else { %>
                                 N/A

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -48,7 +48,8 @@ module.exports = function(config) {
             'edx_proctoring/static/proctoring/js/models/*.js',
             'edx_proctoring/static/proctoring/js/collections/*.js',
             'edx_proctoring/static/proctoring/js/views/*.js',
-            'edx_proctoring/static/proctoring/spec/*.js'
+            'edx_proctoring/static/proctoring/spec/*.js',
+            'edx_proctoring/static/proctoring/js/dropdown.js'
         ],
 
         // preprocess matching files before serving them to the browser

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
add dropdown menu to Instructor Dashboard Proctored Exam Attempts panel for exam attempts in the error state and change [x] to Reset for exam attempts not in the error state

**Description:**

* Adds a dropdown menu component.
* Uses the dropdown menu component on the Instructor Dashboard Proctored Exam Attempt panel for proctored exam attempts in the `error` state, providing two options:
    * `Resume`, which transitions the exam attempt into the `ready_to_resume` state.
    * `Reset`, which behaves the same as the previous reset functionality, originally exposed via the `[x]` link
* Changes the `[x]` link to `Reset` for exam attempts in other states.

NOTE: Feature toggle is exposed via [this](https://github.com/edx/edx-platform/pull/26147) pull request in edx-platform.

**Big Picture**
![image](https://user-images.githubusercontent.com/11871801/105437812-c435a380-5c2f-11eb-8ff0-f7a2cf72b458.png)

**Dropdown**
![image](https://user-images.githubusercontent.com/11871801/105439775-6efb9100-5c33-11eb-8367-9ebaa5a4e95f.png)

**Confirmation**
![image](https://user-images.githubusercontent.com/11871801/105439799-79b62600-5c33-11eb-8856-ab1857b95dca.png)

**User Flow**
![dropdown-demo-small-01-21-21](https://user-images.githubusercontent.com/11871801/105440521-afa7da00-5c34-11eb-9b38-845d93f0dd08.gif)
[HIGH QUALITY DEMO](https://user-images.githubusercontent.com/11871801/105440260-43c57180-5c34-11eb-9206-bddf58eb5c71.mp4)

**JIRA:**

[MST-545](https://openedx.atlassian.net/browse/MST-545)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.