### PR TITLE
Add accordian for attempt table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.7.1] - 2021-03-02
+~~~~~~~~~~~~~~~~~~~~
+* Update table on instructors dashboard to add accordian for multiple attempts
+
 [3.7.0] - 2021-03-01
 ~~~~~~~~~~~~~~~~~~~~
 * Update the learner onboarding status view to consider verified attempts from other courses.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.7.0'
+__version__ = '3.7.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -294,6 +294,7 @@ describe('ProctoredExamAttemptView', function() {
         '{attempt_url: attempt_url, count: pagination_info.current_page + 1}, true) %>' +
         '" > <span aria-hidden="true">&raquo;</span></a> </li> <% }%> </ul><div class="clearfix"></div></div>' +
         '<table class="exam-attempts-table"> <thead><tr class="exam-attempt-headings">' +
+        '<th class="more"></th>' +
         '<th class="username">Username</th>' +
         '<th class="exam-name">Exam Name</th>' +
         '<th class="attempt-allowed-time">Allowed Time (Minutes)</th>' +
@@ -303,9 +304,22 @@ describe('ProctoredExamAttemptView', function() {
         '<th class="c_action">Actions</th>' +
         '</tr></thead>' +
         '<% if (is_proctored_attempts) { %>\n' +
-        '<tbody>' +
         '<% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){ %>' +
-        '<tr class="allowance-items">' +
+        '<tbody class="<%= proctored_exam_attempt.row_class %><% if (proctored_exam_attempt.all_attempts.length > 1)' +
+        ' { %> accordion-trigger <% } %>"' +
+        'aria-expanded="false"' +
+        'id="<%= proctored_exam_attempt.id %>"' +
+        'aria-controls="<%= proctored_exam_attempt.id %>_contents"' +
+        '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>' +
+        'tabindex=0 <% } %>' +
+        '>' +
+        '<tr' +
+        'class="allowance-items"' +
+        '>' +
+        '<td>' +
+        '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>' +
+        '<span class="fa fa-chevron-right" aria-hidden="true"></span>' +
+        '<% } %> </td>' +
         '<td>' +
         '<%- interpolate(gettext(\' %(username)s \'), { username: proctored_exam_attempt.user.username }, true) %>' +
         '</td>' +
@@ -371,27 +385,20 @@ describe('ProctoredExamAttemptView', function() {
         '<% } %>' +
         '</td>' +
         '</tr>' +
-        '<% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt){ %>' +
+        '</tbody>' +
+        '<% if (proctored_exam_attempt.all_attempts.length > 1) { %>' +
+        '<tbody class="accordion-panel is-hidden" id="<%= proctored_exam_attempt.id %>_contents">' +
+        '<% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt) { %>' +
         '<tr class="allowance-items">' +
-        '<td></td>' +
-        '<td></td>' +
-        '<td></td>' +
-        '<td></td>' +
+        '<td></td> <td></td> <td></td> <td></td> <td></td>' +
         '<td> <%= getDateFormat(proctored_exam_attempt.started_at) %></td>' +
         '<td> <%= getDateFormat(proctored_exam_attempt.completed_at) %></td>' +
         '<td>' +
-        '<% if (proctored_exam_attempt.status){ %>' +
+        '<% if (proctored_exam_attempt.status) { %>' +
         '<%= getExamAttemptStatus(proctored_exam_attempt.status) %>' +
-        '<% } else { %>' +
-        'N/A' +
-        '<% } %>' +
-        '</td>' +
-        '<td></td>' +
-        '</tr>' +
-        '<% }); %>' +
-        '<% }); %>' +
-        '</tbody>' +
-        '<% } %>' +
+        '<% } else { %> N/A <% } %> </td>' +
+        '<td></td> </tr> <% }); %>' +
+        '</tbody> <% }%> <% }); %> <% } %>' +
         '</table>' +
         '<% if (!is_proctored_attempts) { %>' +
         '<p> No exam results found. </p>' +
@@ -626,9 +633,9 @@ describe('ProctoredExamAttemptView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Error');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
 
         expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).not.toHaveLength(0);
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
@@ -681,9 +688,9 @@ describe('ProctoredExamAttemptView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Ready to resume');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Ready to resume');
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').hasClass('is-visible')).toEqual(false);
     });
 
@@ -707,9 +714,9 @@ describe('ProctoredExamAttemptView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('testuser1');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).toContain('Normal Exam');
-        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Error');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody.accordion-panel').html()).toContain('Error');
 
         expect(this.proctored_exam_attempt_view.$el.find('button.action').html()).toHaveLength(0);
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown').html()).toHaveLength(0);
@@ -820,7 +827,37 @@ describe('ProctoredExamAttemptView', function() {
         this.server.respond();
         this.server.respond();
 
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('testuser1');
-        expect(this.proctored_exam_attempt_view.$el.find('tr.allowance-items').html()).not.toContain('Normal Exam');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).not.toContain('testuser1');
+        expect(this.proctored_exam_attempt_view.$el.find('tbody').html()).not.toContain('Normal Exam');
+    });
+
+    it('shows and hides accordion when toggled', function() {
+        setFixtures('<div class="student-proctored-exam-container" data-course-id="test_course_id" ' +
+            'data-enable-exam-resume-proctoring-improvements="True"></div>');
+
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(getExpectedGroupedProctoredExamAttemptWithAttemptStatusJson('submitted', false))
+            ]
+        );
+        this.proctored_exam_attempt_view = new edx.instructor_dashboard.proctoring.ProctoredExamAttemptView();
+
+        // Process all requests so far
+        this.server.respond();
+        this.server.respond();
+
+        // check that accordion is hidden
+        expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(true);
+
+        // click to expand section
+        spyOnEvent('.accordion-trigger', 'click');
+        $('.accordion-trigger').trigger('click');
+
+        // check that accordion is no longer hidden
+        expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(false);
     });
 });

