### PR TITLE
Revert updates caused by jsonfield

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.6.6] - 2021-02-24
+~~~~~~~~~~~~~~~~~~~~
+* Revert jsonfield PR
+
 [3.6.5] - 2021-02-23
 ~~~~~~~~~~~~~~~~~~~~
 * Bug fix to allow course staff to reset attempts

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.6.5'
+__version__ = '3.6.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ Django>=2.2
 django-model-utils
 djangorestframework
 django-ipware>=1.1.0
-jsonfield
+jsonfield2
 pytz>=2018
 pycryptodomex>=3.4.7
 django-crum

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.0.5
+amqp==5.0.3
     # via kombu
 appdirs==1.4.4
     # via fs
@@ -16,7 +16,7 @@ celery==5.0.4
     #   event-tracking
 certifi==2020.12.5
     # via requests
-cffi==1.14.5
+cffi==1.14.4
     # via cryptography
 chardet==4.0.0
     # via requests
@@ -32,7 +32,7 @@ click==7.1.2
     #   click-didyoumean
     #   click-plugins
     #   click-repl
-cryptography==3.4.6
+cryptography==3.3.1
     # via pyjwt
 django-crum==0.7.9
     # via
@@ -51,7 +51,7 @@ django-waffle==2.1.0
     #   edx-drf-extensions
 django-webpack-loader==0.7.0
     # via -r requirements/base.in
-django==2.2.19
+django==2.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -63,7 +63,7 @@ django==2.2.19
     #   edx-drf-extensions
     #   edx-when
     #   event-tracking
-    #   jsonfield
+    #   jsonfield2
     #   rest-condition
 djangorestframework==3.12.2
     # via
@@ -78,11 +78,11 @@ edx-django-utils==3.13.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-when
-edx-drf-extensions==6.5.0
+edx-drf-extensions==6.4.0
     # via
     #   -r requirements/base.in
     #   edx-when
-edx-opaque-keys==2.2.0
+edx-opaque-keys==2.1.1
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -99,8 +99,10 @@ future==0.18.2
     # via pyjwkest
 idna==2.10
     # via requests
-jsonfield==3.1.0
-    # via -r requirements/base.in
+jsonfield2==3.0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 kombu==5.0.2
     # via celery
 lxml==4.6.2
@@ -111,13 +113,13 @@ newrelic==6.0.1.155
     # via edx-django-utils
 pbr==5.5.1
     # via stevedore
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.14
     # via click-repl
 psutil==5.8.0
     # via edx-django-utils
 pycparser==2.20
     # via cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.9.9
     # via
     #   -r requirements/base.in
     #   pyjwkest
@@ -127,7 +129,7 @@ pyjwt[crypto]==1.7.1
     # via
     #   drf-jwt
     #   edx-rest-api-client
-pymongo==3.11.3
+pymongo==3.11.2
     # via
     #   edx-opaque-keys
     #   event-tracking
@@ -136,7 +138,7 @@ python-dateutil==2.8.1
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   xblock
-pytz==2021.1
+pytz==2020.5
     # via
     #   -r requirements/base.in
     #   celery
@@ -161,7 +163,9 @@ semantic-version==2.8.5
 six==1.15.0
     # via
     #   click-repl
+    #   cryptography
     #   edx-drf-extensions
+    #   edx-opaque-keys
     #   event-tracking
     #   fs
     #   pyjwkest
@@ -185,7 +189,7 @@ wcwidth==0.2.5
     # via prompt-toolkit
 web-fragments==1.0.0
     # via xblock
-webob==1.8.7
+webob==1.8.6
     # via xblock
 xblock==1.4.0
     # via edx-when

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
-amqp==5.0.5
+amqp==5.0.3
 billiard==3.6.3.0
 celery==5.0.4
 click-didyoumean==0.0.3
 click-repl==0.1.6
 click==7.1.2
 kombu==5.0.2
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.14
 vine==5.0.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,7 @@ filelock==3.0.12
     #   virtualenv
 idna==2.10
     # via requests
-packaging==20.9
+packaging==20.8
     # via tox
 pluggy==0.13.1
     # via tox
@@ -40,11 +40,11 @@ toml==0.10.2
     # via tox
 tox-battery==0.6.1
     # via -r requirements/ci.in
-tox==3.22.0
+tox==3.21.2
     # via
     #   -r requirements/ci.in
     #   tox-battery
 urllib3==1.26.3
     # via requests
-virtualenv==20.4.2
+virtualenv==20.4.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,6 +11,9 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
+# jsonfield2 > 3.0.3 dropped support for python 3.5
+jsonfield2==3.0.3
+
 # pinning it to latest release.
 celery==5.0.4
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,14 +6,16 @@
 #
 appdirs==1.4.4
     # via virtualenv
