### PR TITLE
Added endpoint and frontend ui to group multiple attempts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.5.0] - 2021-02-18
+~~~~~~~~~~~~~~~~~~~~
+* Add new UI for instructor dashboard that groups attempts for each user and exam.
+* Add endpoint that returns a list of most recent attempts for each user and exam. Each
+  attempt that is returned contains additional data on the past attempts
+  associated with the user/exam.
+
 [3.4.1] - 2021-02-17
 ~~~~~~~~~~~~~~~~~~~~
 * Restrict the resume option on the instructor dashboard to attempts that are
@@ -22,7 +29,7 @@ Unreleased
 [3.4.0] - 2021-02-11
 ~~~~~~~~~~~~~~~~~~~~
 * Add a new interstitial for exam attempts in the "ready_to_resume" state to
-  indicate to learner that their exam attempt is ready to be resumed and to 
+  indicate to learner that their exam attempt is ready to be resumed and to
   prompt the learner to resume their exam.
 
 [3.3.0] - 2021-02-11

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.4.1'
+__version__ = '3.5.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -329,7 +329,7 @@ class ProctoredExamStudentAttemptManager(models.Manager):
         """
         Returns attempts for a given exam and user
         """
-        return self.filter(user_id=user_id, proctored_exam_id=exam_id)
+        return self.filter(user_id=user_id, proctored_exam_id=exam_id).order_by('-created')
 
 
 class ProctoredExamStudentAttempt(TimeStampedModel):

--- a/edx_proctoring/settings/common.py
+++ b/edx_proctoring/settings/common.py
@@ -20,6 +20,7 @@ def plugin_settings(settings):
             'proctoring/js/models/learner_onboarding_model.js',
             'proctoring/js/collections/proctored_exam_allowance_collection.js',
             'proctoring/js/collections/proctored_exam_attempt_collection.js',
+            'proctoring/js/collections/proctored_exam_attempt_grouped_collection.js',
             'proctoring/js/collections/proctored_exam_onboarding_collection.js',
             'proctoring/js/collections/proctored_exam_collection.js',
             'proctoring/js/views/Backbone.ModalDialog.js',

