### PR TITLE
Moved updating review field to post_delete function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.6.6] - 2021-02-01
+~~~~~~~~~~~~~~~~~~~~~
+* Bug fix for issue that prevented exam resets
+
 [2.6.5] - 2021-01-28
 ~~~~~~~~~~~~~~~~~~~~~
 * Update error interstitial to use the reset_exam_attempt flow that is used for other

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '2.6.5'
+__version__ = '2.6.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_reviews.py
+++ b/edx_proctoring/tests/test_reviews.py
@@ -5,6 +5,7 @@ Review callback tests
 import json
 
 import ddt
+import mock
 from crum import set_current_request
 from mock import call, patch
 
@@ -545,8 +546,12 @@ class ReviewTests(LoggedInTestCase):
         self.assertTrue(review.is_attempt_active)
 
         # now delete the attempt, which puts it into the archive table
-        remove_exam_attempt(self.attempt_id, requesting_user=self.user)
+        with mock.patch('edx_proctoring.api.update_attempt_status') as mock_update_status:
+            remove_exam_attempt(self.attempt_id, requesting_user=self.user)
 
         # check that the field has been updated
         review = ProctoredExamSoftwareSecureReview.get_review_by_attempt_code(self.attempt['attempt_code'])
         self.assertFalse(review.is_attempt_active)
+
+        # check that update_attempt_status has not been called, as the attempt has been archived
+        mock_update_status.assert_not_called()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Previously, when an attempt was deleted, a `pre_delete` function was executed that had a side effect of updating the associated review for that attempt. This caused problems, as saving that review called other functions to check if the associated attempt had been deleted, which at them time of saving the review, it had not been (as this was all set off by a `pre_delete` function for the attempt model). 

I've moved the side effect of updating the review to a `post_delete` function, so any code that is executed after the review is saved will accurately reflect if the associated attempt is archived or not.

**JIRA:**

[CR-3207](https://openedx.atlassian.net/browse/CR-3207)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.