### PR TITLE
feat: Modify Learner Onboarding API to determine whether onboarding is past due in a course and display this status in the onboarding panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,15 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.11.0] - 2021-05-24
+~~~~~~~~~~~~~~~~~~~~~
+* Add ability to get onboarding statuses from a proctoring provider API endpoint
+* Extend the learner onboarding status API to determine whether the only onboarding exam or all
+  onboarding exams are past due and past an "onboarding_past_due" flag in the response. modify
+  the API to not return a link to the onboarding exam if the onboarding exam should not be
+  accessible by the learner (i.e. it is to be released or is past due).
+* Modify the display behavior of the learner onboarding panel to display "Onboarding Past Due"
+  if the only onboarding or all onboarding exams are past due.
 
 [3.10.2] - 2021-05-24
 ~~~~~~~~~~~~~~~~~~~~~
@@ -24,10 +33,6 @@ Unreleased
 * Add API endpoint which provides proctoring generic and backend specific
   instructions for the proctoring exam. Usage case is to provide required data
   for the learning app MFE.
-
-[3.10.0] - 2021-05-19
-~~~~~~~~~~~~~~~~~~~~~
-* Add by-backend configurability of the link which shows on the onboarding panel
 
 [3.10.0] - 2021-05-19
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.10.2'
+__version__ = '3.11.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_info.js
@@ -174,6 +174,7 @@
                     onboardingDetail: statusText.detail,
                     showOnboardingReminder: !['verified', 'other_course_approved'].includes(data.onboarding_status),
                     onboardingNotReleased: releaseDate > now,
+                    onboardingPastDue: data.onboarding_past_due,
                     showOnboardingExamLink: this.shouldShowExamLink(data.onboarding_status),
                     onboardingLink: data.onboarding_link,
                     onboardingReleaseDate: releaseDate.toLocaleDateString(),

--- a/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
+++ b/edx_proctoring/static/proctoring/templates/proctored-exam-info.underscore
@@ -28,7 +28,9 @@
     <%} %>
     </div>
     <% if (showOnboardingExamLink) { %>
-        <% if (onboardingNotReleased) { %>
+        <% if (onboardingPastDue) { %>
+            <a class="action action-onboarding action-disabled"><%= gettext("Onboarding Past Due") %></a>
+        <% } else if (onboardingNotReleased) { %>
             <a class="action action-onboarding action-disabled"><%= gettext("Onboarding Opens") %> <%= onboardingReleaseDate %></a>
         <%} else if (onboardingStatus && onboardingStatus === 'other_course_approved') { %>
             <a href="<%= onboardingLink %>" class="action action-onboarding-practice"><%= gettext("View Onboarding Exam") %></a>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

In [MST-734](https://openedx.atlassian.net/browse/MST-734), code was introduced to fix a bug where the learner onboarding panel was not showing up in learners' course outlines when the onboarding exam(s) was/were past due. However, this did not address the fact that there remained a link to a past due onboarding exam in the panel, generating confusion for learners.

This code change addresses this issue by extending the StudentOnboardingStatusView to add a new field "onboarding_past_due". "onboarding_past_due" is true if every onboarding exam in the course is past due. If there is at least one currently available or to be released onboarding exam in the course, we favor that onboarding exam and return false. If this flag is true, and the learner's onboarding status is in a state where the onboarding link is to be displayed, we display "Onboarding Past Due" instead. This code also changes the current behavior to not pass "onboarding_link" unless the onboarding exam is accessible by the learner.

<img width="357" alt="Screen Shot 2021-05-21 at 3 46 57 PM" src="https://user-images.githubusercontent.com/11871801/119196304-f1feed80-ba53-11eb-812b-c2e69721fd5b.png">


**JIRA:**

[MST-746](https://openedx.atlassian.net/browse/MST-746)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.