### PR TITLE
MST-734 Add due_date to the learning_sequence accessible_sequences check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.8.3] - 2021-04-05
+~~~~~~~~~~~~~~~~~~~~~
+* Use exam due_date or course end date to evaluate the visibility of the onboarding status panel
 
 [3.8.2] - 2021-04-02
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.8.2'
+__version__ = '3.8.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -350,14 +350,16 @@ class MockUserCourseOutlineData:
 
 class MockScheduleData:
     """Mock Outline Schedule"""
-    def __init__(self, schedule_items):
+    def __init__(self, schedule_items, course_end=None):
         self.sequences = schedule_items
+        self.course_end = course_end
 
 
 class MockScheduleItemData:
     """Mock Schedule Item"""
-    def __init__(self, effective_start):
+    def __init__(self, effective_start, due_date=None):
         self.effective_start = effective_start
+        self.due = due_date
 
 
 class MockLearningSequencesService:
@@ -367,8 +369,12 @@ class MockLearningSequencesService:
         self.schedule_items = schedule_items
 
     def get_user_course_outline_details(self, course_key, user, at_time):
-        """ Return mock CourseOutlineDetailsData """
+        """ Return mock UserCourseOutlineDetailsData """
         return MockUserCourseOutlineDetailsData(
             MockUserCourseOutlineData(self.accessible_sequences),
             MockScheduleData(self.schedule_items),
         )
+
+    def get_user_course_outline(self, course_key, user, at_time):
+        """ Return mock UserCourseOutlineData """
+        return MockUserCourseOutlineData(self.accessible_sequences)

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -439,6 +439,7 @@ class ProctoredExamViewTests(LoggedInTestCase):
         self.assertEqual(response_data['time_limit_mins'], proctored_exam.time_limit_mins)
 
 
+@ddt.ddt
 class TestStudentOnboardingStatusView(ProctoredExamTestCase):
     """
     Tests for StudentOnboardingStatusView
@@ -823,14 +824,15 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         message = 'There is no onboarding exam accessible to this user.'
         self.assertEqual(response_data['detail'], message)
 
-    def test_onboarding_not_yet_released(self):
+    @ddt.data(None, timezone.now() + timezone.timedelta(days=3))
+    def test_onboarding_not_yet_released(self, due_date):
         """
         If the onboarding section has not been released the release date is returned
         """
         tomorrow = timezone.now() + timezone.timedelta(days=1)
         self.course_scheduled_sections[
             BlockUsageLocator.from_string(self.onboarding_exam.content_id)
-        ] = MockScheduleItemData(tomorrow)
+        ] = MockScheduleItemData(tomorrow, due_date=due_date)
 
         set_runtime_service('learning_sequences', MockLearningSequencesService(
             list(self.course_scheduled_sections.keys()),

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -282,3 +282,21 @@ def is_reattempting_exam(from_status, to_status):
         ProctoredExamStudentAttemptStatus.is_in_progress_status(from_status) and
         ProctoredExamStudentAttemptStatus.is_pre_started_status(to_status)
     )
+
+
+def get_visibility_check_date(course_schedule, usage_key):
+    """
+    Utility function to return the date, of which
+    we should use to test the learner's visibility to the exam
+
+    Returns one of the following:
+        * The due date of the course structure usage_key
+        * The course end date
+        * The max datetime if no course_end date specified
+    """
+    visibility_check_date = course_schedule.course_end or pytz.utc.localize(datetime.max)
+    exam_schedule_item = course_schedule.sequences.get(usage_key)
+    if exam_schedule_item and exam_schedule_item.due:
+        visibility_check_date = exam_schedule_item.due
+
+    return visibility_check_date

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -80,6 +80,7 @@ from edx_proctoring.statuses import (
 from edx_proctoring.utils import (
     AuthenticatedAPIView,
     get_time_remaining_for_attempt,
+    get_visibility_check_date,
     humanized_time,
     locate_attempt_by_attempt_code,
     obscured_user_id
@@ -369,7 +370,12 @@ class StudentOnboardingStatusView(ProctoredAPIView):
 
         for onboarding_exam in onboarding_exams:
             usage_key = BlockUsageLocator.from_string(onboarding_exam.content_id)
-            if usage_key not in details.outline.accessible_sequences:
+            visibility_check_date = get_visibility_check_date(details.schedule, usage_key)
+            user_outline = learning_sequences_service.get_user_course_outline(
+                course_key, user, visibility_check_date
+            )
+
+            if usage_key not in user_outline.accessible_sequences:
                 onboarding_exams.remove(onboarding_exam)
 
         if not onboarding_exams:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
**Description:**

We want to ensure due dates do not hide learner's onboarding status panel

**JIRA:**

[MST-734](https://openedx.atlassian.net/browse/MST-734)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.