### PR TITLE
chore: replaced jsonfield2 with jsonfield

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 * Add GH action for migrations tests.
 * Add test for `_register_proctored_exam_attempt`.
 
+[4.0.4] - 2021-10-05
+~~~~~~~~~~~~~~~~~~~~~
+* Switched from jsonfield2 to jsonfield as the earlier one has archived and merged back in the latter one.
+
 [4.0.2] - 2021-09-28
 ~~~~~~~~~~~~~~~~~~~~~
 * Batch of refactorings to use format strings/lazy string formatting for logging calls

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.0.3'
+__version__ = '4.0.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ Django>=2.2
 django-model-utils
 djangorestframework
 django-ipware>=1.1.0
-jsonfield2
+jsonfield
 pyjwt[crypto]>=2.1.0		# Used for encoding JWTs when communicating with proctoring provider backends
 pytz>=2018
 pycryptodomex>=3.4.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,7 +47,7 @@ django==2.2.24
     #   edx-drf-extensions
     #   edx-when
     #   event-tracking
-    #   jsonfield2
+    #   jsonfield
     #   rest-condition
 django-crum==0.7.9
     # via
@@ -106,10 +106,8 @@ future==0.18.2
     # via pyjwkest
 idna==3.2
     # via requests
-jsonfield2==3.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+jsonfield==3.1.0
+    # via -r requirements/base.in
 kombu==5.1.0
     # via celery
 lxml==4.6.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,6 @@
 # Common constraints for edx repos
 -c common_constraints.txt
 
-# jsonfield2 > 3.0.3 dropped support for python 3.5
-jsonfield2==3.0.3
-
 # pinning it to latest release.
 celery==5.0.4
 # celery latest version requires click<8.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,7 @@ ddt==1.4.2
     #   edx-i18n-tools
     #   edx-when
     #   event-tracking
-    #   jsonfield2
+    #   jsonfield
     #   rest-condition
 django-crum==0.7.9
     # via
@@ -124,10 +124,8 @@ iniconfig==1.1.1
     # via pytest
 jinja2==3.0.1
     # via code-annotations
-jsonfield2==3.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+jsonfield==3.1.0
+    # via -r requirements/base.in
     # via celery
 lazy==1.4
     # via bok-choy


### PR DESCRIPTION

**Description:**

We are going to replace jsonfield2 with jsonfield as the earlier one has archived and merged back in the latter one.

**JIRA:**

[BOM-2412](https://openedx.atlassian.net/browse/BOM-2412)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.