### PR TITLE
fix: ajax call used for attempt status throws fewer 500s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.2.1] - 2021-02-11
+~~~~~~~~~~~~~~~~~~~~
+* bugfix to 500 errors from proctored exam attempt status endpoint used by the LMS to drive timer functionality
+
 [3.2.0] - 2021-02-10
 ~~~~~~~~~~~~~~~~~~~~
 * Update to update_attempt_status function to account for multiple attempts per exam

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.2.0'
+__version__ = '3.2.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -885,7 +885,8 @@ class StudentProctoredExamAttemptCollection(ProctoredAPIView):
                 'exam_type': (
                     _('a timed exam') if not attempt['taking_as_proctored'] else
                     (_('a proctored exam') if not attempt['is_sample_attempt'] else
-                     (_('an onboarding exam') if provider.supports_onboarding else _('a practice exam')))
+                     (_('an onboarding exam') if (provider and provider.supports_onboarding) else
+                      _('a practice exam')))
                 ),
                 'exam_display_name': exam['exam_name'],
                 'exam_url_path': exam_url_path,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

fixes some 500 errors I saw in splunk
(`index="prod-edx" service_variant="lms" "an onboarding exam" AND "a practice exam"` if you are internal to edX and you'd like to see them too)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.