### PR TITLE
[Fix]: Fix the mistake where the value to pass into vendor javascript should be milliseconds rather than seconds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.11.5] - 2021-06-01
+~~~~~~~~~~~~~~~~~~~~~
+* Fix a bug where we are to pass to vendor javascript a value in milliseconds, instead of just seconds
+
 [3.11.4] - 2021-05-27
 ~~~~~~~~~~~~~~~~~~~~~
 * Use the same DEFAULT_DESKTOP_APPLICATION_PING_INTERVAL_SECONDS interval to start the exam and ping the

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.11.4'
+__version__ = '3.11.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -140,6 +140,10 @@ edx = edx || {};
         var action = $this.data('action');
         var shouldUseWorker = window.Worker && edx.courseware.proctored_exam.configuredWorkerURL;
         var pingInterval = edx.courseware.proctored_exam.ProctoringAppPingInterval;
+        var startIntervalInMilliseconds;
+        if (pingInterval) {
+            startIntervalInMilliseconds = pingInterval * 1000;
+        }
 
         e.preventDefault();
         e.stopPropagation();
@@ -147,7 +151,7 @@ edx = edx || {};
         setActionButtonLoadingState($this);
 
         if (shouldUseWorker) {
-            workerPromiseForEventNames(actionToMessageTypesMap[action])(pingInterval)
+            workerPromiseForEventNames(actionToMessageTypesMap[action])(startIntervalInMilliseconds)
                 .then(updateExamAttemptStatusPromise(actionUrl, action))
                 .then(reloadPage)
                 .catch(errorHandlerGivenMessage(

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Bug fixing the interval values passed into Vendor javascript when starting a proctored exam

**JIRA:**

[MST-810](https://openedx.atlassian.net/browse/MST-810)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [x] Create a tag matching the new version number.