### PR TITLE
feat: allow configurability by backend of url from onboarding panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,14 @@ Unreleased
 ~~~~~~~~~~
 * Add ability to get onboarding statuses from a proctoring provider API endpoint
 
+[3.10.0] - 2021-05-19
+~~~~~~~~~~~~~~~~~~~~~
+* Add by-backend configurability of the link which shows on the onboarding panel
+
 [3.9.4] - 2021-05-19
 ~~~~~~~~~~~~~~~~~~~~
 * Fix a bug in processing onboarding exams in StudentOnboardingStatusView,
-  resulting in an incorrect list of accessible onboarding exams. 
+  resulting in an incorrect list of accessible onboarding exams.
 
 [3.9.3] - 2021-05-18
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.9.4'
+__version__ = '3.10.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/backend.py
+++ b/edx_proctoring/backends/backend.py
@@ -20,6 +20,7 @@ class ProctoringBackendProvider(metaclass=abc.ABCMeta):
     has_dashboard = False
     # whether practice exams map to "onboarding" exams for this backend
     supports_onboarding = False
+    help_center_article_url = ''
 
     @abc.abstractmethod
     def register_exam_attempt(self, exam, context):

--- a/edx_proctoring/backends/software_secure.py
+++ b/edx_proctoring/backends/software_secure.py
@@ -31,8 +31,8 @@ SOFTWARE_SECURE_INVALID_CHARS = u'[]<>#:|!?/\'"*\\'
 
 class SoftwareSecureBackendProvider(ProctoringBackendProvider):
     """
-    Implementation of the ProctoringBackendProvider for Software Secure's
-    RPNow product
+    Implementation of the ProctoringBackendProvider for PSI's
+    (formerly Software Secure's) RPNow product
     """
     verbose_name = u'RPNow'
     passing_statuses = SoftwareSecureReviewStatus.passing_statuses

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -176,7 +176,8 @@
                     onboardingNotReleased: releaseDate > now,
                     showOnboardingExamLink: this.shouldShowExamLink(data.onboarding_status),
                     onboardingLink: data.onboarding_link,
-                    onboardingReleaseDate: releaseDate.toLocaleDateString()
+                    onboardingReleaseDate: releaseDate.toLocaleDateString(),
+                    reviewRequirementsUrl: data.review_requirements_url
                 };
 
                 $(this.el).html(this.template(data));

--- a/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
@@ -36,5 +36,9 @@
             <a href="<%= onboardingLink %>" class="action action-onboarding"><%= gettext("Complete Onboarding") %></a>
         <%} %>
     <%} %>
-    <a href="https://support.edx.org/hc/en-us/articles/207249428-How-do-proctored-exams-work" class="action action-info-link"><%= gettext("Review instructions and system requirements for proctored exams") %></a>
+    <% if (reviewRequirementsUrl) { %>
+        <a href="<%= reviewRequirementsUrl %>" class="action action-info-link"><%= gettext("Review instructions and system requirements for proctored exams") %></a>
+    <%} else { %>
+        <a href="https://support.edx.org/hc/en-us/articles/207249428-How-do-proctored-exams-work" class="action action-info-link"><%= gettext("Review instructions and system requirements for proctored exams") %></a>
+    <%} %>
 </div>

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -712,6 +712,20 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         onboarding_link = reverse('jump_to', args=['a/b/c', self.onboarding_exam.content_id])
         self.assertEqual(response_data['onboarding_link'], onboarding_link)
 
+    def test_requirements_url_backend_specific(self):
+        """
+        Test that proctoring backend's setting affects what support center link is put in
+        """
+        backend = get_backend_provider(name=self.onboarding_exam.backend)
+        backend.help_center_article_url = 'https://example.com'
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id=a/b/c'
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['review_requirements_url'], backend.help_center_article_url)
+
     def test_ignore_history_table(self):
         """
         Test that deleted attempts are not evaluated when requesting onboarding status

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -431,6 +431,7 @@ class StudentOnboardingStatusView(ProctoredAPIView):
                 data={'detail': _('There is no onboarding exam related to this course id.')}
             )
 
+        backend = get_backend_provider(name=onboarding_exams[0].backend)
         learning_sequences_service = get_runtime_service('learning_sequences')
         course_key = CourseKey.from_string(course_id)
         user = get_user_model().objects.get(username=(username or request.user.username))
@@ -469,6 +470,7 @@ class StudentOnboardingStatusView(ProctoredAPIView):
         effective_start = details.schedule.sequences.get(onboarding_exam_usage_key).effective_start
         data['onboarding_link'] = reverse('jump_to', args=[course_id, onboarding_exam.content_id])
         data['onboarding_release_date'] = effective_start.isoformat()
+        data['review_requirements_url'] = backend.help_center_article_url
 
         attempts = ProctoredExamStudentAttempt.objects.get_proctored_practice_attempts_by_course_id(course_id, [user])
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.9.4",
+  "version": "3.10.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
Motivation is mostly to enable us to swap out these URLs by a
remote-config PR, not really the backend-specificity. But it might be
helpful in the future if we add more backends!

After merging, we can merge https://github.com/edx/edx-internal/pull/5109 to affect the desired change in the requesting ticket.

Jira:[MST-824](https://openedx.atlassian.net/browse/MST-824)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.