### PR TITLE
[MST-751] Prevent allowance dropdown from overflowing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[3.9.3] - 2021-05-18
+~~~~~~~~~~~~~~~~~~~~
+* Fix styling on allowance dropdown to prevent overflow for long exam names.
+
 [3.9.2] - 2021-05-17
 ~~~~~~~~~~~~~~~~~~~~
 * Remove the hide condition for onboarding exam reset by student. Roll out Proctoring Improvement Waffle Flag

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.9.2'
+__version__ = '3.9.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/templates/add-new-allowance.underscore
+++ b/edx_proctoring/static/proctoring/templates/add-new-allowance.underscore
@@ -1,3 +1,8 @@
+<style>
+    select#proctored_exam {
+        width: 100%;
+    }
+</style>
 <div class='modal-header'><%- gettext("Add a New Allowance") %></div>
 <form>
     <h3 class='error-response'><h3>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Fix styling on allowance dropdown to prevent overflow for long exam names.

![Screen Shot 2021-05-17 at 3 59 29 PM](https://user-images.githubusercontent.com/10442143/118550832-2f4d3d80-b72b-11eb-907a-6a2b015df7af.png)

**JIRA:**

[MST-751](https://openedx.atlassian.net/browse/MST-751)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.