### PR TITLE
[MST-666] Update onboarding status view to consider attempts from other courses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.7.0] - 2021-03-01
+~~~~~~~~~~~~~~~~~~~~
+* Update the learner onboarding status view to consider verified attempts from other courses.
+
 [3.6.7] - 2021-02-24
 ~~~~~~~~~~~~~~~~~~~~
 * Fix requirements file

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.6.7'
+__version__ = '3.7.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -252,6 +252,10 @@ class InstructorDashboardOnboardingAttemptStatus:
     verified = 'verified'
     error = 'error'
 
+    # The following status is not a true attempt status, but is used when the
+    # user's onboarding profile is approved in a different course.
+    other_course_approved = 'other_course_approved'
+
     onboarding_statuses = {
         ProctoredExamStudentAttemptStatus.created: setup_started,
         ProctoredExamStudentAttemptStatus.download_software_clicked: setup_started,

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -19,7 +19,7 @@ from django.test import TestCase
 from django.test.client import Client
 
 from edx_proctoring.api import create_exam
-from edx_proctoring.models import ProctoredExam, ProctoredExamStudentAttempt
+from edx_proctoring.models import ProctoredExamStudentAttempt
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import MockCreditService, MockInstructorService
@@ -373,32 +373,3 @@ class ProctoredExamTestCase(LoggedInTestCase):
         Replaces newlines and multiple spaces with a single space.
         """
         return ' '.join(string.replace('\n', '').split())
-
-
-def create_onboarding_exam(
-    course_id='a/b/c',
-    content_id='test_content',
-    exam_name='Test Exam',
-    external_id='123aXqe3'
-):
-    """
-    Create and return an onboarding exam.
-
-    Parameters:
-    * course_id: the course ID for the course in which to create the exam
-    * content_id: the content ID
-    * exam_name: the name of the exam
-    * external_id: the external ID of the exam
-    """
-    onboarding_exam = ProctoredExam.objects.create(
-        course_id=course_id,
-        content_id=content_id,
-        exam_name=exam_name,
-        external_id=external_id,
-        time_limit_mins=90,
-        is_active=True,
-        is_proctored=True,
-        is_practice_exam=True,
-        backend='test',
-    )
-    return onboarding_exam

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.6.7",
+  "version": "3.7.0",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

If the learner has no onboarding attempts in a course, an additional check is added for verified attempts in other courses. If at least one verified attempt exists, a message will display on the onboarding status panel that their onboarding profile is approved in another course. If the attempt is close to expiring (within a month), the message will be updated to inform the user.

---
![Screen Shot 2021-02-25 at 5 35 53 PM](https://user-images.githubusercontent.com/10442143/109327348-3cdae180-7826-11eb-87f8-14aacb5b5665.png)
---
![Screen Shot 2021-02-26 at 11 35 57 AM](https://user-images.githubusercontent.com/10442143/109327889-d1454400-7826-11eb-9779-88e1bb381242.png)
---


**JIRA:**

[MST-666](https://openedx.atlassian.net/browse/MST-666)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.