### PR TITLE
[Chore]: MST-677 Roll out the waffle flag ProctoringImprovements 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.9.2] - 2021-05-17
+~~~~~~~~~~~~~~~~~~~~
+* Remove the hide condition for onboarding exam reset by student. Roll out Proctoring Improvement Waffle Flag
 
 [3.9.1] - 2021-05-17
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.9.1'
+__version__ = '3.9.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/templates/onboarding_exam/rejected.html
+++ b/edx_proctoring/templates/onboarding_exam/rejected.html
@@ -8,32 +8,20 @@
 {% endblock %}
 
 {% block body %}
-
-  {% if experimental_proctoring_features %}
-    <p>
-      {% blocktrans %}
-        Please contact
-        <a href="mailto:{{ integration_specific_email }}">
-          {{ integration_specific_email }}
-        </a> if you have questions. You may retake this onboarding exam by clicking "Retry my exam".
-      {% endblocktrans %}
-    </p>
-    <div>
-      {% trans "Retry my exam" as retry_exam %}
-      <button type="button" class="exam-action-button proctored-reset-onboarding btn btn-pl-primary btn-base" data-action="reset_attempt" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-loading-text="<span class='fa fa-circle-o-notch fa-spin'></span> {% trans 'Resetting Onboarding Exam' %}" data-cta-text="{{ retry_exam }}">
-        {{ retry_exam }}
-      </button>
-    </div>
-  {% else %}
-    <p>
-      {% blocktrans %}
-        Please contact
-        <a href="mailto:{{ integration_specific_email }}">
-          {{ integration_specific_email }}
-        </a> if you have questions, or to retry your onboarding exam.
-      {% endblocktrans %}
-    </p>
-  {% endif %}
+  <p>
+    {% blocktrans %}
+      Please contact
+      <a href="mailto:{{ integration_specific_email }}">
+        {{ integration_specific_email }}
+      </a> if you have questions. You may retake this onboarding exam by clicking "Retry my exam".
+    {% endblocktrans %}
+  </p>
+  <div>
+    {% trans "Retry my exam" as retry_exam %}
+    <button type="button" class="exam-action-button proctored-reset-onboarding btn btn-pl-primary btn-base" data-action="reset_attempt" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-loading-text="<span class='fa fa-circle-o-notch fa-spin'></span> {% trans 'Resetting Onboarding Exam' %}" data-cta-text="{{ retry_exam }}">
+      {{ retry_exam }}
+    </button>
+  </div>
   <script>
     $('.exam-action-button').click(
         edx.courseware.proctored_exam.updateStatusHandler

--- a/edx_proctoring/templates/onboarding_exam/submitted.html
+++ b/edx_proctoring/templates/onboarding_exam/submitted.html
@@ -32,25 +32,23 @@
       to validate that your setup still meets the requirements for proctoring.
     {% endblocktrans %}
   </p>
-  {% if experimental_proctoring_features %}
-    <p>
-      {% blocktrans %}
-        If you have made an error in this submission you may restart the onboarding process. 
-        Your current submission will be removed and will not receive a review.
-      {% endblocktrans %}
-      </br>
-      {% trans "I understand and want to reset this onboarding exam." as retry_confirm %}
-      <button type="button" class="btn btn-link exam-action-confirm" data-cta-text="{{ retry_confirm }}">
-        {{ retry_confirm }}
-      </button>
-    </p>
-    <p>
-      {% trans "Retry my exam" as retry_exam %}
-      <button type="button" class="exam-action-button proctored-reset-onboarding btn btn-pl-primary btn-base" disabled data-action="reset_attempt" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-cta-text="{{ retry_exam }}">
-        {{ retry_exam }}
-      </button>
-    </p>
-  {% endif %}
+  <p>
+    {% blocktrans %}
+      If you have made an error in this submission you may restart the onboarding process. 
+      Your current submission will be removed and will not receive a review.
+    {% endblocktrans %}
+    </br>
+    {% trans "I understand and want to reset this onboarding exam." as retry_confirm %}
+    <button type="button" class="btn btn-link exam-action-confirm" data-cta-text="{{ retry_confirm }}">
+      {{ retry_confirm }}
+    </button>
+  </p>
+  <p>
+    {% trans "Retry my exam" as retry_exam %}
+    <button type="button" class="exam-action-button proctored-reset-onboarding btn btn-pl-primary btn-base" disabled data-action="reset_attempt" data-exam-id="{{exam_id}}" data-change-state-url="{{change_state_url}}" data-cta-text="{{ retry_exam }}">
+      {{ retry_exam }}
+    </button>
+  </p>
   <p>
     {% blocktrans %}
       Please contact

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Students can always retry their onboarding exams. This change rolls out the `courseware.proctoring_improvements` waffle flag on the frontend

**JIRA:**

[MST-677](https://openedx.atlassian.net/browse/MST-677)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.