### PR TITLE
DRAFT: [BD-26] [EDUCATOR-5813] Add prerequisites check in the MFE learning app API before user starts a proctored exam

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Unreleased
 * Extend exam attempt API to return additional data for proctored exams.
 * Add API endpoint which provides exam review policy for specific exam.
   Usage case is to provide required data for the learning app MFE.
+* Extend exam attempt API endpoint to check if user has satisfied prerequisites
+  before starting a proctored exam.
 
 [3.10.1] - 2021-05-21
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Extend exam attempt API to return additional data for proctored exams.
+* Add API endpoint which provides exam review policy for specific exam.
+  Usage case is to provide required data for the learning app MFE.
 
 [3.10.1] - 2021-05-21
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -642,6 +642,11 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             'ping_interval': provider.ping_interval,
             'attempt_code': attempt['attempt_code']
         })
+        # in case user is not verified we need to send them to verification page
+        if attempt['status'] == ProctoredExamStudentAttemptStatus.created:
+            attempt_data['verification_url'] = '{base_url}/id-verification'.format(
+                base_url=settings.ACCOUNT_MICROFRONTEND_URL
+            )
         if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
                                  ProctoredExamStudentAttemptStatus.download_software_clicked):
             provider_attempt = provider.get_attempt(attempt)

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1770,6 +1770,8 @@ def check_prerequisites(exam, user_id):
     """
     credit_service = get_runtime_service('credit')
     credit_state = credit_service.get_credit_state(user_id, exam['course_id'])
+    if not credit_state:
+        return exam
     credit_requirement_status = credit_state.get('credit_requirement_status', [])
 
     prerequisite_status = _are_prerequirements_satisfied(
@@ -1778,7 +1780,6 @@ def check_prerequisites(exam, user_id):
         filter_out_namespaces=['grade']
     )
 
-    # add any prerequisite information, if applicable
     exam.update({
         'prerequisite_status': prerequisite_status
     })
@@ -1787,21 +1788,15 @@ def check_prerequisites(exam, user_id):
         # do we have any declined prerequisites, if so, then we
         # will auto-decline this proctored exam
         if prerequisite_status['declined_prerequisites']:
-            # user hasn't a record of attempt, create one now
-            # so we can mark it as declined
             _create_and_decline_attempt(exam['id'], user_id)
             return exam
 
-        # do we have failed prerequisites? That takes priority in terms of
-        # messaging
         if prerequisite_status['failed_prerequisites']:
-            # Let's resolve the URLs to jump to this prerequisite
             prerequisite_status['failed_prerequisites'] = _resolve_prerequisite_links(
                 exam,
                 prerequisite_status['failed_prerequisites']
             )
         else:
-            # Let's resolve the URLs to jump to this prerequisite
             prerequisite_status['pending_prerequisites'] = _resolve_prerequisite_links(
                 exam,
                 prerequisite_status['pending_prerequisites']

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -647,8 +647,10 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             attempt_data['verification_url'] = '{base_url}/id-verification'.format(
                 base_url=settings.ACCOUNT_MICROFRONTEND_URL
             )
-        if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
-                                 ProctoredExamStudentAttemptStatus.download_software_clicked):
+        if attempt['status'] in (
+                ProctoredExamStudentAttemptStatus.created,
+                ProctoredExamStudentAttemptStatus.download_software_clicked
+        ):
             provider_attempt = provider.get_attempt(attempt)
             download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
             attempt_data['software_download_url'] = download_url

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -637,8 +637,12 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     }
 
     if provider:
-        attempt_data['desktop_application_js_url'] = provider.get_javascript()
-        attempt_data['ping_interval'] = provider.ping_interval
+        attempt_data.update({
+            'desktop_application_js_url': provider.get_javascript(),
+            'ping_interval': provider.ping_interval,
+            'external_id': attempt['external_id'],
+            'attempt_code': attempt['attempt_code']
+        })
     else:
         attempt_data['desktop_application_js_url'] = ''
 

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -640,9 +640,13 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
         attempt_data.update({
             'desktop_application_js_url': provider.get_javascript(),
             'ping_interval': provider.ping_interval,
-            'external_id': attempt['external_id'],
             'attempt_code': attempt['attempt_code']
         })
+        if attempt['status'] in (ProctoredExamStudentAttemptStatus.created,
+                                 ProctoredExamStudentAttemptStatus.download_software_clicked):
+            provider_attempt = provider.get_attempt(attempt)
+            download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
+            attempt_data['software_download_url'] = download_url
     else:
         attempt_data['desktop_application_js_url'] = ''
 

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -72,7 +72,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         exam_data = response_data['exam']
 
-        # if exam started we do not check for prerequisites
+        # if exam started the prerequisites are not checked
         assert 'prerequisite_status' not in exam_data
         assert 'active_attempt' in response_data and response_data['active_attempt']
         self.assertHasExamData(response_data, has_attempt=True)

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -10,9 +10,9 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from edx_proctoring.api import get_review_policy_by_exam_id
 from edx_proctoring.exceptions import BackendProviderNotConfigured, ProctoredExamNotFoundException
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
-from edx_proctoring.api import get_review_policy_by_exam_id
 
 from .utils import ProctoredExamTestCase
 

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -18,7 +18,7 @@ from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import Client
 
-from edx_proctoring.api import create_exam
+from edx_proctoring.api import create_exam, create_exam_review_policy
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
@@ -377,6 +377,16 @@ class ProctoredExamTestCase(LoggedInTestCase):
             is_sample_attempt=True,
             status=ProctoredExamStudentAttemptStatus.started,
             allowed_time_limit_mins=10
+        )
+
+    def _create_review_policy(self, exam_id):
+        """
+        Calls the api's create_exam_review_policy to create an exam review policy object.
+        """
+        return create_exam_review_policy(
+            exam_id,
+            self.user.id,
+            "This is a test review policy."
         )
 
     @staticmethod

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -121,6 +121,11 @@ urlpatterns = [
         views.ProctoredSettingsView.as_view(),
         name='proctored_exam.proctoring_settings'
     ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/review_policy/exam_id/(?P<exam_id>\d+)/$',
+        views.ProctoredExamReviewPolicyView.as_view(),
+        name='proctored_exam.review_policy'
+    ),
 
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -230,7 +230,8 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
-                # exam hasn't started yet and is proctored so check if prerequisites are satisfied
+                # exam hasn't been started yet but it is proctored
+                # so needs to be checked if prerequisites are satisfied
                 elif exam['is_proctored']:
                     exam = check_prerequisites(exam, request.user.id)
                 exam.update({'attempt': attempt_data})

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -230,8 +230,8 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
-                # exam hasn't started yet so check if prerequisites are satisfied
-                else:
+                # exam hasn't started yet and is proctored so check if prerequisites are satisfied
+                elif exam['is_proctored']:
                     exam = check_prerequisites(exam, request.user.id)
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -289,7 +289,8 @@ class ProctoredExamReviewPolicyView(ProctoredAPIView):
         """
         try:
             review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
