### PR TITLE
[MST-738] Add username to proctoring info panel view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[3.8.4] - 2021-04-05
+~~~~~~~~~~~~~~~~~~~~~
+* Add the request username to the proctoring info panel, allowing course staff to masquerade as
+  a specific user.
+
 [3.8.3] - 2021-04-05
 ~~~~~~~~~~~~~~~~~~~~~
 * Use exam due_date or course end date to evaluate the visibility of the onboarding status panel

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.8.3'
+__version__ = '3.8.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -63,7 +63,11 @@
     edx.courseware.proctored_exam.ProctoredExamInfo = Backbone.View.extend({
         initialize: function() {
             this.course_id = this.$el.data('course-id');
+            this.username = this.$el.data('username');
             this.model.url = this.model.url + '?course_id=' + encodeURIComponent(this.course_id);
+            if (this.username) {
+                this.model.url = this.model.url + '&username=' + encodeURIComponent(this.username);
+            }
             this.template_url = '/static/proctoring/templates/proctored-exam-info.underscore';
             this.status = '';
 

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
@@ -128,6 +128,33 @@ describe('ProctoredExamInfo', function() {
             .toHaveLength(0);
     });
 
+    it('should render if username is provided', function() {
+        setFixtures(
+            '<div class="proctoring-info-panel" data-course-id="test_course_id" ' +
+            'data-username="test_username"></div>'
+        );
+        this.server.respondWith(
+            'GET',
+            '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id&username=test_username',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedProctoredExamInfoJson('verified'))
+            ]
+        );
+
+        this.proctored_exam_info = new edx.courseware.proctored_exam.ProctoredExamInfo({
+            el: $('.proctoring-info-panel'),
+            model: new LearnerOnboardingModel()
+        });
+        this.server.respond();
+        this.server.respond();
+        expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
+            .toContain('Verified');
+    });
+
     it('should not render proctoring info panel for exam with 404 response', function() {
         this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status?course_id=test_course_id',
             [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
**Description:**

This allows course staff to view a specific learner's onboarding status while masquerading.

Related PRs:
https://github.com/edx/edx-platform/pull/27244
https://github.com/edx/frontend-app-learning/pull/406

**JIRA:**

[MST-738](https://openedx.atlassian.net/browse/MST-738)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.