--- a/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_grouped_collection.js
+++ b/edx_proctoring/static/proctoring/js/collections/proctored_exam_attempt_grouped_collection.js
@@ -1,0 +1,15 @@
+edx = edx || {};
+(function(Backbone) {
+    'use strict';
+
+    edx.instructor_dashboard = edx.instructor_dashboard || {};
+    edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
+
+    edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection = Backbone.Collection.extend({
+        /* model for a collection of ProctoredExamAttempt */
+        model: edx.instructor_dashboard.proctoring.ProctoredExamAttemptModel,
+        url: '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/'
+    });
+    this.edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection =
+      edx.instructor_dashboard.proctoring.ProctoredExamAttemptGroupedCollection;
+}).call(this, Backbone);

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -2,6 +2,7 @@ describe('ProctoredExamAttemptView', function() {
     'use strict';
 
     var html = '';
+    var groupedHtml = '';
     var deletedProctoredExamAttemptJson = [{
         attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
         proctored_exam_attempts: [],
@@ -59,10 +60,121 @@ describe('ProctoredExamAttemptView', function() {
         );
     }
 
+    function getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson(status, isPracticeExam) {
+        // eslint-disable-next-line no-param-reassign
+        isPracticeExam = typeof isPracticeExam !== 'undefined' ? isPracticeExam : false;
+        return (
+            [{
+                attempt_url: '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/edX/DemoX/Demo_Course',
+                pagination_info: {
+                    current_page: 1,
+                    has_next: false,
+                    has_previous: false,
+                    total_pages: 1
+                },
+                proctored_exam_attempts: [{
+                    allowed_time_limit_mins: 1,
+                    attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                    completed_at: null,
+                    created: '2015-08-10T09:15:45Z',
+                    external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                    id: 43,
+                    is_sample_attempt: false,
+                    last_poll_ipaddr: null,
+                    last_poll_timestamp: null,
+                    modified: '2015-08-10T09:15:45Z',
+                    started_at: '2015-08-10T09:15:45Z',
+                    status: status,
+                    taking_as_proctored: true,
+                    proctored_exam: {
+                        content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                        course_id: 'edX/DemoX/Demo_Course',
+                        exam_name: 'Normal Exam',
+                        external_id: null,
+                        id: 17,
+                        is_active: true,
+                        is_practice_exam: isPracticeExam,
+                        is_proctored: true,
+                        time_limit_mins: 1
+                    },
+                    user: {
+                        username: 'testuser1',
+                        email: 'testuser1@test.com',
+                        id: 1
+                    },
+                    all_attempts: [
+                        {
+                            allowed_time_limit_mins: 1,
+                            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E09',
+                            completed_at: null,
+                            created: '2015-08-10T09:15:45Z',
+                            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae8',
+                            id: 43,
+                            is_sample_attempt: false,
+                            last_poll_ipaddr: null,
+                            last_poll_timestamp: null,
+                            modified: '2015-08-10T09:15:45Z',
+                            started_at: '2015-08-10T09:15:45Z',
+                            status: status,
+                            taking_as_proctored: true,
+                            proctored_exam: {
+                                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                                course_id: 'edX/DemoX/Demo_Course',
+                                exam_name: 'Normal Exam',
+                                external_id: null,
+                                id: 17,
+                                is_active: true,
+                                is_practice_exam: isPracticeExam,
+                                is_proctored: true,
+                                time_limit_mins: 1
+                            },
+                            user: {
+                                username: 'testuser1',
+                                email: 'testuser1@test.com',
+                                id: 1
+                            }
+                        },
+                        {
+                            allowed_time_limit_mins: 1,
+                            attempt_code: '20C32387-372E-48BD-BCAC-A2BE9DC91E10',
+                            completed_at: null,
+                            created: '2015-08-10T09:15:45Z',
+                            external_id: '40eceb15-bcc3-4791-b43f-4e843afb7ae9',
+                            id: 44,
+                            is_sample_attempt: false,
+                            last_poll_ipaddr: null,
+                            last_poll_timestamp: null,
+                            modified: '2015-08-10T09:15:45Z',
+                            started_at: '2015-08-10T09:15:45Z',
+                            status: 'resumed',
+                            taking_as_proctored: true,
+                            proctored_exam: {
+                                content_id: 'i4x://edX/DemoX/sequential/9f5e9b018a244ea38e5d157e0019e60c',
+                                course_id: 'edX/DemoX/Demo_Course',
+                                exam_name: 'Normal Exam',
+                                external_id: null,
+                                id: 17,
+                                is_active: true,
+                                is_practice_exam: isPracticeExam,
+                                is_proctored: true,
+                                time_limit_mins: 1
+                            },
+                            user: {
+                                username: 'testuser1',
+                                email: 'testuser1@test.com',
+                                id: 1
+                            }
+                        }
+                    ]
+                }]
+            }]
+        );
+    }
+
     beforeEach(function() {
         html = '<div class="wrapper-content wrapper">' +
         '<% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>' +
-        '<section class="content">' +
+        '<div class="content exam-attempts-content">' +
         '<div class="top-header">' +
         '<div class="search-attempts">' +
         '<input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"' +
@@ -125,43 +237,9 @@ describe('ProctoredExamAttemptView', function() {
         '</td>' +
         '<td>' +
         '<% if (proctored_exam_attempt.status){ %> ' +
-        '<% if (enable_exam_resume_proctoring_improvements) { %>' +
-        '<% if (' +
-        'proctored_exam_attempt.status == "error" &&' +
-        '!proctored_exam_attempt.proctored_exam.is_practice_exam' +
-        ') { %>' +
-        '<div class="wrapper-action-more">' +
-        '<button class="action action-more" type="button" id="actions-dropdown-link-<%= dashboard_index %>"' +
-        'aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-<%= dashboard_index %>"' +
-        'data-dashboard-index="<%= dashboard_index %>">' +
-        '<span class="fa fa-cog" aria-hidden="true"></span>' +
-        '</button>' +
-        '<div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">' +
-        '<ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>"' +
-        'aria-label="<%- gettext("Available Actions") %>" role="menu">' +
-        '<li class="actions-item" role="menuitem">' +
-        '<a href="#" class="action resume-attempt"' +
-        'data-attempt-id="<%= proctored_exam_attempt.id %>" data-user-id="<%= proctored_exam_attempt.user.id %>" >' +
-        '<%- gettext("Resume") %>' +
-        '</a>' +
-        '</li>' +
-        '<li class="actions-item" id="actions-item-email-settings-<%= dashboard_index %>" role="menuitem">' +
-        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >' +
-        '<%- gettext("Reset") %>' +
-        '</a>' +
-        '</li>' +
-        '</ul>' +
-        '</div>' +
-        '</div>' +
-        '<% } else { %>' +
-        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >' +
-        '<%- gettext("Reset") %>' +
-        '</a>' +
-        '<% } %>' +
-        '<% } else { %>' +
         '<a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>' +
-        '<% } %>' +
         ' <% } else { %>N/A <% } %>' +
+        '</td>' +
         '</tr>' +
         ' <% }); %> ' +
         '</tbody>' +
@@ -170,7 +248,7 @@ describe('ProctoredExamAttemptView', function() {
         '<% if (!is_proctored_attempts) { %> ' +
         '<p> No exam results found. </p>' +
         '<% } %> ' +
-        '</section> </div>';
+        '</div> </div>';
         this.server = sinon.fakeServer.create();
         this.server.autoRespond = true;
         setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id"></div>');
@@ -181,6 +259,154 @@ describe('ProctoredExamAttemptView', function() {
                 200,
                 {'Content-Type': 'text/html'},
                 html
+            ]
+        );
+
+        groupedHtml = '<div class="wrapper-content wrapper">' +
+        '<% var is_proctored_attempts = proctored_exam_attempts.length !== 0 %>' +
+        '<div class="content exam-attempts-content">' +
+        '<div class="top-header">' +
+        '<div class="search-attempts">' +
+        '<input type="text" id="search_attempt_id" placeholder="e.g johndoe or john.doe@gmail.com"' +
+        '<% if (inSearchMode) { %> value="<%= searchText %>" <%} %>' +
+        '/> <span class="search"><span class="icon fa fa-search" aria-hidden="true"></span></span> ' +
+        '<span class="clear-search"><span class="icon fa fa-remove" aria-hidden="true"></span></span>' +
+        '</div>' +
+        '<ul class="pagination">' +
+        '<% if (!pagination_info.has_previous){ %>' +
+        '<li class="disabled"> <a aria-label="Previous"> <span aria-hidden="true">&laquo;</span> </a> </li>' +
+        '<% } else { %>' +
+        '<li>' +
+        '<a class="target-link " data-target-url="' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: pagination_info.current_page - 1}, true) %>' +
+        '"' +
+        'href="#" aria-label="Previous">' +
+        '<span aria-hidden="true">&laquo;</span> </a> </li> <% }%>' +
+        '<% for(var n = 1; n <= pagination_info.total_pages; n++) { %>' +
+        '<li> <a class="target-link <% if (pagination_info.current_page == n){ %> active <% } %>" data-target-url=" ' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ", {attempt_url: attempt_url, count: n}, true) %>' +
+        '"href="#"><%= n %> </a></li> <% } %>' +
+        '<% if (!pagination_info.has_next){ %>' +
+        '<li class="disabled"> <a aria-label="Next"> <span aria-hidden="true">&raquo;</span> </a></li>' +
+        '<% } else { %> <li> <a class="target-link" href="#" aria-label="Next" data-target-url="' +
+        '<%- interpolate("%(attempt_url)s?page=%(count)s ",' +
+        '{attempt_url: attempt_url, count: pagination_info.current_page + 1}, true) %>' +
+        '" > <span aria-hidden="true">&raquo;</span></a> </li> <% }%> </ul><div class="clearfix"></div></div>' +
+        '<table class="exam-attempts-table"> <thead><tr class="exam-attempt-headings">' +
+        '<th class="username">Username</th>' +
+        '<th class="exam-name">Exam Name</th>' +
+        '<th class="attempt-allowed-time">Allowed Time (Minutes)</th>' +
+        '<th class="attempt-started-at">Started At</th>' +
+        '<th class="attempt-completed-at">Completed At</th>' +
+        '<th class="attempt-status">Status</th>' +
+        '<th class="c_action">Actions</th>' +
+        '</tr></thead>' +
+        '<% if (is_proctored_attempts) { %>\n' +
+        '<tbody>' +
+        '<% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){ %>' +
+        '<tr class="allowance-items">' +
+        '<td>' +
+        '<%- interpolate(gettext(\' %(username)s \'), { username: proctored_exam_attempt.user.username }, true) %>' +
+        '</td>' +
+        '<td>' +
+        '<%- interpolate(gettext(\' %(exam_display_name)s \'), ' +
+        '{ exam_display_name: proctored_exam_attempt.proctored_exam.exam_name }, true) %>' +
+        '</td>' +
+        '<td> <%= proctored_exam_attempt.allowed_time_limit_mins %></td>' +
+        '<td> <%= proctored_exam_attempt.exam_attempt_type %></td>' +
+        '<% if (proctored_exam_attempt.all_attempts.length <= 1){ %>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.status){ %>' +
+        '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>' +
+        '<% } else { %> N/A <% } %>' +
+        '</td>' +
+        '<% } else { %>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<% } %>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.status){ %>' +
+        '<% if (' +
+        'proctored_exam_attempt.status == "error" &&' +
+        '!proctored_exam_attempt.proctored_exam.is_practice_exam' +
+        ') { %>' +
+        '<div class="wrapper-action-more">' +
+        '<button class="action action-more" type="button" ' +
+        'id="actions-dropdown-link-<%= dashboard_index %>" aria-haspopup="true" aria-expanded="false" ' +
+        'aria-controls="actions-dropdown-<%= dashboard_index %>" data-dashboard-index="<%= dashboard_index %>">' +
+        '<span class="fa fa-cog" aria-hidden="true"></span>' +
+        '</button>' +
+        '<div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">' +
+        '<ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>" ' +
+        'aria-label="<%- gettext("Available Actions") %>" role="menu">' +
+        '<li class="actions-item" role="menuitem">' +
+        '<a href="#" class="action resume-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" ' +
+        'data-user-id="<%= proctored_exam_attempt.user.id %>" >' +
+        '<%- gettext("Resume") %>' +
+        '</a>' +
+        '</li>' +
+        '<li class="actions-item" role="menuitem">' +
+        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" ' +
+        'data-user-id="<%= proctored_exam_attempt.user.id %>" ' +
+        'data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >' +
+        '<%- gettext("Reset") %>' +
+        '</a>' +
+        '</li>' +
+        '</ul>' +
+        '</div>' +
+        '</div>' +
+        '<% } else { %>' +
+        '<a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" ' +
+        'data-user-id="<%= proctored_exam_attempt.user.id %>" ' +
+        'data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >' +
+        '<%- gettext("Reset") %>' +
+        '</a>' +
+        '<% } %>' +
+        '<% } else { %>' +
+        'N/A' +
+        '<% } %>' +
+        '</td>' +
+        '</tr>' +
+        '<% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt){ %>' +
+        '<tr class="allowance-items">' +
+        '<td></td>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<td></td>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>' +
+        '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.status){ %>' +
+        '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>' +
+        '<% } else { %>' +
+        'N/A' +
+        '<% } %>' +
+        '</td>' +
+        '<td></td>' +
+        '</tr>' +
+        '<% }); %>' +
+        '<% }); %>' +
+        '</tbody>' +
+        '<% } %>' +
+        '</table>' +
+        '<% if (!is_proctored_attempts) { %>' +
+        '<p> No exam results found. </p>' +
+        '<% } %>' +
+        '</div>' +
+        '</div>';
+
+        // load the underscore template response before calling the proctored exam attemp view.
+        this.server.respondWith(
+            'GET',
+            '/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore',
+            [
+                200,
+                {'Content-Type': 'text/html'},
+                groupedHtml
             ]
         );
     });
@@ -385,13 +611,13 @@ describe('ProctoredExamAttemptView', function() {
         setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id" ' +
             'data-enable-exam-resume-proctoring-improvements="True"></div>');
 
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
             [
                 200,
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('error'))
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error'))
             ]
         );
         this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
@@ -400,9 +626,9 @@ describe('ProctoredExamAttemptView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1  </td>');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('error');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Error');
 
         expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).not.toHaveLength(0);
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
@@ -418,13 +644,13 @@ describe('ProctoredExamAttemptView', function() {
         );
 
         // again fetch the results after the proctored exam attempt is marked ready_to_resume
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
             [
                 200,
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('ready_to_resume'))
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('ready_to_resume'))
             ]
         );
 
@@ -457,7 +683,7 @@ describe('ProctoredExamAttemptView', function() {
 
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('ready_to_resume');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Ready to resume');
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
     });
 
@@ -466,13 +692,13 @@ describe('ProctoredExamAttemptView', function() {
         setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id" ' +
             'data-enable-exam-resume-proctoring-improvements="True"></div>');
 
-        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/course_id/test_course_id',
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
             [
                 200,
                 {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(getExpectedProctoredExamAttemptWithAttemptStatusJson('error', true))
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', true))
             ]
         );
         this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
@@ -481,11 +707,120 @@ describe('ProctoredExamAttemptView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items')).toContainHtml('<td> testuser1  </td>');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
         expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('error');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Error');
 
         expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).toHaveLength(0);
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').html()).toHaveLength(0);
+    });
+
+    it('should display grouped attempts', function() {
+        var rows;
+
+        setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id" ' +
+            'data-enable-exam-resume-proctoring-improvements="True"></div>');
+
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
+
+        rows = this.proctored_exam_attempt_view.$el.find('tbody').children();
+
+        expect(rows.length).toEqual(3);
+
+        // check that status does not appear in first row of group
+        expect(rows[0].outerHTML).not.toContain('Error');
+        expect(rows[0].outerHTML).not.toContain('Resumed');
+        expect(rows[0].outerHTML).toContain('action-more');
+
+        // check that status is present in other two rows
+        expect(rows[1].outerHTML).toContain('Error');
+        expect(rows[1].outerHTML).not.toContain('action-more');
+        expect(rows[2].outerHTML).toContain('resumed');
+        expect(rows[2].outerHTML).not.toContain('action-more');
+    });
+
+    it('deletes attempts using new endpoint', function() {
+        setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id" ' +
+            'data-enable-exam-resume-proctoring-improvements="True"></div>');
+
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('error', false))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
+
+        // delete the proctored exam attempts
+        this.server.respondWith(
+            'DELETE',
+            '/api/edx_proctoring/v1/proctored_exam/exam_id/17/user_id/1/reset_attempts',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify([])
+            ]
+        );
+
+        // again fetch the results after the proctored exam attempt deletion
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(deletedProctoredExamAttemptJson)
+            ]
+        );
+
+        spyOn(window, 'confirm').and.callFake(function() {
+            return true;
+        });
+
+        // click the gear button to open the action dropdown
+        spyOnEvent('.action-more', 'click');
+        $('.action-more').trigger('click');
+
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(true);
+        expect(this.proctored_exam_attempt_view.$el.find(
+            '.actions-dropdown .actions-dropdown-list .actions-item .action'
+        )[0].text).toContain('Resume');
+        expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
+        + '.actions-item .action')[1].text).toContain('Reset');
+
+        // trigger the remove attempt event.
+        spyOnEvent('.remove-attempt', 'click');
+        $('.remove-attempt').trigger('click');
+
+        // process the deleted attempt requests.
+        this.server.respond();
+        this.server.respond();
+
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('Normal Exam');
     });
 });

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore
@@ -160,23 +160,76 @@
                             </td>
                             <td> <%= proctored_exam_attempt.allowed_time_limit_mins %></td>
                             <td> <%= proctored_exam_attempt.exam_attempt_type %></td>
