### PR TITLE
Add onboarding status logic to proctoring api file

### DIFF
--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -289,6 +289,20 @@ class ProctoredExamStudentAttemptManager(models.Manager):
             queryset = queryset.filter(user__in=users)
         return queryset
 
+    def get_onboarding_attempts_by_user_list(self, users, backend):
+        """
+        Returns all the onboarding attempts by the list of user, and proctoring backend
+        This function will will a django query set.
+        """
+        queryset = self.filter(
+            proctored_exam__is_practice_exam=True,
+            proctored_exam__is_active=True,
+            proctored_exam__backend=backend,
+            taking_as_proctored=True,
+            user___in=users,
+        ).order_by('-modified')
+        return query_set
+
     def get_filtered_exam_attempts(self, course_id, search_by):
         """
         Returns the Student Exam Attempts for the given course_id filtered by search_by.

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -252,6 +252,10 @@ class InstructorDashboardOnboardingAttemptStatus:
     verified = 'verified'
     error = 'error'
 
+    # The following status is not a true attempt status, but is used when the
+    # user's onboarding profile is approved in a different course.
+    other_course_approved = 'other_course_approved'
+
     onboarding_statuses = {
         ProctoredExamStudentAttemptStatus.created: setup_started,
         ProctoredExamStudentAttemptStatus.download_software_clicked: setup_started,


### PR DESCRIPTION
**Description:**

Just a draft. This is to provide an unproven logic block to help retrieve the onboarding status of our learners.

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.