### PR TITLE
Improve onboarding copy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.7.15] - 2021-03-24
+~~~~~~~~~~~~~~~~~~~~~
+* Improved learner messaging on onboarding panel and submitted interstitial.
+
 [3.7.14] - 2021-03-19
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix issue where a course key object was being passed in to `get_proctoring_escalation_email`,

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.7.14'
+__version__ = '3.7.15'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -43,7 +43,7 @@
             status: gettext('Approved in Another Course'),
             message: gettext('You are eligible to take proctored exams in this course.'),
             detail: gettext(
-                'If your device has changed, we recommended you complete this ' +
+                'If your device has changed, we recommend that you complete this ' +
                 'course\'s onboarding exam in order to ensure that your setup ' +
                 'still meets the requirements for proctoring.'
             )

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -41,11 +41,10 @@
         },
         other_course_approved: {
             status: gettext('Approved in Another Course'),
-            message: gettext(
-                'Your onboarding profile has been approved in another course, ' +
-                'so you are eligible to take proctored exams in this course. ' +
-                'However, it is highly recommended that you complete this ' +
-                'course\'s onboarding exam in order to ensure that your device ' +
+            message: gettext('You are eligible to take proctored exams in this course.'),
+            detail: gettext(
+                'If your device has changed, we recommended you complete this ' +
+                'course\'s onboarding exam in order to ensure that your setup ' +
                 'still meets the requirements for proctoring.'
             )
         },
@@ -93,6 +92,11 @@
             });
 
             $el.find('.onboarding-status-message').css({
+                'margin-bottom': '15px'
+            });
+
+            $el.find('.onboarding-status-detail').css({
+                'font-size': '0.8rem',
                 'margin-bottom': '15px'
             });
 
@@ -157,6 +161,7 @@
                 data = {
                     onboardingStatus: statusText.status,
                     onboardingMessage: statusText.message,
+                    onboardingDetail: statusText.detail,
                     showOnboardingReminder: !['verified', 'other_course_approved'].includes(data.onboarding_status),
                     onboardingNotReleased: releaseDate > now,
                     showOnboardingExamLink: this.shouldShowExamLink(data.onboarding_status),

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -115,6 +115,12 @@
                 'margin-bottom': '15px'
             });
 
+            $el.find('.action-onboarding-practice').css({
+                color: '#ffffff',
+                background: '#0075b4',
+                'margin-bottom': '15px'
+            });
+
             $el.find('.action-disabled').css({
                 background: '#b4b6bd'
             });
