### PR TITLE
feat: support logging of ping errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[3.8.8] - 2021-04-23
+~~~~~~~~~~~~~~~~~~~~
+* Add detailed logging of ping failures
+* Expose ping timeout value to external javascript worker
 * Add documentation for javascript worker development
 
 [3.8.7] - 2021-04-16

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.8.7'
+__version__ = '3.8.8'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -26,9 +26,9 @@ export const handlerWrapper = (Handler) => {
       }
       case 'ping': {
         if (handler.onPing) {
-          handler.onPing()
+          handler.onPing(message.data.timeout)
             .then(() => self.postMessage({ type: 'echo' }))
-            .catch(() => self.postMessage({ type: 'pingFailed' }));
+            .catch(error => self.postMessage({ type: 'pingFailed!', error }));
         }
         break;
       }

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -28,7 +28,7 @@ export const handlerWrapper = (Handler) => {
         if (handler.onPing) {
           handler.onPing(message.data.timeout)
             .then(() => self.postMessage({ type: 'echo' }))
-            .catch(error => self.postMessage({ type: 'pingFailed!', error }));
+            .catch(error => self.postMessage({ type: 'pingFailed', error }));
         }
         break;
       }

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -76,8 +76,8 @@ edx = edx || {};
     function workerTimeoutPromise(timeoutMilliseconds) {
         var message = 'worker failed to respond after ' + timeoutMilliseconds + 'ms';
         return new Promise(function(resolve, reject) {
-            setTimeout(function () {
-                reject(Error(message))
+            setTimeout(function() {
+                reject(Error(message));
             }, timeoutMilliseconds);
         });
     }

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -171,7 +171,9 @@ edx = edx || {};
                 this.model.get('attempt_status') !== 'ready_to_submit'
             ) {
                 edx.courseware.proctored_exam.pingApplication(pingInterval)
-                    .catch(self.endExamForFailureState.bind(self));
+                    .catch(function(error) {
+                        self.endExamForFailureState(error);
+                    });
             }
             if (self.timerTick % self.poll_interval === 0) {
                 url = self.model.url + '/' + self.model.get('attempt_id');
@@ -216,11 +218,12 @@ edx = edx || {};
                 edx.courseware.proctored_exam.endExam(self.model.get('exam_started_poll_url')).then(self.reloadPage);
             }
         },
-        endExamForFailureState: function() {
+        endExamForFailureState: function(error) {
             var self = this;
             return $.ajax({
                 data: {
-                    action: 'error'
+                    action: 'error',
+                    detail: String(error)
                 },
                 url: this.model.url + '/' + this.model.get('attempt_id'),
                 type: 'PUT'

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -736,6 +736,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
 
         course_id = attempt['proctored_exam']['course_id']
         action = request.data.get('action')
+        detail = request.data.get('detail')
 
         err_msg = (
             'user_id={user_id} attempted to update attempt_id={attempt_id} in '
@@ -804,14 +805,15 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
             else:
                 exam_attempt_id = False
             LOG.warning(
-                'Browser JS reported problem with proctoring desktop application. Did block user: '
-                '{should_block_user}. user_id={user_id}, course_id={course_id}, exam_id={exam_id}, '
-                'attempt_id={attempt_id}'.format(
+                'Browser JS reported problem with proctoring desktop application. Error detail: '
+                '{error_detail}. Did block user: {should_block_user}. user_id={user_id}, '
+                'course_id={course_id}, exam_id={exam_id}, attempt_id={attempt_id}'.format(
                     should_block_user=should_block_user,
                     user_id=user_id,
                     course_id=course_id,
                     exam_id=attempt['proctored_exam']['id'],
                     attempt_id=attempt_id,
+                    error_detail=detail
                 )
             )
         elif action == 'decline':

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

1. Allow error details to be passed from either the external worker or frontend code in this library to the backend for logging. This should allow us to get more granular with why a user got kicked out of an exam.
2. Passes a time out parameter into the worker function. This allows a single source of truth for timeout values. This is unused until we alter the Proctortrack worker code. Because the proctortrack timeout is not in sync with ours, errors in that worker code may be lost.

Related Worker PR: https://github.com/joshivj/edx-proctoring-proctortrack/pull/13

**JIRA:**

[MST-743](https://openedx.atlassian.net/browse/MST-743)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.