--- a/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-proctored-exam-attempts-grouped.underscore
@@ -138,6 +138,7 @@
             <table class="exam-attempts-table">
                 <thead>
                     <tr class="exam-attempt-headings">
+                        <th class="more"></th>
                         <th class="username"><%- gettext("Username") %></th>
                         <th class="exam-name"><%- gettext("Exam Name") %></th>
                         <th class="attempt-allowed-time"><%- gettext("Time Limit") %> </th>
@@ -149,9 +150,22 @@
                     </tr>
                 </thead>
                 <% if (is_proctored_attempts) { %>
-                <tbody>
                     <% _.each(proctored_exam_attempts, function(proctored_exam_attempt, dashboard_index){ %>
+                    <tbody
+                        class="<%= proctored_exam_attempt.row_class %><% if (proctored_exam_attempt.all_attempts.length > 1) { %> accordion-trigger <% } %>"
+                        aria-expanded="false"
+                        id="<%= proctored_exam_attempt.id %>"
+                        aria-controls="<%= proctored_exam_attempt.id %>_contents"
+                        <% if (proctored_exam_attempt.all_attempts.length > 1) { %>
+                            tabindex=0
+                        <% } %>
+                    >
                         <tr class="allowance-items">
+                            <td>
+                                <% if (proctored_exam_attempt.all_attempts.length > 1) { %>
+                                    <span class="fa fa-chevron-right" aria-hidden="true"></span>
+                                <% } %>
+                            </td>
                             <td>
                                 <%- interpolate(gettext(' %(username)s '), { username: proctored_exam_attempt.user.username }, true) %>
                             </td>
@@ -210,9 +224,12 @@
                                 <% } %>
                             </td>
                         </tr>
+                        </tbody>
                         <% if (proctored_exam_attempt.all_attempts.length > 1) { %>
+                            <tbody class="accordion-panel is-hidden" id="<%= proctored_exam_attempt.id %>_contents">
                             <% _.each(proctored_exam_attempt.all_attempts, function(proctored_exam_attempt) { %>
                                 <tr class="allowance-items">
+                                    <td></td>
                                     <td></td>
                                     <td></td>
                                     <td></td>
@@ -229,9 +246,9 @@
                                     <td></td>
                                 </tr>
                             <% }); %>
+                            </tbody>
                         <% }%>
                     <% }); %>
-                </tbody>
                 <% } %>
             </table>
             <% if (!is_proctored_attempts) { %>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Added accordion to attempt table when user has multiple attempts on an exam. 

<img width="1281" alt="Screen Shot 2021-03-02 at 8 28 44 AM" src="https://user-images.githubusercontent.com/46360176/109664036-bfbbaf00-7b3a-11eb-934f-c23226442ae9.png">

<img width="1277" alt="Screen Shot 2021-03-02 at 8 28 52 AM" src="https://user-images.githubusercontent.com/46360176/109664059-c2b69f80-7b3a-11eb-9f3b-35166fb30e08.png">


**JIRA:**

[MST-663](https://openedx.atlassian.net/browse/MST-663)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.