-astroid==2.5
+astroid==2.4.2
     # via
     #   pylint
     #   pylint-celery
-bleach==3.3.0
+bleach==3.2.3
     # via readme-renderer
 certifi==2020.12.5
     # via requests
+cffi==1.14.4
+    # via cryptography
 chardet==4.0.0
     # via
     #   diff-cover
@@ -26,15 +28,17 @@ click==7.1.2
     #   code-annotations
     #   edx-lint
     #   pip-tools
-code-annotations==1.1.0
+code-annotations==1.0.2
     # via edx-lint
 colorama==0.4.4
     # via twine
-diff-cover==4.2.1
+cryptography==3.3.1
+    # via secretstorage
+diff-cover==4.2.0
     # via -r requirements/dev.in
 distlib==0.3.1
     # via virtualenv
-django==2.2.19
+django==2.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/dev.in
@@ -46,7 +50,7 @@ docutils==0.16
     # via readme-renderer
 edx-i18n-tools==0.5.3
     # via -r requirements/dev.in
-edx-lint==4.0.1
+edx-lint==3.0.2
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
@@ -62,22 +66,26 @@ isort==5.7.0
     # via
     #   -r requirements/quality.in
     #   pylint
+jeepney==0.6.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2-pluralize==0.3.0
     # via diff-cover
-jinja2==2.11.3
+jinja2==2.11.2
     # via
     #   code-annotations
     #   diff-cover
     #   jinja2-pluralize
 keyring==22.0.1
     # via twine
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.4.3
     # via astroid
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via pylint
-packaging==20.9
+packaging==20.8
     # via
     #   bleach
     #   tox
@@ -85,7 +93,7 @@ path.py==12.5.0
     # via
     #   -r requirements/dev.in
     #   edx-i18n-tools
-path==15.1.2
+path==15.0.1
     # via path.py
 pbr==5.5.1
     # via stevedore
@@ -103,9 +111,11 @@ py==1.10.0
     # via tox
 pycodestyle==2.6.0
     # via -r requirements/quality.in
+pycparser==2.20
+    # via cffi
 pydocstyle==5.1.1
     # via -r requirements/quality.in
-pygments==2.8.0
+pygments==2.7.4
     # via
     #   diff-cover
     #   readme-renderer
@@ -117,7 +127,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.0
+pylint==2.6.0
     # via
     #   edx-lint
     #   pylint-celery
@@ -127,7 +137,7 @@ pyparsing==2.4.7
     # via packaging
 python-slugify==4.0.1
     # via code-annotations
-pytz==2021.1
+pytz==2020.5
     # via django
 pyyaml==5.4.1
     # via
@@ -143,9 +153,13 @@ requests==2.25.1
     #   twine
 rfc3986==1.4.0
     # via twine
+secretstorage==3.3.0
+    # via keyring
 six==1.15.0
     # via
+    #   astroid
     #   bleach
+    #   cryptography
     #   edx-i18n-tools
     #   edx-lint
     #   readme-renderer
@@ -165,11 +179,11 @@ toml==0.10.2
     #   tox
 tox-battery==0.6.1
     # via -r requirements/dev.in
-tox==3.22.0
+tox==3.21.2
     # via
     #   -r requirements/dev.in
     #   tox-battery
-tqdm==4.57.0
+tqdm==4.56.0
     # via twine
 twine==3.3.0
     # via
@@ -177,7 +191,7 @@ twine==3.3.0
     #   -r requirements/quality.in
 urllib3==1.26.3
     # via requests
-virtualenv==20.4.2
+virtualenv==20.4.0
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-amqp==5.0.5
+amqp==5.0.3
     # via kombu
 appdirs==1.4.4
     # via fs
@@ -14,7 +14,7 @@ babel==2.9.0
     # via sphinx
 billiard==3.6.3.0
     # via celery
-bleach==3.3.0
+bleach==3.2.3
     # via readme-renderer
 celery==5.0.4
     # via
@@ -22,7 +22,7 @@ celery==5.0.4
     #   event-tracking
 certifi==2020.12.5
     # via requests
-cffi==1.14.5
+cffi==1.14.4
     # via cryptography
 chardet==4.0.0
     # via
@@ -40,7 +40,7 @@ click==7.1.2
     #   click-didyoumean
     #   click-plugins
     #   click-repl
-cryptography==3.4.6
+cryptography==3.3.1
     # via pyjwt
 django-crum==0.7.9
     # via
@@ -59,7 +59,7 @@ django-waffle==2.1.0
     #   edx-drf-extensions
 django-webpack-loader==0.7.0
     # via -r requirements/base.in
