### PR TITLE
Fix for a11y bug on Special Exam Attempts panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Fixed accessibility bug on Special Exam Attempts panel on instructor dashboard
 
 [3.7.9] - 2021-03-09
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/static/proctoring/js/dropdown.js
+++ b/edx_proctoring/static/proctoring/js/dropdown.js
@@ -81,6 +81,7 @@ edx = edx || {};
         $dropdown.on('keydown', function(e) {
             catchKeyPress($(this), e);
         });
+        event.stopPropagation();
     };
 
     edx.dashboard.dropdown.bindToggleButtons = function(selector) {

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_attempt_view.js
@@ -298,6 +298,7 @@ edx = edx || {};
             // based on code from openedx/features/course_experience/static/course_experience/js/CourseOutline.js
             // but modified to better fit this feature's needs
             var accordionRow, isExpanded, $toggleChevron, $contentPanel;
+            event.preventDefault();
             accordionRow = event.currentTarget;
             if (accordionRow.classList.contains('accordion-trigger')) {
                 isExpanded = accordionRow.getAttribute('aria-expanded') === 'true';
@@ -318,6 +319,7 @@ edx = edx || {};
         },
         keyToggleAttemptAccordion: function(event) {
             var key = event.which || event.keyCode || 0;
+            event.preventDefault();
 
             if (key === 13) {
                 $(event.target).click();

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_attempt_spec.js
@@ -707,6 +707,7 @@ describe('ProctoredExamAttemptView', function() {
         )[0].text).toContain('Resume');
         expect(this.proctored_exam_attempt_view.$el.find('.actions-dropdown .actions-dropdown-list '
         + '.actions-item .action')[1].text).toContain('Reset');
+        expect(this.proctored_exam_attempt_view.$el.find('.accordion-panel').hasClass('is-hidden')).toEqual(true);
 
         // trigger the resume attempt event.
         spyOnEvent('.resume-attempt', 'click');


### PR DESCRIPTION
**Description:**

On the Special Exam Attempts panel in the instructor dashboard, the gear icon triggered both the accordion and the action menu. You also could not expand the action menu by hitting enter. This fix prevents a click event on the gear icon from bubbling up to the parent, and also fixes the keypress issue.

**JIRA:**

[MST-702](https://openedx.atlassian.net/browse/MST-702)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.