### PR TITLE
fix: Remove confusing language on proctoring info panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.8.9] - 2021-05-07
+~~~~~~~~~~~~~~~~~~~~
+* Update language on proctored exam info panel if learner has
+  a verified onboarding attempt
+
 [3.8.8] - 2021-04-23
 ~~~~~~~~~~~~~~~~~~~~
 * Add detailed logging of ping failures

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.8.8'
+__version__ = '3.8.9'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -29,7 +29,7 @@
         submitted: submittedText,
         verified: {
             status: gettext('Verified'),
-            message: gettext('You can now take proctored exams in this course.')
+            message: gettext('Your onboarding exam has been approved in this course.')
         },
         rejected: {
             status: gettext('Rejected'),
@@ -41,7 +41,7 @@
         },
         other_course_approved: {
             status: gettext('Approved in Another Course'),
-            message: gettext('You are eligible to take proctored exams in this course.'),
+            message: gettext('Your onboarding exam has been approved in another course.'),
             detail: gettext(
                 'If your device has changed, we recommend that you complete this ' +
                 'course\'s onboarding exam in order to ensure that your setup ' +
@@ -51,8 +51,7 @@
         expiring_soon: {
             status: gettext('Expiring Soon'),
             message: gettext(
-                'Your onboarding profile has been approved in another course, ' +
-                'so you are eligible to take proctored exams in this course. ' +
+                'Your onboarding profile has been approved in another course. ' +
                 'However, your onboarding status is expiring soon. Please ' +
                 'complete onboarding again to ensure that you will be ' +
                 'able to continue taking proctored exams.'

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_info_spec.js
@@ -445,7 +445,7 @@ describe('ProctoredExamInfo', function() {
         expect(this.proctored_exam_info.$el.find('.onboarding-status').html())
             .toContain('Approved in Another Course');
         expect(this.proctored_exam_info.$el.find('.onboarding-status-message').html())
-            .toContain('You are eligible to take proctored exams');
+            .toContain('Your onboarding exam has been approved in another course');
         expect(this.proctored_exam_info.$el.find('.onboarding-status-detail').html())
             .toContain('we recommend that you complete');
         expect(this.proctored_exam_info.$el.find('.action-onboarding').html())

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "main": "edx_proctoring/static/index.js",
   "scripts":{
     "test":"gulp test"


### PR DESCRIPTION
## [MST-700 ](https://openedx.atlassian.net/browse/MST-700)

Remove language that says learners with a verified onboarding can take exams. This created confusion for learners who did not realize they must also complete IDV before taking a proctored exam.


**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.