### PR TITLE
Pass string into get_proctoring_escalation_email rather than object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.7.14] - 2021-03-19
+~~~~~~~~~~~~~~~~~~~~~
+* Fix issue where a course key object was being passed in to `get_proctoring_escalation_email`,
+  rather than a string.
+
 [3.7.13] - 2021-03-16
 ~~~~~~~~~~~~~~~~~~~~~
 * Update proctored exam error message to remove statement that the user must restart their exam

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.7.13'
+__version__ = '3.7.14'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -2140,7 +2140,7 @@ def _get_proctored_exam_context(exam, attempt, user_id, course_id, is_practice_e
         ) if attempt else '',
         'link_urls': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}),
         'tech_support_email': settings.TECH_SUPPORT_EMAIL,
-        'proctoring_escalation_email': _get_proctoring_escalation_email(course_id),
+        'proctoring_escalation_email': _get_proctoring_escalation_email(exam['course_id']),
         'exam_review_policy': _get_review_policy_by_exam_id(exam['id']),
         'backend_js_bundle': provider.get_javascript(),
         'provider_tech_support_email': provider.tech_support_email,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.7.13",
+  "version": "3.7.14",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.