@@ -159,7 +165,8 @@
                 statusText = this.getExamAttemptText(this.status);
                 releaseDate = new Date(data.onboarding_release_date);
                 data = {
-                    onboardingStatus: statusText.status,
+                    onboardingStatus: this.status,
+                    onboardingStatusText: statusText.status,
                     onboardingMessage: statusText.message,
                     onboardingDetail: statusText.detail,
                     showOnboardingReminder: !['verified', 'other_course_approved'].includes(data.onboarding_status),

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
@@ -45,6 +45,11 @@ describe('ProctoredExamInfo', function() {
             '<div class="onboarding-status-message">' +
             '<span class="onboarding-status-message"><%= onboardingMessage %></span>' +
             '</div>' +
+            '<% if (onboardingDetail) { %>' +
+            '<div class="onboarding-status-detail">' +
+            '<span class="onboarding-status-detail"><%= onboardingDetail %></span>' +
+            '</div>' +
+            '<%} %>' +
             '<%} %>' +
             '<div class="onboarding-reminder">' +
             '<% if (showOnboardingReminder) { %>' +
@@ -413,7 +418,9 @@ describe('ProctoredExamInfo', function() {
         expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
             .toContain('Approved in Another Course');
         expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
-            .toContain('it is highly recommended that you complete this course\'s onboarding exam');
+            .toContain('You are eligible to take proctored exams');
+        expect(this.proctored_exam_info.$el.find('.onboarding-status-detail').html())
+            .toContain('we recommended you complete');
         expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
             .toContain('Complete Onboarding');
     });

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
@@ -37,10 +37,10 @@ describe('ProctoredExamInfo', function() {
     beforeEach(function() {
         html = '<div class="proctoring-info">' +
             '<h3 class="message-title"> <%= gettext("This course contains proctored exams") %></h3>' +
-            '<% if (onboardingStatus) { %>' +
+            '<% if (onboardingStatusText) { %>' +
             '<div class="onboarding-status">' +
             '<span class="onboarding-status"><%= gettext("Current Onboarding Status:") %> ' +
-            '<%= onboardingStatus %></span>' +
+            '<%= onboardingStatusText %></span>' +
             '</div>' +
             '<div class="onboarding-status-message">' +
             '<span class="onboarding-status-message"><%= onboardingMessage %></span>' +
@@ -420,7 +420,7 @@ describe('ProctoredExamInfo', function() {
         expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
             .toContain('You are eligible to take proctored exams');
         expect(this.proctored_exam_info.$el.find('.onboarding-status-detail').html())
-            .toContain('we recommended you complete');
+            .toContain('we recommend that you complete');
         expect(this.proctored_exam_info.$el.find('.action-onboarding').html())
             .toContain('Complete Onboarding');
     });

--- a/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
@@ -1,8 +1,8 @@
 <div class="proctoring-info">
     <h3 class="message-title"> <%= gettext("This course contains proctored exams") %></h3>
-    <% if (onboardingStatus) { %>
+    <% if (onboardingStatusText) { %>
         <div class="onboarding-status">
-            <span class="onboarding-status"><%= gettext("Current Onboarding Status:") %> <%= onboardingStatus %></span>
+            <span class="onboarding-status"><%= gettext("Current Onboarding Status:") %> <%= onboardingStatusText %></span>
         </div>
         <div class="onboarding-status-message">
             <span class="onboarding-status-message"><%= onboardingMessage %></span>
@@ -30,6 +30,8 @@
     <% if (showOnboardingExamLink) { %>
         <% if (onboardingNotReleased) { %>
             <a class="action action-onboarding action-disabled"><%= gettext("Onboarding Opens") %> <%= onboardingReleaseDate %></a>
+        <%} else if (onboardingStatus && onboardingStatus === 'other_course_approved') { %>
+            <a href="<%= onboardingLink %>" class="action action-onboarding-practice"><%= gettext("Go To Onboarding") %></a>
         <%} else { %>
             <a href="<%= onboardingLink %>" class="action action-onboarding"><%= gettext("Complete Onboarding") %></a>
         <%} %>

--- a/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
@@ -7,6 +7,11 @@
         <div class="onboarding-status-message">
             <span class="onboarding-status-message"><%= onboardingMessage %></span>
         </div>
+        <% if (onboardingDetail) { %>
+            <div class="onboarding-status-detail">
+                <span class="onboarding-status-detail"><%= onboardingDetail %></span>
+            </div>
+        <%} %>
     <%} %>
     <div class="onboarding-reminder">
     <% if (showOnboardingReminder) { %>
@@ -18,7 +23,7 @@
             <%} %>
         </h4>
         <p class="message-copy">
-            <%= gettext("Onboarding profile review, including identity verification, can take 2+ business days.") %>
+            <%= gettext("Onboarding profile review can take 2+ business days.") %>
         </p>
     <%} %>
     </div>

--- a/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
@@ -31,7 +31,7 @@
         <% if (onboardingNotReleased) { %>
             <a class="action action-onboarding action-disabled"><%= gettext("Onboarding Opens") %> <%= onboardingReleaseDate %></a>
         <%} else if (onboardingStatus && onboardingStatus === 'other_course_approved') { %>
-            <a href="<%= onboardingLink %>" class="action action-onboarding-practice"><%= gettext("Go To Onboarding") %></a>
+            <a href="<%= onboardingLink %>" class="action action-onboarding-practice"><%= gettext("View Onboarding Exam") %></a>
         <%} else { %>
             <a href="<%= onboardingLink %>" class="action action-onboarding"><%= gettext("Complete Onboarding") %></a>
         <%} %>

--- a/edx_proctoring/templates/onboarding_exam/submitted.html
+++ b/edx_proctoring/templates/onboarding_exam/submitted.html
@@ -47,6 +47,13 @@
   {% endif %}
   <p>
     {% blocktrans %}
+      If you already have an onboarding profile approved through another course,
+      the this submission will not be reviewed. You may retry this exam at any time
+      to validate the proctoring software is set up properly on your device.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% blocktrans %}
       Please contact
       <a href="mailto:{{ integration_specific_email }}">
         {{ integration_specific_email }}

--- a/edx_proctoring/templates/onboarding_exam/submitted.html
+++ b/edx_proctoring/templates/onboarding_exam/submitted.html
@@ -11,9 +11,8 @@
     {% blocktrans %}
       If you do not have an onboarding profile with the system,
       Verificient will review your submission and create an onboarding
-      profile, to grant you access to proctored exams.  Onboarding
-      profile review, including identity verification, can take 2+
-      business days.
+      profile to grant you access to proctored exams. Onboarding
+      profile review can take 2+ business days.
     {% endblocktrans %}
   </p>
   <p>
@@ -24,6 +23,13 @@
         {{ learner_notification_from_email }}
       </a>,
       so make sure this email has been added to your inbox filter.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% blocktrans %}
+      If you already have an onboarding profile approved through another course,
+      this submission will not be reviewed. You may retry this exam at any time
+      to validate that your setup still meets the requirements for proctoring.
     {% endblocktrans %}
   </p>
   {% if experimental_proctoring_features %}
@@ -45,13 +51,6 @@
       </button>
     </p>
   {% endif %}
-  <p>
-    {% blocktrans %}
-      If you already have an onboarding profile approved through another course,
-      this submission will not be reviewed. You may retry this exam at any time
-      to validate the proctoring software is set up properly on your device.
-    {% endblocktrans %}
-  </p>
   <p>
     {% blocktrans %}
       Please contact

--- a/edx_proctoring/templates/onboarding_exam/submitted.html
+++ b/edx_proctoring/templates/onboarding_exam/submitted.html
@@ -48,7 +48,7 @@
   <p>
     {% blocktrans %}
       If you already have an onboarding profile approved through another course,
-      the this submission will not be reviewed. You may retry this exam at any time
+      this submission will not be reviewed. You may retry this exam at any time
       to validate the proctoring software is set up properly on your device.
     {% endblocktrans %}
   </p>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.7.14",
+  "version": "3.7.15",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

Improves a few messages to learners to reduce confusion.

1. De-emphasize the need to retake onboarding if the user already has a profile. I have attempted to reduce the amount of text and the size of the panel in this case.
2. Remove reference to identity verification as it may imply a relation IDV
3. Updates this submitted interstitial to explicitly state practice attempts will not be reviewed. The first sentence implies this but it's easy to read past. Do we think this change is too verbose?

**JIRA:**

[MST-687](https://openedx.atlassian.net/browse/MST-687?atlOrigin=eyJpIjoiMzE5NDU4ZDQzYmRmNDE5Y2I3OGMxZWRkYTAwYjUyOGMiLCJwIjoiaiJ9)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.