### PR TITLE
fix: Verificient onboarding API requires obscured user id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[3.11.1] - 2021-05-25
+~~~~~~~~~~~~~~~~~~~~~
+* Fix for onboarding status API endpoint. The endpoint requires an obscured user id.
+
 [3.11.0] - 2021-05-24
 ~~~~~~~~~~~~~~~~~~~~~
 * Add ability to get onboarding statuses from a proctoring provider API endpoint

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.11.0'
+__version__ = '3.11.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -54,6 +54,7 @@ from edx_proctoring.statuses import (
 )
 from edx_proctoring.tests import mock_perm
 from edx_proctoring.urls import urlpatterns
+from edx_proctoring.utils import obscured_user_id
 from edx_proctoring.views import require_course_or_global_staff, require_staff
 from mock_apps.models import Profile
 
@@ -1067,6 +1068,12 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
             reverse('edx_proctoring:user_onboarding.status')
             + '?course_id={}'.format(self.onboarding_exam.course_id)
         )
+
+        mocked_onboarding_api.assert_called_with(
+            course_id=self.onboarding_exam.course_id,
+            user_id=obscured_user_id(self.user_id, self.onboarding_exam.backend)
+        )
+
         self.assertEqual(response.status_code, 200)
         response_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response_data['onboarding_status'], attempt_status)
@@ -1082,7 +1089,7 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         update_attempt_status(attempt_id, ProctoredExamStudentAttemptStatus.submitted)
 
         mocked_onboarding_api.return_value = {
-            'user_id': '123abc',
+            'user_id': self.user_id,
             'status': VerificientOnboardingProfileStatus.approved,
             'expiration_date': '2051-05-21'
         }
@@ -1090,6 +1097,11 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         response = self.client.get(
             reverse('edx_proctoring:user_onboarding.status')
             + '?course_id={}'.format(self.onboarding_exam.course_id)
+        )
+
+        mocked_onboarding_api.assert_called_with(
+            course_id=self.onboarding_exam.course_id,
+            user_id=obscured_user_id(self.user_id, self.onboarding_exam.backend)
         )
         self.assertEqual(response.status_code, 200)
         response_data = json.loads(response.content.decode('utf-8'))

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -525,7 +525,8 @@ class StudentOnboardingStatusView(ProctoredAPIView):
 
         if waffle.switch_is_active(ONBOARDING_PROFILE_API):
             try:
-                onboarding_profile_data = backend.get_onboarding_profile_info(course_id=course_id, user_id=user.id)
+                obs_user_id = obscured_user_id(user.id, onboarding_exam.backend)
+                onboarding_profile_data = backend.get_onboarding_profile_info(course_id=course_id, user_id=obs_user_id)
             except BackendProviderOnboardingProfilesException as exc:
                 # if backend raises exception, log message and return data from onboarding exam attempt
                 log_message = (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

The onboarding status API requires an obscured user id as a parameter. Currently we are receiving 404 responses from this endpoint because we are sending non-obscured user ids, which Verificient's system does not recognize.