-        except ProctoredExamReviewPolicyNotFoundException:
+        except ProctoredExamReviewPolicyNotFoundException as e:
+            LOG.warning(str(e))
             review_policy = None
         return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -28,6 +28,7 @@ from django.utils.translation import ugettext as _
 from edx_proctoring import constants
 from edx_proctoring.api import (
     add_allowance_for_user,
+    check_prerequisites,
     create_exam,
     create_exam_attempt,
     get_active_exams_for_user,
@@ -229,6 +230,9 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
+                # exam hasn't started yet so check if prerequisites are satisfied
+                else:
+                    exam = check_prerequisites(exam, request.user.id)
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:
                 exam = {}

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -44,6 +44,7 @@ from edx_proctoring.api import (
     get_last_verified_onboarding_attempts_per_user,
     get_proctoring_settings_by_exam_id,
     get_user_attempts_by_exam_id,
+    get_review_policy_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
     remove_allowance_for_user,
@@ -61,7 +62,8 @@ from edx_proctoring.exceptions import (
     ProctoredExamNotFoundException,
     ProctoredExamPermissionDenied,
     ProctoredExamReviewAlreadyExists,
-    StudentExamAttemptDoesNotExistsException
+    StudentExamAttemptDoesNotExistsException,
+    ProctoredExamReviewPolicyNotFoundException
 )
 from edx_proctoring.models import (
     ProctoredExam,
@@ -264,6 +266,32 @@ class ProctoredSettingsView(ProctoredAPIView):
         response_dict = get_proctoring_settings_by_exam_id(exam_id)
 
         return Response(data=response_dict, status=status.HTTP_200_OK)
+
+
+class ProctoredExamReviewPolicyView(ProctoredAPIView):
+    """
+    Endpoint for getting review policy for proctored exam.
+
+    edx_proctoring/v1/proctored_exam/review_policy/exam_id/{exam_id}
+
+    Supports:
+        HTTP GET:
+            ** Scenarios **
+            Returns review policy for proctored exam
+            {
+                "review_policy": "Example review policy."
+            }
+
+    """
+    def get(self, request, exam_id):
+        """
+        HTTP GET handler. Returns review policy for proctored exam.
+        """
+        try:
+            review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
+        except ProctoredExamReviewPolicyNotFoundException:
+            review_policy = None
+        return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 
 
 class ProctoredExamView(ProctoredAPIView):

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -289,8 +289,8 @@ class ProctoredExamReviewPolicyView(ProctoredAPIView):
         """
         try:
             review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
-        except ProctoredExamReviewPolicyNotFoundException as e:
-            LOG.warning(str(e))
+        except ProctoredExamReviewPolicyNotFoundException as exc:
+            LOG.warning(str(exc))
             review_policy = None
         return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -43,8 +43,8 @@ from edx_proctoring.api import (
     get_exam_by_id,
     get_last_verified_onboarding_attempts_per_user,
     get_proctoring_settings_by_exam_id,
-    get_user_attempts_by_exam_id,
     get_review_policy_by_exam_id,
+    get_user_attempts_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
     remove_allowance_for_user,
@@ -62,8 +62,8 @@ from edx_proctoring.exceptions import (
     ProctoredExamNotFoundException,
     ProctoredExamPermissionDenied,
     ProctoredExamReviewAlreadyExists,
-    StudentExamAttemptDoesNotExistsException,
-    ProctoredExamReviewPolicyNotFoundException
+    ProctoredExamReviewPolicyNotFoundException,
+    StudentExamAttemptDoesNotExistsException
 )
 from edx_proctoring.models import (
     ProctoredExam,


### PR DESCRIPTION
**Description:**

Extend MFE learning app API to check if prerequisites are satisfied before user starts a proctored exam.

NOTE: should be merged after #864 

**JIRA:**

[EDUCATOR-5813](https://openedx.atlassian.net/browse/EDUCATOR-5813)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.