### PR TITLE
add a ready_to_resume interstitial to prompt user to resume their exam

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.4.0] - 2021-02-11
+~~~~~~~~~~~~~~~~~~~~
+* Add a new interstitial for exam attempts in the "ready_to_resume" state to
+  indicate to learner that their exam attempt is ready to be resumed and to 
+  prompt the learner to resume their exam.
+
 [3.3.0] - 2021-02-11
 ~~~~~~~~~~~~~~~~~~~~
 * Add learner onboarding view to instructor dashboard.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/proctored_exam/ready_to_resume.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_resume.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+<div class="sequence proctored-exam entrance" data-exam-id="{{exam_id}}">
+  <h3>
+    {% blocktrans %}
+      Your exam is ready to be resumed.
+    {% endblocktrans %}
+  </h3>
+  <p>
+    {% blocktrans %}
+        You will have {{ total_time }} to complete your exam.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% blocktrans %}
+        To be eligible for credit or the program credential associated with this course, you must pass the proctoring review for this exam.
+    {% endblocktrans %}
+  </p>
+  <button class="gated-sequence start-timed-exam action-primary" data-ajax-url="{{enter_exam_endpoint}}" data-exam-id="{{exam_id}}" data-attempt-proctored=true data-start-immediately=false>
+    {% trans "Continue to my proctored exam." %}
+    <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
+    <p>
+      {% blocktrans %}
+        You will be guided through steps to set up online proctoring software and verify your identity.</br>
+      {% endblocktrans %}
+    </p>
+  </button>
+
+  {% if allow_proctoring_opt_out %}
+    {% include 'proctored_exam/proctoring_opt_out_button.html' %}
+  {% endif %}
+</div>
+{% include 'proctored_exam/confirm-decline.html' %}
+{% include 'proctored_exam/footer.html' %}

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -352,6 +352,21 @@ class ProctoredExamTestCase(LoggedInTestCase):
             allowed_time_limit_mins=10
         )
 
+    def _create_started_onboarding_exam_attempt(self, started_at=None):
+        """
+        Creates the ProctoredExamStudentAttempt object.
+        """
+        return ProctoredExamStudentAttempt.objects.create(
+            proctored_exam_id=self.onboarding_exam_id,
+            taking_as_proctored=True,
+            user_id=self.user_id,
+            external_id=self.external_id,
+            started_at=started_at if started_at else datetime.now(pytz.UTC),
+            is_sample_attempt=True,
+            status=ProctoredExamStudentAttemptStatus.started,
+            allowed_time_limit_mins=10
+        )
+
     @staticmethod
     def _normalize_whitespace(string):
         """

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Add a new interstitial for exam attempts in the "ready_to_resume" state to indicate to learner that their exam attempt is ready to be resumed and to prompt the learner to resume their exam.

![image](https://user-images.githubusercontent.com/11871801/107576047-a4eebe00-6bbe-11eb-822e-8b6afb37c958.png)

**JIRA:**

[MST-617](https://openedx.atlassian.net/browse/MST-617)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.