### PR TITLE
[MST-695] Update error message for proctored exams

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.7.13] - 2021-03-16
+~~~~~~~~~~~~~~~~~~~~~
+* Update proctored exam error message to remove statement that the user must restart their exam
+  from scratch, and include a proctoring escalation email rather than a link to support if
+  applicable.
+
 [3.7.12] - 2021-03-15
 ~~~~~~~~~~~~~~~~~~~~~
 * Update the onboarding status to take into account sections that are not accessible to the user

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.7.12'
+__version__ = '3.7.13'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/proctored_exam/error.html
+++ b/edx_proctoring/templates/proctored_exam/error.html
@@ -6,19 +6,21 @@
     {% endblocktrans %}
   </h3>
 
-  <p>
-    {% blocktrans %}
-      A technical error has occurred with your proctored exam. Please
-      reach out to <a href="{{link_urls.contact_us}}" target="_blank">
-      edX Support</a> and your course team immediately for assistance.
-    {% endblocktrans %}
-  </p>
-  <p>
-    {% blocktrans %}
-      Once the error is resolved, you will need to restart the exam
-      and answer all questions again. If you have concerns about your
-      proctoring session results, please contact your course team.
-    {% endblocktrans %}
-  </p>
+<p>
+  {% if proctoring_escalation_email %}
+      {% blocktrans %}
+        A system error has occurred with your proctored exam. Please reach out to your course 
+        team at <a href="mailto:{{proctoring_escalation_email}}">{{proctoring_escalation_email}}</a> 
+        for assistance, and return to the exam once you receive further instructions.
+      {% endblocktrans %}
+  {% else %}
+      {% blocktrans %}
+        A system error has occurred with your proctored exam. Please reach out to 
+        <a href="{{link_urls.contact_us}}" target="_blank">{{platform_name}} Support</a> for 
+        assistance, and return to the exam once you receive further instructions.
+      {% endblocktrans %}
+  {% endif %}
+</p>
+
 </div>
 {% include 'proctored_exam/footer.html' %}

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -67,7 +67,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         self.timed_exam_submitted_expired = 'The time allotted for this exam has expired. Your exam has been submitted'
         self.submitted_timed_exam_msg_with_due_date = 'After the due date has passed,'
         self.exam_time_expired_msg = 'You did not complete the exam in the allotted time'
-        self.exam_time_error_msg = 'A technical error has occurred with your proctored exam'
+        self.exam_time_error_msg = 'A system error has occurred with your proctored exam'
         self.chose_proctored_exam_msg = 'Set up and start your proctored exam'
         self.proctored_exam_optout_msg = 'Take this exam without proctoring'
         self.proctored_exam_completed_msg = 'Are you sure you want to end your proctored exam'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.7.12",
+  "version": "3.7.13",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
**Description:**

Since course teams can now resume exams that are in an error state, learners should no longer have to start their proctored exams from scratch. This updates the proctoring error message to reflect that, and also includes the proctoring escalation email instead of a link to support, if it exists.

The error message has been changed to:

> A system error has occurred with your proctored exam. Please reach out to your course team at {proctoring_escalation_email} for assistance, and return to the exam once you receive further instructions.

Or, if there is no escalation email:

> A system error has occurred with your proctored exam. Please reach out to {link to support} for assistance, and return to the exam once you receive further instructions.

---
![Screen Shot 2021-03-16 at 4 06 14 PM](https://user-images.githubusercontent.com/10442143/111373025-cf2a1480-8671-11eb-97ed-9250f805bc0e.png)
---
![Screen Shot 2021-03-16 at 4 07 11 PM](https://user-images.githubusercontent.com/10442143/111373031-d2250500-8671-11eb-9216-bf0a9384982a.png)
---

**JIRA:**

[MST-695](https://openedx.atlassian.net/browse/MST-695)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.