### PR TITLE
fix: Fix bug in StudentOnboardingStatusView for no sequence schedule for a sequence

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.11.3] - 2021-05-27
+~~~~~~~~~~~~~~~~~~~~~
+* Fix a bug where the Learning Sequences API does not have a schedule for a sequence, which can occur
+  when a sequence is unavailable to a learner, and the learner should not know of the existence of the sequence
+  (e.g. when a sequence is content gated by enrollment track and the learner is not in the requisite enrollment track).
+
 [3.11.2] - 2021-05-25
 ~~~~~~~~~~~~~~~~~~~~~
 * Add allow-list to prevent nonexistent backend configurations from causing errors

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.11.2'
+__version__ = '3.11.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -846,6 +846,24 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         message = 'There is no onboarding exam accessible to this user.'
         self.assertEqual(response_data['detail'], message)
 
+    def test_no_accessible_onboarding_no_schedule(self):
+        """
+        Test that the request returns 404 if onboarding exams exist but none are accessible to the user by
+        virtue of there being no associated sequence schedule.
+        """
+        set_runtime_service('learning_sequences', MockLearningSequencesService(
+            [],  # sections user can see (none)
+            {},  # all scheduled sections
+        ))
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}'.format(self.course_id)
+        )
+        self.assertEqual(response.status_code, 404)
+        response_data = json.loads(response.content.decode('utf-8'))
+        message = 'There is no onboarding exam accessible to this user.'
+        self.assertEqual(response_data['detail'], message)
+
     @ddt.data(None, timezone.now() + timezone.timedelta(days=3))
     def test_onboarding_not_yet_released(self, due_date):
         """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -609,14 +609,21 @@ class StudentOnboardingStatusView(ProctoredAPIView):
             usage_key = BlockUsageLocator.from_string(onboarding_exam.content_id)
 
             if usage_key not in details.outline.accessible_sequences:
-                effective_start = details.schedule.sequences.get(usage_key).effective_start
-                due_date = get_visibility_check_date(details.schedule, usage_key)
+                sequence_schedule = details.schedule.sequences.get(usage_key)
 
-                if effective_start and pytz.utc.localize(datetime.now()) < effective_start:
-                    future_exams.append(onboarding_exam)
-                elif due_date and pytz.utc.localize(datetime.now()) > due_date:
-                    past_due_exams.append(onboarding_exam)
+                if sequence_schedule:
+                    effective_start = details.schedule.sequences.get(usage_key).effective_start
+                    due_date = get_visibility_check_date(details.schedule, usage_key)
+
+                    if effective_start and pytz.utc.localize(datetime.now()) < effective_start:
+                        future_exams.append(onboarding_exam)
+                    elif due_date and pytz.utc.localize(datetime.now()) > due_date:
+                        past_due_exams.append(onboarding_exam)
+                    else:
+                        non_date_inaccessible_exams.append(onboarding_exam)
                 else:
+                    # if the sequence schedule is not available, then the sequence is not available
+                    # to the learner
                     non_date_inaccessible_exams.append(onboarding_exam)
 
         return non_date_inaccessible_exams, future_exams, past_due_exams

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

This code change fixes a bug introduced by https://github.com/edx/edx-proctoring/pull/855 ([MST-746](https://openedx.atlassian.net/browse/MST-746)). The Learning Sequences API returns details about a given user's course outline, including sequence scheduling information. In some cases, a sequence that is inaccessible to a learner is still returned in the schedule, because the learner is allowed to know of the sequence's existence. A future onboarding exam is an example of this. In other cases, inaccessible sequences should be truly inaccessible to the learner, and, as such, they are not returned in the schedule. An onboarding exam that is content gated by enrollment track to an enrollment track in which the learner is not enrolled is an example of this. The bug was that the `StudentOnbaordingStatusView` was not taking into account that an inaccessible sequence might not have a schedule. This code change fixes that bug by adding None checking.

**JIRA:**

None.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.