### PR TITLE
[MST-571] Create Course Onboarding Status Endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.1.0] - 2021-02-08
+~~~~~~~~~~~~~~~~~~~~
+* Add endpoint to return onboarding status information for users in a course.
 
 [3.0.0] - 2021-02-05
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1437,7 +1437,7 @@ def get_all_exam_attempts(course_id):
 
 def get_filtered_exam_attempts(course_id, search_by):
     """
-    Returns all exam attempts for a course id filtered by  the search_by string in user names and emails.
+    Returns all exam attempts for a course id filtered by the search_by string in user names and emails.
     """
     exam_attempts = ProctoredExamStudentAttempt.objects.get_filtered_exam_attempts(course_id, search_by)
     return [ProctoredExamStudentAttemptSerializer(active_exam).data for active_exam in exam_attempts]
@@ -2423,3 +2423,14 @@ def get_integration_specific_email(provider):
     Return the edX contact email to use for a particular provider.
     """
     return getattr(provider, 'integration_specific_email', None) or constants.DEFAULT_CONTACT_EMAIL
+
+
+def get_enrollments_for_course(course_id):
+    """
+    Return all enrollments for a course from the LMS Enrollments runtime API.
+
+    Parameters:
+    * course_id: course ID for the course
+    """
+    enrollments_sevice = get_runtime_service('enrollments')
+    return enrollments_sevice.get_active_enrollments_by_course(course_id)

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -117,6 +117,21 @@ class ProctoredExam(TimeStampedModel):
 
         return cls.objects.filter(filtered_query)
 
+    @classmethod
+    def get_practice_proctored_exams_for_course(cls, course_id):
+        """
+        Return all practice proctored exams for a course.
+
+        Arguments
+        * course_id: course ID of the course
+        """
+        return cls.objects.filter(
+            course_id=course_id,
+            is_active=True,
+            is_practice_exam=True,
+            is_proctored=True
+        )
+
 
 class ProctoredExamReviewPolicy(TimeStampedModel):
     """
@@ -247,6 +262,27 @@ class ProctoredExamStudentAttemptManager(models.Manager):
         """
         filtered_query = Q(proctored_exam__course_id=course_id)
         return self.filter(filtered_query).order_by('-created')  # pylint: disable=no-member
+
+    def get_all_exam_attempts_by_exam_id(self, exam_id):
+        """
+        Returns all the exam attempts in an exam with the given exam ID.
+
+        Parameters:
+        * exam_id: ID of the exam
+        """
+        return self.filter(proctored_exam_id=exam_id)
+
+    def get_exam_attempts_for_users_by_exam_id(self, exam_id, users):
+        """
+        Returns all the exam attempts for iterable users in an exam with the given exam ID.
+
+        Parameters:
+        * exam_id: ID of the exam
+        * users: an iterable of users to filter by
+        """
+        queryset = self.get_all_exam_attempts_by_exam_id(exam_id)
+        queryset = queryset.filter(user__in=users)
+        return queryset
 
     def get_filtered_exam_attempts(self, course_id, search_by):
         """

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -235,3 +235,43 @@ class SoftwareSecureReviewStatus:
             )
             raise ProctoredExamBadReviewStatus(err_msg)
         return True
