### PR TITLE
Fix bug to allow course staff to reset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.6.5] - 2021-02-23
+~~~~~~~~~~~~~~~~~~~~
+* Bug fix to allow course staff to reset attempts
+
 [3.6.4] - 2021-02-24
 ~~~~~~~~~~~~~~~~~~~~
 * Switched from jsonfield2 to jsonfield as the earlier one has archived and merged back in the latter one.
@@ -31,7 +35,7 @@ Unreleased
 
 [3.6.1] - 2021-02-19
 ~~~~~~~~~~~~~~~~~~~~
-* Add time_remaining_seconds field of ProctoredExamStudentAttempt model to readonly_fields in 
+* Add time_remaining_seconds field of ProctoredExamStudentAttempt model to readonly_fields in
   Django admin page so it is not required when editing the model.
 * Update reference to Exception.message to use string representation of the exception, as message
   is no longer an attribute of the Exception class.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.6.4'
+__version__ = '3.6.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -102,7 +102,7 @@ def require_course_or_global_staff(func):
     def wrapped(request, *args, **kwargs):  # pylint: disable=missing-docstring
         instructor_service = get_runtime_service('instructor')
         course_id = kwargs.get('course_id', None)
-        exam_id = request.data.get('exam_id', None)
+        exam_id = request.data.get('exam_id') or kwargs.get('exam_id', None)
         attempt_id = kwargs.get('attempt_id', None)
         if request.user.is_staff:
             return func(request, *args, **kwargs)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**
@edx/masters-devs-cosmonauts 
The method decorator `require_course_or_global_staff` was expecting the exam_id to be contained in the request data as opposed to the function arguments. This prevented course staff from resetting an attempt using the new reset flow. 

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.