### PR TITLE
Use Verificient onboarding status API endpoint for course home proctoring panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.10.2] - 2021-05-24
+~~~~~~~~~~~~~~~~~~~~~
+* Use onboarding status API endpoint for student onboarding info panel
+
 [3.10.1] - 2021-05-21
 ~~~~~~~~~~~~~~~~~~~~~
 * Add ability to get onboarding statuses from a proctoring provider API endpoint

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -316,6 +316,14 @@ If no ``user_id`` is provided, a list of attempts will be returned. This list ca
 This URL can be accessed through the ``get_onboarding_attempts`` method of the ``edx_proctoring.backends.rest.BaseRestProctoringProvider`` class. If either the URL or the method need to be changed,
 both can be overriden.
 
+The following status strings can be filtered for or returned in Verificient's implementation::
+
+    * approved-in-course
+    * approved-in-different-course
+    * rejected
+    * expired
+    * pending
+    * no-profile
 
 Python wrapper
 --------------

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.10.1'
+__version__ = '3.10.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/backends/backend.py
+++ b/edx_proctoring/backends/backend.py
@@ -130,8 +130,8 @@ class ProctoringBackendProvider(metaclass=abc.ABCMeta):
         return False
 
     # pylint: disable=unused-argument
-    def get_onboarding_attempts(self, course_id, **kwargs):
+    def get_onboarding_profile_info(self, course_id, **kwargs):
         """
-        Returns onboarding attempts for a given course and optional user
+        Returns onboarding profile information for a given course and optional user
         """
         return None

--- a/edx_proctoring/backends/rest.py
+++ b/edx_proctoring/backends/rest.py
@@ -21,7 +21,7 @@ from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
-    BackendProviderOnboardingStatusesException,
+    BackendProviderOnboardingProfilesException,
     BackendProviderSentNoAttemptID
 )
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus, SoftwareSecureReviewStatus
@@ -338,7 +338,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
             raise BackendProviderCannotRetireUser(content) from exc
         return data
 
-    def get_onboarding_attempts(self, course_id, **kwargs):
+    def get_onboarding_profile_info(self, course_id, **kwargs):
         url = self.onboarding_statuses_url.format(course_id=course_id)
         if kwargs:
             query_string = urlencode(kwargs)
@@ -347,7 +347,7 @@ class BaseRestProctoringProvider(ProctoringBackendProvider):
         response = self.session.get(url)
 
         if response.status_code != 200:
-            raise BackendProviderOnboardingStatusesException(response.content, response.status_code)
+            raise BackendProviderOnboardingProfilesException(response.content, response.status_code)
         data = response.json()
         return data
 

--- a/edx_proctoring/backends/tests/test_backend.py
+++ b/edx_proctoring/backends/tests/test_backend.py
@@ -182,8 +182,8 @@ class PassthroughBackendProvider(ProctoringBackendProvider):
     def on_exam_saved(self, exam):
         return super().on_exam_saved(exam)
 
-    def get_onboarding_attempts(self, course_id, **kwargs):
-        return super().get_onboarding_attempts(course_id, **kwargs)
+    def get_onboarding_profile_info(self, course_id, **kwargs):
+        return super().get_onboarding_profile_info(course_id, **kwargs)
 
 
 class TestBackends(TestCase):
@@ -224,7 +224,7 @@ class TestBackends(TestCase):
 
         self.assertIsNone(provider.get_exam(None))
 
