### PR TITLE
Bug fix for exam reset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[2.6.4] - 2021-01-26
+~~~~~~~~~~~~~~~~~~~~~
+* Fix bug that was preventing exams from being reset
 * Add exam removal endpoint to be used on the instructor dashboard in place of the
   current exam attempt reset endpoint as we now have multiple attempts. This new
   endpoint is only accessible to course and edX staff

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.6.3'
+__version__ = '2.6.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/signals.py
+++ b/edx_proctoring/signals.py
@@ -120,12 +120,17 @@ def on_attempt_changed(sender, instance, signal, **kwargs):  # pylint: disable=u
             if not result:
                 log.error(u'Failed to remove attempt %d from %s', instance.id, backend.verbose_name)
 
+        # check to see if there is a review that should be updated
         current_review = models.ProctoredExamSoftwareSecureReview.get_review_by_attempt_code(
             attempt_code=instance.attempt_code
         )
+        # archive attempt before updating the review
+        models.archive_model(models.ProctoredExamStudentAttemptHistory, instance, id='attempt_id')
         if current_review:
+            # update field to note that attempt is no longer active
             current_review.is_attempt_active = False
             current_review.save()
+        return
     models.archive_model(models.ProctoredExamStudentAttemptHistory, instance, id='attempt_id')
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

The current code was preventing an exam reset in self paced courses, where the exam would cause a change in certificate/grades. I believe this is caused by the fact that this line here https://github.com/edx/edx-proctoring/blob/a7ca6841fb09804986acf6c6f3156c4fcac72ba3/edx_proctoring/signals.py#L128 triggers this line https://github.com/edx/edx-proctoring/blob/a7ca6841fb09804986acf6c6f3156c4fcac72ba3/edx_proctoring/signals.py#L178 which expects an active attempt. To resolve this, I've updated the code to archive the attempt before saving the update to the review model to ensure that any post save workflow for the review model mirrors if an attempt is active or not. 

**JIRA:**

[MST-616](https://openedx.atlassian.net/browse/MST-616)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.