-django==2.2.19
+django==2.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -71,7 +71,7 @@ django==2.2.19
     #   edx-drf-extensions
     #   edx-when
     #   event-tracking
-    #   jsonfield
+    #   jsonfield2
     #   rest-condition
 djangorestframework==3.12.2
     # via
@@ -94,18 +94,18 @@ edx-django-utils==3.13.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-when
-edx-drf-extensions==6.5.0
+edx-drf-extensions==6.4.0
     # via
     #   -r requirements/base.in
     #   edx-when
-edx-opaque-keys==2.2.0
+edx-opaque-keys==2.1.1
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-when
 edx-rest-api-client==5.3.0
     # via -r requirements/base.in
-edx-sphinx-theme==2.0.0
+edx-sphinx-theme==1.6.1
     # via -r requirements/doc.in
 edx-when==2.0.0
     # via -r requirements/base.in
@@ -119,10 +119,12 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-jinja2==2.11.3
+jinja2==2.11.2
     # via sphinx
-jsonfield==3.1.0
-    # via -r requirements/base.in
+jsonfield2==3.0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 kombu==5.0.2
     # via celery
 lxml==4.6.2
@@ -133,7 +135,7 @@ markupsafe==1.1.1
     #   xblock
 newrelic==6.0.1.155
     # via edx-django-utils
-packaging==20.9
+packaging==20.8
     # via
     #   bleach
     #   sphinx
@@ -141,17 +143,17 @@ pbr==5.5.1
     # via stevedore
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.14
     # via click-repl
 psutil==5.8.0
     # via edx-django-utils
 pycparser==2.20
     # via cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.9.9
     # via
     #   -r requirements/base.in
     #   pyjwkest
-pygments==2.8.0
+pygments==2.7.4
     # via
     #   doc8
     #   readme-renderer
@@ -162,7 +164,7 @@ pyjwt[crypto]==1.7.1
     # via
     #   drf-jwt
     #   edx-rest-api-client
-pymongo==3.11.3
+pymongo==3.11.2
     # via
     #   edx-opaque-keys
     #   event-tracking
@@ -173,7 +175,7 @@ python-dateutil==2.8.1
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   xblock
-pytz==2021.1
+pytz==2020.5
     # via
     #   -r requirements/base.in
     #   babel
@@ -205,8 +207,10 @@ six==1.15.0
     # via
     #   bleach
     #   click-repl
+    #   cryptography
     #   doc8
     #   edx-drf-extensions
+    #   edx-opaque-keys
     #   edx-sphinx-theme
     #   event-tracking
     #   fs
@@ -220,7 +224,7 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.5.1
+sphinx==3.4.3
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -257,7 +261,7 @@ web-fragments==1.0.0
     # via xblock
 webencodings==0.5.1
     # via bleach
-webob==1.8.7
+webob==1.8.6
     # via xblock
 xblock==1.4.0
     # via edx-when

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,14 +4,16 @@
 #
 #    make upgrade
 #
-astroid==2.5
+astroid==2.4.2
     # via
     #   pylint
     #   pylint-celery
-bleach==3.3.0
+bleach==3.2.3
     # via readme-renderer
 certifi==2020.12.5
     # via requests
+cffi==1.14.4
+    # via cryptography
 chardet==4.0.0
     # via requests
 click-log==0.3.2
@@ -21,11 +23,13 @@ click==7.1.2
     #   click-log
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.0
+code-annotations==1.0.2
     # via edx-lint
 colorama==0.4.4
     # via twine
-django==2.2.19
+cryptography==3.3.1
+    # via secretstorage
+django==2.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.in
@@ -33,7 +37,7 @@ django==2.2.19
     #   edx-lint
 docutils==0.16
     # via readme-renderer
-edx-lint==4.0.1
+edx-lint==3.0.2
     # via -r requirements/quality.in
 idna==2.10
     # via requests
@@ -41,17 +45,21 @@ isort==5.7.0
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==2.11.3
+jeepney==0.6.0
+    # via
+    #   keyring
+    #   secretstorage
+jinja2==2.11.2
     # via code-annotations
 keyring==22.0.1
     # via twine
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.4.3
     # via astroid
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via pylint
-packaging==20.9
+packaging==20.8
     # via bleach
 pbr==5.5.1
     # via stevedore
@@ -59,9 +67,11 @@ pkginfo==1.7.0
     # via twine
 pycodestyle==2.6.0
     # via -r requirements/quality.in
+pycparser==2.20
+    # via cffi
 pydocstyle==5.1.1
     # via -r requirements/quality.in
-pygments==2.8.0
+pygments==2.7.4
     # via readme-renderer
 pylint-celery==0.3
     # via edx-lint
@@ -71,7 +81,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.0
+pylint==2.6.0
     # via
     #   edx-lint
     #   pylint-celery
