### PR TITLE
Fix Django admin bugs in ProctoredExamStudentAttempt admin form.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.6.1] - 2021-02-19
+~~~~~~~~~~~~~~~~~~~~
+* Add time_remaining_seconds field of ProctoredExamStudentAttempt model to readonly_fields in 
+  Django admin page so it is not required when editing the model.
+* Update reference to Exception.message to use string representation of the exception, as message
+  is no longer an attribute of the Exception class.
+
 [3.6.0] - 2021-02-19
 ~~~~~~~~~~~~~~~~~~~~
 * Do not override exam view for a learner taking a practice exam when the learner does

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.6.0'
+__version__ = '3.6.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -437,7 +437,8 @@ class ProctoredExamStudentAttemptAdmin(admin.ModelAdmin):
         'is_sample_attempt',
         'student_name',
         'review_policy_id',
-        'is_status_acknowledged'
+        'is_status_acknowledged',
+        'time_remaining_seconds'
     ]
 
     list_display = [
@@ -485,7 +486,9 @@ class ProctoredExamStudentAttemptAdmin(admin.ModelAdmin):
             if change:
                 update_attempt_status(obj.id, form.cleaned_data['status'])
         except (ProctoredExamIllegalStatusTransition, StudentExamAttemptDoesNotExistsException) as ex:
-            messages.error(request, ex.message)
+            # prevent showing success message inappropriately
+            messages.set_level(request, messages.ERROR)
+            messages.error(request, str(ex))
 
     def has_add_permission(self, request):
         """Don't allow adds"""

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

* Add time_remaining_seconds field of ProctoredExamStudentAttempt model to readonly_fields in 
  Django admin page so it is not required when editing the model.

### Old:

![image](https://user-images.githubusercontent.com/11871801/107427652-a9987100-6aef-11eb-8e6f-e5e559d9429d.png)
![image](https://user-images.githubusercontent.com/11871801/107427738-b1f0ac00-6aef-11eb-9cd8-40dbd52d3854.png)

### New:

![image](https://user-images.githubusercontent.com/11871801/107427517-7d7cf000-6aef-11eb-9b6b-429c6f983170.png)

* Update reference to Exception.message to use string representation of the exception, as message
  is no longer an attribute of the Exception class.

### Old:

![image](https://user-images.githubusercontent.com/11871801/107427825-cb91f380-6aef-11eb-93f7-3201fb5c90fb.png)


### New:

![image](https://user-images.githubusercontent.com/11871801/107427431-63dba880-6aef-11eb-9052-25d99fd0a677.png)

**JIRA:**

None.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.