### PR TITLE
[MST-614] Return None from _get_practice_exam_view when the requesting learner does not have access to take proctoring.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.6.0] - 2021-02-19
+~~~~~~~~~~~~~~~~~~~~
+* Do not override exam view for a learner taking a practice exam when the learner does
+  not have access to proctoring. This allows the learner to see the exam content and does
+  not allow the learner access to the proctoring software.
+
 [3.5.1] - 2021-02-19
 ~~~~~~~~~~~~~~~~~~~~
 * Add missing `rejected` status to list of onboarding attempt statuses.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.5.1'
+__version__ = '3.6.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -2069,6 +2069,9 @@ def _get_practice_exam_view(exam, context, exam_id, user_id, course_id):
     """
     user = USER_MODEL.objects.get(id=user_id)
 
+    if not user.has_perm('edx_proctoring.can_take_proctored_exam', exam):
+        return None
+
     student_view_template = None
 
     attempt = get_current_exam_attempt(exam_id, user_id)

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -988,16 +988,6 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
             else:
                 self.assertIn(self.exam_expired_msg, rendered_response)
 
-    def test_get_no_perm_view(self):
-        """
-        Test for get_student_view prompting when the student does not have permission
-        to view proctored exams, this should return None
-        (For edx-proctoring tests, only authenticated students have the permission)
-        """
-        with mock_perm('edx_proctoring.can_take_proctored_exam'):
-            rendered_response = self.render_proctored_exam()
-        self.assertIsNone(rendered_response)
-
     def test_get_studentview_started_onboarding(self):
         """
         Test fallthrough page case for onboarding exams
@@ -1015,12 +1005,19 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         rendered_response = self.render_onboarding_exam()
         self.assertIn('Proctoring onboarding exam', rendered_response)
 
-    def test_get_onboarding_no_perm(self):
+    @ddt.data(
+        render_proctored_exam,
+        render_practice_exam,
+        render_onboarding_exam
+    )
+    def test_get_exam_view_no_perm(self, render_exam):
         """
-        Test that onboarding exams are gated by the same permission as proctored exams
+        Test for get_student_view prompting when the student does not have permission
+        to view proctored exams, this should return None
+        (For edx-proctoring tests, only authenticated students have the permission)
         """
         with mock_perm('edx_proctoring.can_take_proctored_exam'):
-            rendered_response = self.render_onboarding_exam()
+            rendered_response = render_exam(self)
         self.assertIsNone(rendered_response)
 
     @ddt.data(

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Return None from _get_practice_exam_view when the requesting learner does not have access to take proctoring. This prevents the view from being overridden and allows the learner to view exam content but does not allow them access to the proctoring software. This is in line with behavior of onboarding and proctored exams currently.

**JIRA:**

[MST-614](https://openedx.atlassian.net/browse/MST-614)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.