### PR TITLE
fix: process onboarding exams correctly in onboarding status API used by onboarding panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.9.4] - 2021-05-19
+~~~~~~~~~~~~~~~~~~~~
+* Fix a bug in processing onboarding exams in StudentOnboardingStatusView,
+  resulting in an incorrect list of accessible onboarding exams. 
+
 [3.9.3] - 2021-05-18
 ~~~~~~~~~~~~~~~~~~~~
 * Fix styling on allowance dropdown to prevent overflow for long exam names.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.9.3'
+__version__ = '3.9.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -792,8 +792,8 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
             BlockUsageLocator.from_string(inaccessible_onboarding_exam.content_id): exam_schedule,
         }
         set_runtime_service('learning_sequences', MockLearningSequencesService(
-            [accessible_onboarding_exam],   # sections user can see
-            course_sections,                # all scheduled sections
+            [BlockUsageLocator.from_string(accessible_onboarding_exam.content_id)],   # sections user can see
+            course_sections,                                                          # all scheduled sections
         ))
         response = self.client.get(
             reverse('edx_proctoring:user_onboarding.status')

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -438,6 +438,7 @@ class StudentOnboardingStatusView(ProctoredAPIView):
             course_key, user, pytz.utc.localize(datetime.max)
         )
 
+        inaccessible_onboarding_exams = []
         for onboarding_exam in onboarding_exams:
             usage_key = BlockUsageLocator.from_string(onboarding_exam.content_id)
             visibility_check_date = get_visibility_check_date(details.schedule, usage_key)
@@ -446,7 +447,10 @@ class StudentOnboardingStatusView(ProctoredAPIView):
             )
 
             if usage_key not in user_outline.accessible_sequences:
-                onboarding_exams.remove(onboarding_exam)
+                inaccessible_onboarding_exams.append(onboarding_exam)
+
+        for inacessible_onboarding_exam in inaccessible_onboarding_exams:
+            onboarding_exams.remove(inacessible_onboarding_exam)
 
         if not onboarding_exams:
             LOG.info(
@@ -461,7 +465,8 @@ class StudentOnboardingStatusView(ProctoredAPIView):
             )
 
         onboarding_exam = onboarding_exams[0]
-        effective_start = details.schedule.sequences.get(usage_key).effective_start
+        onboarding_exam_usage_key = BlockUsageLocator.from_string(onboarding_exam.content_id)
+        effective_start = details.schedule.sequences.get(onboarding_exam_usage_key).effective_start
         data['onboarding_link'] = reverse('jump_to', args=[course_id, onboarding_exam.content_id])
         data['onboarding_release_date'] = effective_start.isoformat()
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

When returning information about a learner's onboarding status in a course, we exclude onboarding exams that the Learning Sequences API marks as inaccessible. While processing the list of onboarding exams in the course, the list was being modified during iteration, leading to incorrect behavior. This code change fixes this behavior. This fix also exposed a bug in the corresponding tests, which was also fixed in this code change.

**JIRA:**

None.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.