-                            <td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>
-                            <td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>
-                             <td>
-                             <% if (proctored_exam_attempt.status){ %>
-                                <%= getExamAttemptStatus(proctored_exam_attempt.status) %>
+                            <% if (proctored_exam_attempt.all_attempts.length <= 1){ %>
+                                <td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>
+                                <td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>
+                                <td>
+                                <% if (proctored_exam_attempt.status){ %>
+                                    <%= getExamAttemptStatus(proctored_exam_attempt.status) %>
+                                <% } else { %>
+                                    N/A
+                                <% } %>
+                                </td>
                             <% } else { %>
-                                N/A
+                                <td></td>
+                                <td></td>
+                                <td></td>
                             <% } %>
-                            </td>
                             <td>
                                 <% if (proctored_exam_attempt.status){ %>
-                                   <a href="#" class="remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" >[x]</a>
+                                    <% if (
+                                        proctored_exam_attempt.status == "error" &&
+                                        !proctored_exam_attempt.proctored_exam.is_practice_exam
+                                    ) { %>
+                                        <div class="wrapper-action-more">
+                                            <button class="action action-more" type="button" id="actions-dropdown-link-<%= dashboard_index %>" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-<%= dashboard_index %>" data-dashboard-index="<%= dashboard_index %>">
+                                                <span class="fa fa-cog" aria-hidden="true"></span>
+                                            </button>
+                                            <div class="actions-dropdown" id="actions-dropdown-<%= dashboard_index %>" tabindex="-1">
+                                                <ul class="actions-dropdown-list" id="actions-dropdown-list-<%= dashboard_index %>" aria-label="<%- gettext("Available Actions") %>" role="menu">
+                                                    <li class="actions-item" role="menuitem">
+                                                        <a href="#" class="action resume-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" data-user-id="<%= proctored_exam_attempt.user.id %>" >
+                                                            <%- gettext("Resume") %>
+                                                        </a>
+                                                    </li>
+                                                    <li class="actions-item" role="menuitem">
+                                                        <a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" data-user-id="<%= proctored_exam_attempt.user.id %>" data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >
+                                                            <%- gettext("Reset") %>
+                                                        </a>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    <% } else { %>
+                                        <a href="#" class="action remove-attempt" data-attempt-id="<%= proctored_exam_attempt.id %>" data-user-id="<%= proctored_exam_attempt.user.id %>" data-exam-id="<%= proctored_exam_attempt.proctored_exam.id %>" >
+                                            <%- gettext("Reset") %>
+                                        </a>
+                                    <% } %>
                                 <% } else { %>
                                     N/A
                                 <% } %>
                             </td>
                         </tr>
+                        <% if (proctored_exam_attempt.all_attempts.length > 1) { %>
+                            <% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt) { %>
+                                <tr class="allowance-items">
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>
+                                    <td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>
+                                    <td>
+                                    <% if (proctored_exam_attempt.status) { %>
+                                       <%= getExamAttemptStatus(proctored_exam_attempt.status) %>
+                                    <% } else { %>
+                                        N/A
+                                    <% } %>
+                                    </td>
+                                    <td></td>
+                                </tr>
+                            <% }); %>
+                        <% }%>
                     <% }); %>
                 </tbody>
                 <% } %>

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -49,6 +49,17 @@ urlpatterns = [
         name='proctored_exam.attempts.search'
     ),
     url(
+        r'edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/{}$'.format(settings.COURSE_ID_PATTERN),
+        views.StudentProctoredGroupedExamAttemptsByCourse.as_view(),
+        name='proctored_exam.attempts.grouped.course'
+    ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/{}/search/(?P<search_by>.+)$'.format(
+            settings.COURSE_ID_PATTERN),
+        views.StudentProctoredGroupedExamAttemptsByCourse.as_view(),
+        name='proctored_exam.attempts.grouped.search'
+    ),
+    url(
         r'edx_proctoring/v1/proctored_exam/attempt$',
         views.StudentProctoredExamAttemptCollection.as_view(),
         name='proctored_exam.attempt.collection'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Added new endpoint and UI for grouping multiple attempts on the instructor dashboard. This makes it easier for course staff and edX staff to view how many attempts a user has on an exam, and what the status of each of those attempts is.

Example of what attempts look like with only one attempt per user per exam:

![Screen Shot 2021-02-18 at 9 38 52 AM](https://user-images.githubusercontent.com/46360176/108373555-079f1580-71ce-11eb-96fa-c7f1f7bd0cca.png)

Example with multiple attempts:

![Screen Shot 2021-02-18 at 9 44 46 AM](https://user-images.githubusercontent.com/46360176/108373585-0f5eba00-71ce-11eb-9706-157cd1adc80e.png)


**JIRA:**

[MST-583](https://openedx.atlassian.net/browse/MST-583)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.