### PR TITLE
Add exam attempts removal endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Add exam removal endpoint to be used on the instructor dashboard in place of the
+  current exam attempt reset endpoint as we now have multiple attempts. This new
+  endpoint is only accessible to course and edX staff
 
 [2.6.2] - 2021-01-25
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -117,6 +117,11 @@ urlpatterns = [
         views.AnonymousReviewCallback.as_view(),
         name='anonymous.proctoring_review_callback'
     ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/exam_id/(?P<exam_id>\d+)/user_id/(?P<user_id>[\d]+)/reset_attempts$',
+        views.StudentProctoredExamResetAttempts.as_view(),
+        name='proctored_exam.attempts.reset'
+    ),
     url(r'^', include('rest_framework.urls', namespace='rest_framework'))
 ]
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1298,3 +1298,21 @@ class UserRetirement(AuthenticatedAPIView):
         self._retire_user_allowances(user_id)
 
         return Response(status=code)
+
+
+class StudentProctoredExamResetAttempts(ProctoredAPIView):
+    """
+    Endpoint for deleting all attempts associated with a given exam and a given user
+    """
+
+    @method_decorator(require_course_or_global_staff)
+    def delete(self, request, exam_id, user_id):
+        """
+        HTTP DELETE handler, deletes all attempts for a given exam and username
+        """
+        attempts = ProctoredExamStudentAttempt.objects.filter(user_id=user_id, proctored_exam_id=exam_id)
+        if len(attempts) == 0:
+            return Response(data='There are no attempts related to this user id and exam id', status=404)
+        for attempt in attempts:
+            remove_exam_attempt(attempt.id, request.user)
+        return Response()


### PR DESCRIPTION
**Description:**

Created new endpoint to remove all attempts for a given exam id and user id. The endpoint makes use of the `remove_exam_attempt` function which updates the credit requirement status and grade overrides as needed.

This endpoint will be invoked on the instructor dashboard in place of the current reset attempt endpoint, as we now have multiple attempts. In the current code, only course staff or edX staff can use this endpoint.

**JIRA:**

[MST-582](https://openedx.atlassian.net/browse/MST-582)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.