### PR TITLE
Update onboarding exam error interstitial

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.6.5] - 2021-01-28
+~~~~~~~~~~~~~~~~~~~~~
+* Update error interstitial to use the reset_exam_attempt flow that is used for other
+  onboarding attempt reset
+
 [2.6.4] - 2021-01-26
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix bug that was preventing exams from being reset
@@ -38,7 +43,7 @@ Unreleased
   Backbone is true,
 
   * use the dropdown menu component on the Instructor Dashboard Proctored Exam Attempt panel for proctored exam attempts in the error state, providing the following options:
-    
+
     * Resume, which transitions the exam attempt into the ready_to_resume state.
     * Reset, which behaves the same as the previous reset functionality, originally exposed via the [x] link.
   * change the [x] link to Reset for exam attempts in other states.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.6.4'
+__version__ = '2.6.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/onboarding_exam/error.html
+++ b/edx_proctoring/templates/onboarding_exam/error.html
@@ -16,7 +16,3 @@
   {% endblocktrans %}
 {% endblock %}
 
-{% block retry_cta %}
-  {% trans "Try again" %}
-{% endblock %}
-

--- a/edx_proctoring/templates/practice_exam/error.html
+++ b/edx_proctoring/templates/practice_exam/error.html
@@ -25,39 +25,18 @@
     {% endblock %}
   </p>
   <hr>
-  <button class="gated-sequence start-timed-exam action-primary" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
-    <span class="icon fa fa-lock" aria-hidden="true"></span>
-    <a>
-      {% block retry_cta %}
-        {% trans "Try this practice exam again" %}
-      {% endblock %}
-    </a>
-  </button>
+  <div>
+    {% trans "Retry my exam" as retry_exam %}
+    <button type="button" class="exam-action-button proctored-reset-onboarding btn btn-pl-primary btn-base" data-action="reset_attempt" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-loading-text="<span class='fa fa-circle-o-notch fa-spin'></span> {% trans 'Resetting Onboarding Exam' %}" data-cta-text="{{ retry_exam }}">
+      {{ retry_exam }}
+    </button>
+  </div>
+
 </div>
 {% include 'proctored_exam/footer.html' %}
 <script type="text/javascript">
-  $('.start-timed-exam').click(
-    function(event) {
-      var action_url = $(this).data('ajax-url');
-      var exam_id = $(this).data('exam-id');
-      var attempt_proctored = $(this).data('attempt-proctored');
-      var start_immediately = $(this).data('start-immediately');
-      if (typeof action_url === "undefined" ) {
-        return false;
-      }
-      $.post(
-        action_url,
-        {
-          "exam_id": exam_id,
-          "attempt_proctored": attempt_proctored,
-          "start_clock": start_immediately
-        },
-        function(data) {
-          // reload the page, because we've unlocked it
-          location.reload();
-        }
-      );
-    }
+  $('.exam-action-button').click(
+    edx.courseware.proctored_exam.updateStatusHandler
   );
 </script>
 

--- a/edx_proctoring/templates/practice_exam/submitted.html
+++ b/edx_proctoring/templates/practice_exam/submitted.html
@@ -15,8 +15,9 @@
         You have completed this practice exam and can continue with your course work.
       {% endblocktrans %}
     </p>
-    <button class="gated-sequence start-timed-exam action-primary" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
-      {% trans "You can also retry this practice exam" %}
+    {% trans "Retry my exam" as retry_exam %}
+    <button type="button" class="exam-action-button proctored-reset-onboarding btn btn-pl-primary btn-base" data-action="reset_attempt" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-loading-text="<span class='fa fa-circle-o-notch fa-spin'></span> {% trans 'Resetting Onboarding Exam' %}" data-cta-text="{{ retry_exam }}">
+      {{ retry_exam }}
     </button>
   {% endblock %}
 </div>
@@ -26,28 +27,5 @@
   });
   $('.exam-action-button').click(
       edx.courseware.proctored_exam.updateStatusHandler
-  );
-  $('.start-timed-exam').click(
-    function(event) {
-      var action_url = $(this).data('ajax-url');
-      var exam_id = $(this).data('exam-id');
-      var attempt_proctored = $(this).data('attempt-proctored');
-      var start_immediately = $(this).data('start-immediately');
-      if (typeof action_url === "undefined" ) {
-        return false;
-      }
-      $.post(
-        action_url,
-        {
-          "exam_id": exam_id,
-          "attempt_proctored": attempt_proctored,
-          "start_clock": start_immediately
-        },
-        function(data) {
-          // reload the page, because we've unlocked it
-          location.reload();
-        }
-      );
-    }
   );
 </script>

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -306,7 +306,7 @@ class ProctoredExamTestCase(LoggedInTestCase):
         """
         Create onboarding attempt
         """
-        return self._create_exam_attempt(self.onboarding_exam_id)
+        return self._create_exam_attempt(self.onboarding_exam_id, is_practice_exam=True)
 
     def _create_unstarted_exam_attempt(self, is_proctored=True, is_practice=False):
         """

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

This PR updates the api endpoint used to reset an onboarding attempt that is in an error state. This change aligns all of the onboarding interstitials that allow a reset to use the same endpoint. 

The retry button is not put behind a flag right now, as the option to retry an onboarding exam has already been available. 

**JIRA:**

[MST-616](https://openedx.atlassian.net/browse/MST-616)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.