### PR TITLE
[MST-630] Don't display resume option for practice exams

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.4.1] - 2021-02-17
+~~~~~~~~~~~~~~~~~~~~
+* Restrict the resume option on the instructor dashboard to attempts that are
+  in an "error" state and are not for onboarding or practice exams.
+
 [3.4.0] - 2021-02-11
 ~~~~~~~~~~~~~~~~~~~~
 * Add a new interstitial for exam attempts in the "ready_to_resume" state to

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.4.0'
+__version__ = '3.4.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts.underscore
@@ -172,7 +172,10 @@
                             <td>
                                 <% if (proctored_exam_attempt.status){ %>
                                     <% if (enable_exam_resume_proctoring_improvements) { %>
-                                        <% if (proctored_exam_attempt.status == "error" ) { %>
+                                        <% if (
+                                                proctored_exam_attempt.status == "error" &&
+                                                !proctored_exam_attempt.proctored_exam.is_practice_exam
+                                            ) { %>
                                             <div class="wrapper-action-more">
                                                 <button class="action action-more" type="button" id="actions-dropdown-link-<%= dashboard_index %>" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-<%= dashboard_index %>" data-dashboard-index="<%= dashboard_index %>">
                                                     <span class="fa fa-cog" aria-hidden="true"></span>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Limit the resume option to proctored exam attempts that are both a) in an "error" state and b) not for onboarding/practice exams.

---
![Screen Shot 2021-02-16 at 3 48 28 PM](https://user-images.githubusercontent.com/10442143/108121739-479cb600-7071-11eb-8ba8-aa406149d01f.png)
---

**JIRA:**

[MST-630](https://openedx.atlassian.net/browse/MST-630)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.