### PR TITLE
[BD-26] [EDUCATOR-5816] Create API endpoint to fetch exam review policy and extend exam attempt API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Extend exam attempt API to return additional data for proctored exams.
+* Add API endpoint which provides exam review policy for specific exam.
+  Usage case is to provide required data for the learning app MFE.
 
 [3.10.1] - 2021-05-21
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -642,6 +642,11 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             'ping_interval': provider.ping_interval,
             'attempt_code': attempt['attempt_code']
         })
+        # in case user is not verified we need to send them to verification page
+        if attempt['status'] == ProctoredExamStudentAttemptStatus.created:
+            attempt_data['verification_url'] = '{base_url}/id-verification'.format(
+                base_url=settings.ACCOUNT_MICROFRONTEND_URL
+            )
         if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
                                  ProctoredExamStudentAttemptStatus.download_software_clicked):
             provider_attempt = provider.get_attempt(attempt)

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -647,8 +647,10 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             attempt_data['verification_url'] = '{base_url}/id-verification'.format(
                 base_url=settings.ACCOUNT_MICROFRONTEND_URL
             )
-        if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
-                                 ProctoredExamStudentAttemptStatus.download_software_clicked):
+        if attempt['status'] in (
+                ProctoredExamStudentAttemptStatus.created,
+                ProctoredExamStudentAttemptStatus.download_software_clicked
+        ):
             provider_attempt = provider.get_attempt(attempt)
             download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
             attempt_data['software_download_url'] = download_url

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -637,8 +637,12 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     }
 
     if provider:
-        attempt_data['desktop_application_js_url'] = provider.get_javascript()
-        attempt_data['ping_interval'] = provider.ping_interval
+        attempt_data.update({
+            'desktop_application_js_url': provider.get_javascript(),
+            'ping_interval': provider.ping_interval,
+            'external_id': attempt['external_id'],
+            'attempt_code': attempt['attempt_code']
+        })
     else:
         attempt_data['desktop_application_js_url'] = ''
 

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -640,9 +640,13 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
         attempt_data.update({
             'desktop_application_js_url': provider.get_javascript(),
             'ping_interval': provider.ping_interval,
-            'external_id': attempt['external_id'],
             'attempt_code': attempt['attempt_code']
         })
+        if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
+                                 ProctoredExamStudentAttemptStatus.download_software_clicked):
+            provider_attempt = provider.get_attempt(attempt)
+            download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
+            attempt_data['software_download_url'] = download_url
     else:
         attempt_data['desktop_application_js_url'] = ''
 

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -10,9 +10,9 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from edx_proctoring.api import get_review_policy_by_exam_id
 from edx_proctoring.exceptions import BackendProviderNotConfigured, ProctoredExamNotFoundException
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
-from edx_proctoring.api import get_review_policy_by_exam_id
 
 from .utils import ProctoredExamTestCase
 

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -18,7 +18,7 @@ from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import Client
 
-from edx_proctoring.api import create_exam
+from edx_proctoring.api import create_exam, create_exam_review_policy
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
@@ -377,6 +377,16 @@ class ProctoredExamTestCase(LoggedInTestCase):
             is_sample_attempt=True,
             status=ProctoredExamStudentAttemptStatus.started,
             allowed_time_limit_mins=10
+        )
+
+    def _create_review_policy(self, exam_id):
+        """
+        Calls the api's create_exam_review_policy to create an exam review policy object.
+        """
+        return create_exam_review_policy(
+            exam_id,
+            self.user.id,
+            "This is a test review policy."
         )
 
     @staticmethod

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -121,6 +121,11 @@ urlpatterns = [
         views.ProctoredSettingsView.as_view(),
         name='proctored_exam.proctoring_settings'
     ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/review_policy/exam_id/(?P<exam_id>\d+)/$',
+        views.ProctoredExamReviewPolicyView.as_view(),
+        name='proctored_exam.review_policy'
+    ),
 
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -289,7 +289,8 @@ class ProctoredExamReviewPolicyView(ProctoredAPIView):
         """
         try:
             review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
-        except ProctoredExamReviewPolicyNotFoundException:
+        except ProctoredExamReviewPolicyNotFoundException as e:
+            LOG.warning(str(e))
             review_policy = None
         return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -44,6 +44,7 @@ from edx_proctoring.api import (
     get_last_verified_onboarding_attempts_per_user,
     get_proctoring_settings_by_exam_id,
     get_user_attempts_by_exam_id,
+    get_review_policy_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
     remove_allowance_for_user,
@@ -61,7 +62,8 @@ from edx_proctoring.exceptions import (
     ProctoredExamNotFoundException,
     ProctoredExamPermissionDenied,
     ProctoredExamReviewAlreadyExists,
-    StudentExamAttemptDoesNotExistsException
+    StudentExamAttemptDoesNotExistsException,
+    ProctoredExamReviewPolicyNotFoundException
 )
 from edx_proctoring.models import (
     ProctoredExam,
@@ -264,6 +266,32 @@ class ProctoredSettingsView(ProctoredAPIView):
         response_dict = get_proctoring_settings_by_exam_id(exam_id)
 
         return Response(data=response_dict, status=status.HTTP_200_OK)
+
+
+class ProctoredExamReviewPolicyView(ProctoredAPIView):
+    """
+    Endpoint for getting review policy for proctored exam.
+
+    edx_proctoring/v1/proctored_exam/review_policy/exam_id/{exam_id}
+
+    Supports:
+        HTTP GET:
+            ** Scenarios **
+            Returns review policy for proctored exam
+            {
+                "review_policy": "Example review policy."
+            }
+
+    """
+    def get(self, request, exam_id):
+        """
+        HTTP GET handler. Returns review policy for proctored exam.
+        """
+        try:
+            review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
+        except ProctoredExamReviewPolicyNotFoundException:
+            review_policy = None
+        return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 
 
 class ProctoredExamView(ProctoredAPIView):

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -289,8 +289,8 @@ class ProctoredExamReviewPolicyView(ProctoredAPIView):
         """
         try:
             review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
-        except ProctoredExamReviewPolicyNotFoundException as e:
-            LOG.warning(str(e))
+        except ProctoredExamReviewPolicyNotFoundException as exc:
+            LOG.warning(str(exc))
             review_policy = None
         return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -43,8 +43,8 @@ from edx_proctoring.api import (
     get_exam_by_id,
     get_last_verified_onboarding_attempts_per_user,
     get_proctoring_settings_by_exam_id,
-    get_user_attempts_by_exam_id,
     get_review_policy_by_exam_id,
+    get_user_attempts_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
     remove_allowance_for_user,
@@ -62,8 +62,8 @@ from edx_proctoring.exceptions import (
     ProctoredExamNotFoundException,
     ProctoredExamPermissionDenied,
     ProctoredExamReviewAlreadyExists,
-    StudentExamAttemptDoesNotExistsException,
-    ProctoredExamReviewPolicyNotFoundException
+    ProctoredExamReviewPolicyNotFoundException,
+    StudentExamAttemptDoesNotExistsException
 )
 from edx_proctoring.models import (
     ProctoredExam,


### PR DESCRIPTION
**Description:**

Create an API endpoint to provide exam review policy for the special exams in the MFE app-learning. Also extend current exam attempt API with additional data.

**JIRA:**

[EDUCATOR-5816](https://openedx.atlassian.net/browse/EDUCATOR-5816)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.