### PR TITLE
[MST-664] Handle multiple onboarding exams on instructor dashboard view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,12 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-* Add a script to generate obscure_user_ids for proctoring vendors to use.
 
+[3.6.3] - 2021-02-23
+~~~~~~~~~~~~~~~~~~~~
+* Add a script to generate obscure_user_ids for proctoring vendors to use.
+* Update the logic for the instructor dashboard onboarding view to match the learners' view,
+  so that multiple onboarding exams for the same course can be considered.
 
 [3.6.2] - 2021-02-22
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.6.2'
+__version__ = '3.6.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -272,16 +272,21 @@ class ProctoredExamStudentAttemptManager(models.Manager):
         """
         return self.filter(proctored_exam_id=exam_id)
 
-    def get_exam_attempts_for_users_by_exam_id(self, exam_id, users):
+    def get_onboarding_attempts_by_course_id(self, course_id, users=None):
         """
-        Returns all the exam attempts for iterable users in an exam with the given exam ID.
+        Returns all onboarding attempts for a course, ordered by descending modified field.
 
         Parameters:
-        * exam_id: ID of the exam
-        * users: an iterable of users to filter by
+        * course_id: ID of the course
+        * users (optional): an iterable of users to filter by
         """
-        queryset = self.get_all_exam_attempts_by_exam_id(exam_id)
-        queryset = queryset.filter(user__in=users)
+        queryset = self.get_all_exam_attempts(course_id).filter(
+            proctored_exam__is_practice_exam=True,
+            proctored_exam__is_active=True,
+            taking_as_proctored=True
+        ).order_by('-modified')
+        if users:
+            queryset = queryset.filter(user__in=users)
         return queryset
 
     def get_filtered_exam_attempts(self, course_id, search_by):

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

* Updated the logic for `StudentOnboardingStatusByCourseView` so that, if there are multiple onboarding exams for a single course, attempts for all of them are considered rather than just the first exam created.
* The onboarding attempt queries for both `StudentOnboardingStatusView` and `StudentOnboardingStatusByCourseView` have been consolidated and moved to `models.py` as `get_onboarding_attempts_by_course_id`.
* Ensured that for both views, if the learner(s) have at least one verified attempt, the status returned will always be verified. Else, their most recent attempt will be returned.

**JIRA:**

[MST-664](https://openedx.atlassian.net/browse/MST-664)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.