### PR TITLE
feat: add ability to get onboarding statuses from proctoring provider API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Add ability to get onboarding statuses from a proctoring provider API endpoint
 
 [3.9.3] - 2021-05-18
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -264,6 +264,59 @@ If you wish to modify the aforementioned logic, override the ``get_instructor_ur
 
 --------
 
+Onboarding Status API Endpoint
+------------------------------
+
+A backend can also be configured to support an onboarding status API endpoint. This endpoint should return a learner's onboarding status and expiration according to the provider.
+
+By default, this URL for this endpoint will be ``base_url + u'/api/v1/courses/{course_id}/onboarding_statuses'``, with the following optional query parameters:
+
+    * ``user_id``: a string for the id of a specific user.
+    * ``status``: a string representing the status that should be filtered for
+    * ``page``: an int for the page requested
+    * ``page_size``: an int for the page size requested
+
+If the URL is supplied with a ``user_id``, only that user's attempt info will be returned. The data for a call to
+``api/v1/courses/course-v1:edX+DemoX+Demo_Course/onboarding_statuses?user_id=abc123`` will look like::
+
+    {
+        'user_id': abc123,
+        'status': {status},
+        'expiration_date' : {expiration_date}
+    }
+
+If no ``user_id`` is provided, a list of attempts will be returned. This list can be filtered by the optional query parameters. The data returned for a call to
+``api/v1/courses/course-v1:edX+DemoX+Demo_Course/onboarding_statuses?status=approved_in_course&page=2&page_size=3`` should look like::
+
+    {
+        results: [
+            {
+                user_id: {user_id},
+                status: approved_in_course,
+                expiration_date: {expiration_date}
+            },
+            {
+                user_id: {user_id},
+                status: approved_in_course,
+                expiration_date: {expiration_date}
+            },
+            {
+                user_id: {user_id},
+                status: approved_in_course,
+                expiration_date: {expiration_date}
+            },
+
+        ],
+        count: {count},
+        num_pages: {num_pages}
+        next: 3
+        previous: 1
+    }
+
+This URL can be accessed through the ``get_onboarding_attempts`` method of the ``edx_proctoring.backends.rest.BaseRestProctoringProvider`` class. If either the URL or the method need to be changed,
+both can be overriden.
+
+
 Python wrapper
 --------------
 

--- a/edx_proctoring/backends/backend.py
+++ b/edx_proctoring/backends/backend.py
@@ -127,3 +127,10 @@ class ProctoringBackendProvider(metaclass=abc.ABCMeta):
         Whether learner access to exam content should be blocked during the exam
         """
         return False
+
+    # pylint: disable=unused-argument
+    def get_onboarding_attempts(self, course_id, **kwargs):
+        """
+        Returns onboarding attempts for a given course and optional user
+        """
+        return None

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -176,6 +176,9 @@ class PassthroughBackendProvider(ProctoringBackendProvider):
     def on_exam_saved(self, exam):
         return super().on_exam_saved(exam)
 
+    def get_onboarding_attempts(self, course_id, **kwargs):
+        return super().get_onboarding_attempts(course_id, **kwargs)
+
 
 class TestBackends(TestCase):
     """
@@ -214,6 +217,8 @@ class TestBackends(TestCase):
             provider.on_exam_saved(None)
 
         self.assertIsNone(provider.get_exam(None))
+
+        self.assertIsNone(provider.get_onboarding_attempts(course_id='test'))
 
     def test_null_provider(self):
         """

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -106,6 +106,15 @@ class BackendProviderOnboardingException(ProctoredBaseException):
         self.status = exam_status
 
 
+class BackendProviderOnboardingStatusesException(ProctoredBaseException):
+    """
+    Raised when a backend provider cannot get the requested onboarding statuses
+    """
+    def __init__(self, content, http_status):
+        super().__init__(self, content)
+        self.http_status = http_status
+
+
 class ProctoredExamPermissionDenied(ProctoredBaseException):
     """
     Raised when the calling user does not have access to the requested object.


### PR DESCRIPTION
## [MST-758](https://openedx.atlassian.net/browse/MST-758)

Verificient has provided us with a new API to retrieve the onboarding status of a learner or for all learners within a specified course. This new endpoint is now accessible through the BaseRestProctoringProvider class. The goal of using the endpoint
is to make Verificient the source of truth for onboarding attempt statuses.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.