### PR TITLE
fix: Display Useful Status in InstructorDashboard StudentOnboardingPa…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.8.5] - 2021-04-07
+~~~~~~~~~~~~~~~~~~~~~
+* Add handling of the "onboarding_reset" attempt status to the
+  StudentOnboardingStatusByCourseView view and the StudentOnboardingStatus
+  panel in the Instructor Dashboard.
+
 [3.8.4] - 2021-04-05
 ~~~~~~~~~~~~~~~~~~~~~
 * Add the request username to the proctoring info panel, allowing course staff to masquerade as

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.8.4'
+__version__ = '3.8.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
@@ -27,6 +27,8 @@ edx = edx || {};
         verified: gettext('Verified'),
         rejected: gettext('Rejected'),
         error: gettext('Error'),
+        // TODO: remove as part of MST-745
+        onboarding_reset_past_due: gettext('Onboarding Reset Failed Due to Past Due Exam'),
         // Enrollment modes (Note: 'verified' is both a status and enrollment mode)
         audit: gettext('Audit'),
         honor: gettext('Honor'),

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -256,6 +256,14 @@ class InstructorDashboardOnboardingAttemptStatus:
     # user's onboarding profile is approved in a different course.
     other_course_approved = 'other_course_approved'
 
+    # The following status is not a true attempt status that has a corresponding database
+    # state. This is a consequence of a bug in our software that allows a learner to end up
+    # with their only or their most recent exam attempt being in the "onboarding_reset" state.
+    # The learner should not end up in this state, but while we work on a fix, we should not
+    # display "null" in the Instructor Dashboard Student Onboarding Panel.
+    # TODO: remove as part of MST-745
+    onboarding_reset_past_due = 'onboarding_reset_past_due'
+
     onboarding_statuses = {
         ProctoredExamStudentAttemptStatus.created: setup_started,
         ProctoredExamStudentAttemptStatus.download_software_clicked: setup_started,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
fix: Display Useful Status in InstructorDashboard StudentOnboardingPanel for "onboarding reset" Attempt Status

**Description:**
Due to inconsistencies in the way we handle attempts in past due practice proctored/onboarding exams, learners can end up in an unintended liminal state after attempting to reset their onboarding attempt. If a learner attempts to reset their rejected onboarding attempt after the exam's due date, we process the reset request and move their attempt into the "onboarding_reset" state. Theoretically, a new exam attempt should be created immediately thereafter. However, we have code that prevents the creation of an exam attempt after the exam's due date, so the call to create a subsequent exam attempt fails, leaving the learner with an exam attempt with the "onboarding_reset" status. Theoretically, this situation should never occur, and the fact that it does is a bug. Because of this, we did not handle the "onboarding_reset" status in the StudentOnboardingStatus panel, and this status appears as "null". As an intermediate step, while we think about our due date logic, this pull request adds a new onboarding status "onboarding_status_past_due". This status is displayed as "Onboarding Reset Failed Due to Past Due Exam" in the StudentOnboardingPanel in the InstructorDashboard, which should provide course staff with a clearer explanation.

JIRA: [MST-745](https://openedx.atlassian.net/browse/MST-736) tracks the removal of this intermediate code from the code base once we fix the underlying cause of this bug.
JIRA: [MST-749](https://openedx.atlassian.net/browse/MST-749) tracks the fix for the behavior that allowed for this state to occur.

**JIRA:**

[MST-736](https://openedx.atlassian.net/browse/MST-736)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.