@@ -81,7 +91,7 @@ pyparsing==2.4.7
     # via packaging
 python-slugify==4.0.1
     # via code-annotations
-pytz==2021.1
+pytz==2020.5
     # via django
 pyyaml==5.4.1
     # via code-annotations
@@ -95,9 +105,13 @@ requests==2.25.1
     #   twine
 rfc3986==1.4.0
     # via twine
+secretstorage==3.3.0
+    # via keyring
 six==1.15.0
     # via
+    #   astroid
     #   bleach
+    #   cryptography
     #   edx-lint
     #   readme-renderer
 snowballstemmer==2.1.0
@@ -110,7 +124,7 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
-tqdm==4.57.0
+tqdm==4.56.0
     # via twine
 twine==3.3.0
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ bok-choy==1.1.1
     #   event-tracking
 certifi==2020.12.5
     # via requests
-cffi==1.14.5
+cffi==1.14.4
     # via cryptography
 chardet==4.0.0
     # via requests
@@ -33,11 +33,11 @@ click-plugins==1.1.1
     #   click-plugins
     #   click-repl
     #   code-annotations
-code-annotations==1.1.0
+code-annotations==1.0.2
     # via -r requirements/test.in
 coverage==5.4
     # via pytest-cov
-cryptography==3.4.6
+cryptography==3.3.1
     # via pyjwt
 ddt==1.4.1
     # via -r requirements/test.in
@@ -71,7 +71,7 @@ django-webpack-loader==0.7.0
     #   edx-i18n-tools
     #   edx-when
     #   event-tracking
-    #   jsonfield
+    #   jsonfield2
     #   rest-condition
     # via
     #   -r requirements/base.in
@@ -85,13 +85,13 @@ edx-django-utils==3.13.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-when
-edx-drf-extensions==6.5.0
+edx-drf-extensions==6.4.0
     # via
     #   -r requirements/base.in
     #   edx-when
 edx-i18n-tools==0.5.3
     # via -r requirements/test.in
-edx-opaque-keys==2.2.0
+edx-opaque-keys==2.1.1
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -102,7 +102,7 @@ edx-when==2.0.0
     # via -r requirements/base.in
 event-tracking==1.0.4
     # via -r requirements/base.in
-execnet==1.8.0
+execnet==1.7.1
     # via pytest-xdist
 freezegun==1.1.0
     # via -r requirements/test.in
@@ -118,11 +118,12 @@ idna==2.10
     # via requests
 iniconfig==1.1.1
     # via pytest
-jinja2==2.11.3
+jinja2==2.11.2
     # via code-annotations
-jsonfield==3.1.0
-    # via -r requirements/base.in
-    # via celery
+jsonfield2==3.0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 lazy==1.4
     # via bok-choy
 logilab-common==1.8.1
@@ -139,11 +140,11 @@ mypy-extensions==0.4.3
     # via logilab-common
 newrelic==6.0.1.155
     # via edx-django-utils
-packaging==20.9
+packaging==20.8
     # via pytest
 path.py==12.5.0
     # via edx-i18n-tools
-path==15.1.2
+path==15.0.1
     # via path.py
 pbr==5.5.1
     # via stevedore
@@ -160,7 +161,7 @@ py==1.10.0
     #   pytest-forked
 pycparser==2.20
     # via cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.9.9
     # via
     #   -r requirements/base.in
     #   pyjwkest
@@ -182,7 +183,7 @@ pytest-django==4.1.0
     # via -r requirements/test.in
 pytest-forked==1.3.0
     # via pytest-xdist
-pytest-xdist==2.2.1
+pytest-xdist==2.2.0
     # via -r requirements/test.in
 pytest==6.2.2
     # via
@@ -198,7 +199,7 @@ python-dateutil==2.8.1
     #   xblock
 python-slugify==4.0.1
     # via code-annotations
-pytz==2021.1
+pytz==2020.5
     # via
     #   -r requirements/base.in
     #   celery
@@ -235,8 +236,10 @@ six==1.15.0
     # via
     #   bok-choy
     #   click-repl
+    #   cryptography
     #   edx-drf-extensions
     #   edx-i18n-tools
+    #   edx-opque-keys
     #   event-tracking
     #   fs
     #   pyjwkest
@@ -274,7 +277,7 @@ wcwidth==0.2.5
     # via prompt-toolkit
 web-fragments==1.0.0
     # via xblock
-webob==1.8.7
+webob==1.8.6
     # via xblock
 xblock==1.4.0
     # via edx-when


### PR DESCRIPTION
**Description:**

I believe that the update to jsonfield is causing tests to fail on edx-platform. I'm reverting the changes created by https://github.com/edx/edx-proctoring/pull/791 to test that.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.