### PR TITLE
Fix Course ID being Incorrectly Determined by StudentProctoredExamAttempt PUT handler, preventing course staff from marking exam attempts as "ready_to_resume".

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.7.6] - 2021-03-05
+~~~~~~~~~~~~~~~~~~~~
+* Fix bug with StudentProctoredExamAttempt put handler where course_id was being incorrectly determined,
+  preventing course staff from marking learners' attempts as "ready_to_resume".
 
 [3.7.5] - 2021-03-05
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.7.5'
+__version__ = '3.7.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -674,7 +674,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
             )
             raise StudentExamAttemptDoesNotExistsException(err_msg)
 
-        course_id = attempt['proctored_exam']['id']
+        course_id = attempt['proctored_exam']['course_id']
         action = request.data.get('action')
 
         err_msg = (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "main": "edx_proctoring/static/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:**

Fix Course ID being Incorrectly Determined by StudentProctoredExamAttempt PUT handler, preventing course staff from marking exam attempts as "ready_to_resume". 

**JIRA:**

None.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.