### PR TITLE
3.7.11 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[3.7.10] - 2021-03-15
-~~~~~~~~~~~~~~~~~~~~
+[3.7.11] - 2021-03-15
+~~~~~~~~~~~~~~~~~~~~~
 * Update the onboarding status to take into account sections that are not accessible to the user
 or has a release date in the future. For sections with release dates in the future,
 that date will now be shown to the learner.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.7.10'
+__version__ = '3.7.11'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.7.10",
+  "version": "3.7.11",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
**Description:**

Fixes a missing `~` in the changlog file. I just choose to scrub the 3.7.10 release instead of trying to force push a new tag.

3.7.10 PR #792 

@edx/masters-devs-cosmonauts 