+
+
+class InstructorDashboardOnboardingAttemptStatus:
+    """
+    A class to enumerate the different statuses a proctored exam attempt
+    in an onboarding exam can have and to map them to internal database statutes.
+    These are intended to be used in externally facing applications, such
+    as the Instructor Dashboard.
+    """
+    not_started = 'not_started'
+    setup_started = 'setup_started'
+    proctoring_started = 'proctoring_started'
+    submitted = 'submitted'
+    rejected = 'rejected'
+    verified = 'verified'
+    error = 'error'
+
+    onboarding_statuses = {
+        ProctoredExamStudentAttemptStatus.created: setup_started,
+        ProctoredExamStudentAttemptStatus.download_software_clicked: setup_started,
+        ProctoredExamStudentAttemptStatus.ready_to_start: setup_started,
+        ProctoredExamStudentAttemptStatus.started: proctoring_started,
+        ProctoredExamStudentAttemptStatus.ready_to_submit: proctoring_started,
+        ProctoredExamStudentAttemptStatus.submitted: submitted,
+        ProctoredExamStudentAttemptStatus.verified: verified,
+        ProctoredExamStudentAttemptStatus.error: error,
+    }
+
+    @classmethod
+    def get_onboarding_status_from_attempt_status(cls, status):
+        """
+        Get the externally facing proctored exam attempt onboarding status
+        from an internal database proctored exam attempt status.
+
+        Parameters:
+            * status: a ProctoredExamStudentAttemptStatus status
+        """
+        if status:
+            return cls.onboarding_statuses.get(status)
+        return cls.not_started

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -30,6 +30,7 @@ from edx_proctoring.api import (
     get_attempt_status_summary,
     get_backend_provider,
     get_current_exam_attempt,
+    get_enrollments_for_course,
     get_exam_attempt_by_id,
     get_exam_by_content_id,
     get_exam_by_id,
@@ -88,6 +89,7 @@ from .test_services import (
     MockCreditService,
     MockCreditServiceNone,
     MockCreditServiceWithCourseEndDate,
+    MockEnrollmentsService,
     MockGradesService,
     MockInstructorService
 )
@@ -2448,3 +2450,24 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
 
         del test_backend.integration_specific_email
         assert get_integration_specific_email(test_backend) == DEFAULT_CONTACT_EMAIL
+
+    def test_get_enrollments(self):
+        enrollments = [
+            {
+                'user': 'user_1',
+            },
+            {
+                'user': 'user_2',
+            },
+            {
+                'user': 'user_3',
+            },
+        ]
+        expected_enrollments = [enrollment['user'] for enrollment in enrollments]
+
+        with patch(
+                'edx_proctoring.tests.test_services.MockEnrollmentsService.get_active_enrollments_by_course',
+                return_value=expected_enrollments
+        ):
+            set_runtime_service('enrollments', MockEnrollmentsService(enrollments))
+            self.assertEqual(expected_enrollments, get_enrollments_for_course('course_id'))

--- a/edx_proctoring/tests/test_models.py
+++ b/edx_proctoring/tests/test_models.py
@@ -145,6 +145,45 @@ class ProctoredExamModelTests(LoggedInTestCase):
         proctored_exam_student_history = ProctoredExamStudentAllowanceHistory.objects.filter(user_id=1)
         self.assertEqual(len(proctored_exam_student_history), 1)
 
+    def test_get_practice_proctored_exams_for_course(self):
+        """
+        Test get_practice_proctored_exams_for_course method returns only active
+        practice proctored exams.
+        """
+        course_id = 'test_course'
+        # create proctored exam
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content_1',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+            is_proctored=True,
+        )
+        # create practice proctored exam
+        ProctoredExam.objects.create(
+            course_id=course_id,
+            content_id='test_content_2',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_active=True,
+            is_proctored=True,
+            is_practice_exam=True,
+        )
+        practice_proctored_exams = ProctoredExam.objects.filter(
+            course_id=course_id,
+            is_active=True,
+            is_proctored=True,
+            is_practice_exam=True
+        )
+
+        self.assertQuerysetEqual(
+            ProctoredExam.get_practice_proctored_exams_for_course(course_id),
+            [repr(exam) for exam in practice_proctored_exams]
+        )
+
 
 class ProctoredExamStudentAttemptTests(LoggedInTestCase):
     """

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -307,3 +307,22 @@ class MockCertificateService:
         Returns invalidated certificate for key (user_id + course_key)
         """
         return self.generated_certificate.get((user_id, course_key_or_id))
+
+
+class MockEnrollment:
+    """
+    Mock Enrollment
+    """
+    def __init__(self, user):
+        self.user = user
+
+
+class MockEnrollmentsService:
+    """Mock Enrollments service"""
+    def __init__(self, enrollments):
+        """Initialize mock enrollments"""
+        self.enrollments = [MockEnrollment(enrollment['user']) for enrollment in enrollments]
+
+    def get_active_enrollments_by_course(self, course_id):
+        """Returns mock enrollments"""
+        return self.enrollments

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -19,7 +19,7 @@ from django.test import TestCase
 from django.test.client import Client
 
 from edx_proctoring.api import create_exam
-from edx_proctoring.models import ProctoredExamStudentAttempt
+from edx_proctoring.models import ProctoredExam, ProctoredExamStudentAttempt
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import MockCreditService, MockInstructorService
@@ -358,3 +358,32 @@ class ProctoredExamTestCase(LoggedInTestCase):
         Replaces newlines and multiple spaces with a single space.
         """
         return ' '.join(string.replace('\n', '').split())
+
+
+def create_onboarding_exam(
+    course_id='a/b/c',
+    content_id='test_content',
+    exam_name='Test Exam',
+    external_id='123aXqe3'
+):
+    """
+    Create and return an onboarding exam.
+
+    Parameters:
+    * course_id: the course ID for the course in which to create the exam
+    * content_id: the content ID
+    * exam_name: the name of the exam
+    * external_id: the external ID of the exam
+    """
+    onboarding_exam = ProctoredExam.objects.create(
+        course_id=course_id,
+        content_id=content_id,
+        exam_name=exam_name,
+        external_id=external_id,
+        time_limit_mins=90,
+        is_active=True,
+        is_proctored=True,
+        is_practice_exam=True,
+        backend='test',
+    )
+    return onboarding_exam

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -89,6 +89,11 @@ urlpatterns = [
         name='user_onboarding.status'
     ),
     url(
+        r'edx_proctoring/v1/user_onboarding/status/course_id/{}$'.format(settings.COURSE_ID_PATTERN),
+        views.StudentOnboardingStatusByCourseView.as_view(),
+        name='user_onboarding.status.course'
+    ),
+    url(
         r'edx_proctoring/v1/instructor/{}$'.format(settings.COURSE_ID_PATTERN),
         views.InstructorDashboard.as_view(),
         name='instructor_dashboard_course'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Add endpoint to return onboarding status information for users in a course.

**JIRA:**

[MST-571](https://openedx.atlassian.net/browse/MST-571)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.