-        self.assertIsNone(provider.get_onboarding_attempts(course_id='test'))
+        self.assertIsNone(provider.get_onboarding_profile_info(course_id='test'))
 
     def test_null_provider(self):
         """

--- a/edx_proctoring/backends/tests/test_rest.py
+++ b/edx_proctoring/backends/tests/test_rest.py
@@ -17,7 +17,7 @@ from edx_proctoring.exceptions import (
     BackendProviderCannotRegisterAttempt,
     BackendProviderCannotRetireUser,
     BackendProviderOnboardingException,
-    BackendProviderOnboardingStatusesException,
+    BackendProviderOnboardingProfilesException,
     BackendProviderSentNoAttemptID
 )
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
@@ -417,7 +417,7 @@ class RESTBackendTests(TestCase):
             self.provider.retire_user(user_id)
 
     @responses.activate
-    def test_get_onboarding_status_for_user(self):
+    def test_get_onboarding_profile_for_user(self):
         user_id = 'abcdef5'
         course_id = 'course+abc'
         response_json = {'user_id': user_id, 'status': 'rejected', 'expiration_date': None}
@@ -426,11 +426,11 @@ class RESTBackendTests(TestCase):
             url=self.provider.onboarding_statuses_url.format(course_id=course_id)+'?user_id='+user_id,
             json=response_json
         )
-        result = self.provider.get_onboarding_attempts(course_id=course_id, user_id=user_id)
+        result = self.provider.get_onboarding_profile_info(course_id=course_id, user_id=user_id)
         assert result == response_json
 
     @responses.activate
-    def test_get_onboarding_statuses_for_course_with_query_params(self):
+    def test_get_onboarding_profiles_for_course_with_query_params(self):
         course_id = 'course+abc'
         response_json = {
             "count": 3,
@@ -466,13 +466,13 @@ class RESTBackendTests(TestCase):
             ) + '?status=approved-in-course&page=1&page_size=3',
             json=response_json
         )
-        result = self.provider.get_onboarding_attempts(
+        result = self.provider.get_onboarding_profile_info(
             course_id=course_id, status='approved-in-course', page=1, page_size=3
         )
         assert result == response_json
 
     @responses.activate
-    def test_get_onboarding_statuses_for_course_with_no_params(self):
+    def test_get_onboarding_profiles_for_course_with_no_params(self):
         course_id = 'course+abc'
         response_json = {
             "count": 3,
@@ -496,11 +496,11 @@ class RESTBackendTests(TestCase):
             url=self.provider.onboarding_statuses_url.format(course_id=course_id),
             json=response_json
         )
-        result = self.provider.get_onboarding_attempts(course_id=course_id)
+        result = self.provider.get_onboarding_profile_info(course_id=course_id)
         assert result == response_json
 
     @responses.activate
-    def test_get_onboarding_status_for_unkown_user_id(self):
+    def test_get_onboarding_profiles_for_unknown_user_id(self):
         user_id = 'bad_user'
         course_id = 'course+abc'
         responses.add(
@@ -509,5 +509,5 @@ class RESTBackendTests(TestCase):
             json={'error': 'something'},
             status=404
         )
-        with self.assertRaises(BackendProviderOnboardingStatusesException):
-            self.provider.get_onboarding_attempts(course_id=course_id, user_id=user_id)
+        with self.assertRaises(BackendProviderOnboardingProfilesException):
+            self.provider.get_onboarding_profile_info(course_id=course_id, user_id=user_id)

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -64,4 +64,8 @@ DEFAULT_DESKTOP_APPLICATION_PING_INTERVAL_SECONDS = (
 
 MINIMUM_TIME = datetime.datetime.fromtimestamp(0)
 
+VERIFICATION_DAYS_VALID = 730
+
 PING_FAILURE_PASSTHROUGH_TEMPLATE = 'edx_proctoring.{}_ping_failure_passthrough'
+
+ONBOARDING_PROFILE_API = 'edx_proctoring.onboarding_profile_api'

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -106,9 +106,9 @@ class BackendProviderOnboardingException(ProctoredBaseException):
         self.status = exam_status
 
 
-class BackendProviderOnboardingStatusesException(ProctoredBaseException):
+class BackendProviderOnboardingProfilesException(ProctoredBaseException):
     """
-    Raised when a backend provider cannot get the requested onboarding statuses
+    Raised when a backend provider cannot get the requested onboarding profiles
     """
     def __init__(self, content, http_status):
         super().__init__(self, content)

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -18,6 +18,7 @@ from django.db.models.base import ObjectDoesNotExist
 from django.utils.translation import ugettext_noop
 
 from edx_proctoring.backends import get_backend_provider
+from edx_proctoring.constants import VERIFICATION_DAYS_VALID
 from edx_proctoring.exceptions import (
     AllowanceValueNotAllowedException,
     ProctoredExamNotActiveException,
@@ -303,7 +304,7 @@ class ProctoredExamStudentAttemptManager(models.Manager):
             * users: A list of users object of which we are checking the attempts
             * proctoring_backend: The name of the proctoring backend
         """
-        earliest_allowed_date = datetime.now(pytz.UTC) - timedelta(days=730)
+        earliest_allowed_date = datetime.now(pytz.UTC) - timedelta(days=VERIFICATION_DAYS_VALID)
         return self.filter(
             user__in=users, taking_as_proctored=True, proctored_exam__is_practice_exam=True,
             proctored_exam__backend=proctoring_backend, modified__gt=earliest_allowed_date,

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -288,3 +288,35 @@ class InstructorDashboardOnboardingAttemptStatus:
         if status:
             return cls.onboarding_statuses.get(status)
         return cls.not_started
+
+
+class VerificientOnboardingProfileStatus:
+    """
+    A class for mapping onboarding statuses from Verificient's onboarding status endpoint to
+    internal database values.
+    """
+    no_profile = 'no-profile'
+    approved = 'approved-in-course'
+    other_course_approved = 'approved-in-different-course'
+    rejected = 'rejected'
+    expired = 'expired'
+    pending = 'pending'
+
+    profile_status_mapping = {
+        no_profile: None,
+        approved: ProctoredExamStudentAttemptStatus.verified,
+        other_course_approved: InstructorDashboardOnboardingAttemptStatus.other_course_approved,
+        rejected: ProctoredExamStudentAttemptStatus.rejected,
+        expired: ProctoredExamStudentAttemptStatus.expired,
+        pending: ProctoredExamStudentAttemptStatus.submitted
+    }
+
+    @classmethod
+    def get_edx_status_from_profile_status(cls, api_status):
+        """
+        Get the internal attempt status given a status from the onboarding api
+
+        Parameters:
+            * status (str):
+        """
+        return cls.profile_status_mapping.get(api_status)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Verificient's onboarding status API should be used for the student onboarding panel endpoint `/edx_proctoring/v1/user_onboarding/status`. The use of the endpoint is behind a waffle switch. If that switch is activated, both the current logic and the new onboarding status API will be used so that we can log if there are differences between the two. If the onboarding status API responds with a non 200 HTTP status, we will default to use the data gathered by the current (non onboarding status api) logic. 

As part of this status, functions dealing with the onboarding status api endpoint that previously were named with `attempt` have been renamed as to prevent confusion around attempt vs onboarding profile information.

**JIRA:**

[MST-760](https://openedx.atlassian.net/browse/MST-760)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.