### PR TITLE
[Fix]:MST-810 Add ping interval into exam start handler in worker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.11.4] - 2021-05-27
+~~~~~~~~~~~~~~~~~~~~~
+* Use the same DEFAULT_DESKTOP_APPLICATION_PING_INTERVAL_SECONDS interval to start the exam and ping the
+  proctoring desktop applicaiton
+
 [3.11.3] - 2021-05-27
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix a bug where the Learning Sequences API does not have a schedule for a sequence, which can occur

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.11.3'
+__version__ = '3.11.4'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -2271,7 +2271,8 @@ def _get_proctored_exam_context(exam, attempt, user_id, course_id, is_practice_e
         'learner_notification_from_email': provider.learner_notification_from_email,
         'integration_specific_email': get_integration_specific_email(provider),
         'exam_display_name': exam['exam_name'],
-        'reset_link': password_url
+        'reset_link': password_url,
+        'ping_interval': provider.ping_interval
     }
     if attempt:
         context['exam_code'] = attempt['attempt_code']

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -139,6 +139,7 @@ edx = edx || {};
         var actionUrl = $this.data('change-state-url');
         var action = $this.data('action');
         var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
+        var pingInterval = edx.courseware.proctored_exam.ProctoringAppPingInterval;
 
         e.preventDefault();
         e.stopPropagation();
@@ -146,7 +147,7 @@ edx = edx || {};
         setActionButtonLoadingState($this);
 
         if (shouldUseWorker) {
-            workerPromiseForEventNames(actionToMessageTypesMap[action])()
+            workerPromiseForEventNames(actionToMessageTypesMap[action])(pingInterval)
                 .then(updateExamAttemptStatusPromise(actionUrl, action))
                 .then(reloadPage)
                 .catch(errorHandlerGivenMessage(

--- a/edx_proctoring/templates/proctored_exam/ready_to_start.html
+++ b/edx_proctoring/templates/proctored_exam/ready_to_start.html
@@ -61,6 +61,7 @@
   edx.courseware = edx.courseware || {};
   edx.courseware.proctored_exam = edx.courseware.proctored_exam || {};
   edx.courseware.proctored_exam.configuredWorkerURL = "{{ backend_js_bundle }}";
+  edx.courseware.proctored_exam.ProctoringAppPingInterval = {{ ping_interval }};
 
 
   $('.proctored-enter-exam').click(

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**
To pass into the verificient worker so we can have consistent set of desktop app survival ping intervals

**JIRA:**

[MST-810](https://openedx.atlassian.net/browse/MST-810)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.