### PR TITLE
Serialize exam object to fix 500 error

### DIFF
--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -357,8 +357,9 @@ class StudentOnboardingStatusView(ProctoredAPIView):
             )
 
         user = get_user_model().objects.get(username=(username or request.user.username))
+        serialized_onboarding_exam = ProctoredExamSerializer(onboarding_exam).data
 
-        if not user.has_perm('edx_proctoring.can_take_proctored_exam', onboarding_exam):
+        if not user.has_perm('edx_proctoring.can_take_proctored_exam', serialized_onboarding_exam):
             return Response(
                 status=404,
                 data={'detail': _('There is no exam accessible to this user.')}


### PR DESCRIPTION
**Description:**

Fix for [MST-582](https://openedx.atlassian.net/browse/MST-582). Exam object must be serialized before using it in perm.

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.