### PR TITLE
DRAFT: [BD-26][EDUCATOR-5808] Add additional data to MFE API responses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Extend proctoring settings API to return additional data about proctoring
+  provider and also extend exam attempt API to return exam type. Usage case
+  is to provide required data for the learning app MFE.
 
 [3.10.1] - 2021-05-21
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -100,7 +100,14 @@ def get_proctoring_settings_by_exam_id(exam_id):
         except NotImplementedError as error:
             log.exception(str(error))
             raise BackendProviderNotConfigured(str(error)) from error
-        proctoring_settings_data['exam_proctoring_backend'] = provider.get_proctoring_config()
+        proctoring_settings_data.update({
+            'exam_proctoring_backend': provider.get_proctoring_config(),
+            'provider_tech_support_email': provider.tech_support_email,
+            'provider_tech_support_phone': provider.tech_support_phone,
+            'provider_name': provider.verbose_name,
+            'learner_notification_from_email': provider.learner_notification_from_email,
+            'integration_specific_email': get_integration_specific_email(provider),
+        })
     return proctoring_settings_data
 
 
@@ -618,7 +625,7 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     attempt_data = {
         'in_timed_exam': True,
         'taking_as_proctored': attempt['taking_as_proctored'],
-        'exam_type': get_exam_type(provider, attempt),
+        'exam_type': get_exam_type(exam, provider)['humanized_type'],
         'exam_display_name': exam['exam_name'],
         'exam_url_path': exam_url_path,
         'time_remaining_seconds': time_remaining_seconds,

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1764,6 +1764,46 @@ def get_active_exams_for_user(user_id, course_id=None):
     return result
 
 
+def check_prerequisites(exam, user_id):
+    """
+    Check if prerequisites are satisfied for user to take the exam
+    """
+    credit_service = get_runtime_service('credit')
+    credit_state = credit_service.get_credit_state(user_id, exam['course_id'])
+    if not credit_state:
+        return exam
+    credit_requirement_status = credit_state.get('credit_requirement_status', [])
+
+    prerequisite_status = _are_prerequirements_satisfied(
+        credit_requirement_status,
+        evaluate_for_requirement_name=exam['content_id'],
+        filter_out_namespaces=['grade']
+    )
+
+    exam.update({
+        'prerequisite_status': prerequisite_status
+    })
+
+    if not prerequisite_status['are_prerequisites_satisifed']:
+        # do we have any declined prerequisites, if so, then we
+        # will auto-decline this proctored exam
+        if prerequisite_status['declined_prerequisites']:
+            _create_and_decline_attempt(exam['id'], user_id)
+            return exam
+
+        if prerequisite_status['failed_prerequisites']:
+            prerequisite_status['failed_prerequisites'] = _resolve_prerequisite_links(
+                exam,
+                prerequisite_status['failed_prerequisites']
+            )
+        else:
+            prerequisite_status['pending_prerequisites'] = _resolve_prerequisite_links(
+                exam,
+                prerequisite_status['pending_prerequisites']
+            )
+    return exam
+
+
 def _get_ordered_prerequisites(prerequisites_statuses, filter_out_namespaces=None):
     """
     Apply filter and ordering of requirements status in our credit_state dictionary. This will

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -637,8 +637,23 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     }
 
     if provider:
-        attempt_data['desktop_application_js_url'] = provider.get_javascript()
-        attempt_data['ping_interval'] = provider.ping_interval
+        attempt_data.update({
+            'desktop_application_js_url': provider.get_javascript(),
+            'ping_interval': provider.ping_interval,
+            'attempt_code': attempt['attempt_code']
+        })
+        # in case user is not verified we need to send them to verification page
+        if attempt['status'] == ProctoredExamStudentAttemptStatus.created:
+            attempt_data['verification_url'] = '{base_url}/id-verification'.format(
+                base_url=settings.ACCOUNT_MICROFRONTEND_URL
+            )
+        if attempt['status'] in (
+                ProctoredExamStudentAttemptStatus.created,
+                ProctoredExamStudentAttemptStatus.download_software_clicked
+        ):
+            provider_attempt = provider.get_attempt(attempt)
+            download_url = provider_attempt.get('download_url', None) or provider.get_software_download_url()
+            attempt_data['software_download_url'] = download_url
     else:
         attempt_data['desktop_application_js_url'] = ''
 

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -71,6 +71,9 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         self.assertEqual(response.status_code, 200)
         response_data = json.loads(response.content.decode('utf-8'))
         exam_data = response_data['exam']
+
+        # if exam started we do not check for prerequisites
+        assert 'prerequisite_status' not in exam_data
         assert 'active_attempt' in response_data and response_data['active_attempt']
         self.assertHasExamData(response_data, has_attempt=True)
         self.assertEqual(exam_data['attempt']['exam_url_path'], self.expected_exam_url)
@@ -96,18 +99,21 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         expected_exam_url = '{}/course/{}/{}'.format(
             settings.LEARNING_MICROFRONTEND_URL, self.course_id, self.content_id_timed
         )
+        assert 'prerequisite_status' not in exam_data
         assert 'active_attempt' in response_data and response_data['active_attempt']
         self.assertHasExamData(response_data, has_attempt=True, content_id=self.content_id_timed)
         self.assertEqual(exam_data['attempt']['exam_url_path'], expected_exam_url)
 
     def test_no_attempts_data_before_exam_starts(self):
         """
-        Test we get exam data before exam is started. Ensure no attempts data returned.
+        Test we get exam data before exam is started. Ensure no attempts data returned and prerequisites are checked.
         """
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         response_data = json.loads(response.content.decode('utf-8'))
+        exam_data = response_data['exam']
         assert 'active_attempt' in response_data and not response_data['active_attempt']
+        assert 'prerequisite_status' in exam_data
         self.assertHasExamData(response_data, has_attempt=False)
 
     def test_get_exam_attempts_data_after_exam_is_submitted(self):
@@ -121,6 +127,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         exam_data = response_data['exam']
         assert 'active_attempt' in response_data and not response_data['active_attempt']
+        assert 'prerequisite_status' not in exam_data
         self.assertHasExamData(response_data, has_attempt=True)
         self.assertEqual(exam_data['attempt']['exam_url_path'], self.expected_exam_url)
         self.assertEqual(exam_data['attempt']['attempt_status'], ProctoredExamStudentAttemptStatus.submitted)
@@ -144,6 +151,24 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         assert not response_data['active_attempt']
         assert not exam_data
 
+    def test_prerequisites_are_not_checked_if_exam_is_not_proctored(self):
+        """
+        Tests that prerequisites are not checked for non proctored exams.
+        """
+        url = reverse(
+            'edx_proctoring:proctored_exam.exam_attempts',
+            kwargs={
+                'course_id': self.course_id,
+                'content_id': self.content_id_timed
+            }
+        ) + '?is_learning_mfe=true'
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        exam_data = response_data['exam']
+        assert 'prerequisite_status' not in exam_data
+
     @ddt.data(
         ProctoredExamStudentAttemptStatus.created,
         ProctoredExamStudentAttemptStatus.download_software_clicked,
@@ -159,7 +184,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         """
         Tests the GET exam attempts data contains software download url ONLY when attempt
         is in created or download_software_clicked status and contains verification
-        url ONLY when attempt is inn created status
+        url ONLY when attempt is in created status
         """
         self._create_exam_attempt(self.proctored_exam_id, status=status)
 

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -79,6 +79,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         assert 'active_attempt' in response_data and response_data['active_attempt']
         self.assertHasExamData(response_data, has_attempt=True)
         self.assertEqual(exam_data['attempt']['exam_url_path'], self.expected_exam_url)
+        self.assertEqual(exam_data['type'], 'proctored')
 
     def test_get_started_timed_exam_attempts_data(self):
         """
@@ -117,6 +118,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         assert 'active_attempt' in response_data and not response_data['active_attempt']
         assert 'prerequisite_status' in exam_data
         self.assertHasExamData(response_data, has_attempt=False)
+        self.assertEqual(exam_data['type'], 'proctored')
 
     def test_get_exam_attempts_data_after_exam_is_submitted(self):
         """
@@ -133,6 +135,7 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         self.assertHasExamData(response_data, has_attempt=True)
         self.assertEqual(exam_data['attempt']['exam_url_path'], self.expected_exam_url)
         self.assertEqual(exam_data['attempt']['attempt_status'], ProctoredExamStudentAttemptStatus.submitted)
+        self.assertEqual(exam_data['type'], 'proctored')
 
     def test_no_exam_data_returned_for_non_exam_sequence(self):
         """

--- a/edx_proctoring/tests/utils.py
+++ b/edx_proctoring/tests/utils.py
@@ -18,7 +18,7 @@ from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import Client
 
-from edx_proctoring.api import create_exam
+from edx_proctoring.api import create_exam, create_exam_review_policy
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
@@ -377,6 +377,16 @@ class ProctoredExamTestCase(LoggedInTestCase):
             is_sample_attempt=True,
             status=ProctoredExamStudentAttemptStatus.started,
             allowed_time_limit_mins=10
+        )
+
+    def _create_review_policy(self, exam_id):
+        """
+        Calls the api's create_exam_review_policy to create an exam review policy object.
+        """
+        return create_exam_review_policy(
+            exam_id,
+            self.user.id,
+            "This is a test review policy."
         )
 
     @staticmethod

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -121,6 +121,11 @@ urlpatterns = [
         views.ProctoredSettingsView.as_view(),
         name='proctored_exam.proctoring_settings'
     ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/review_policy/exam_id/(?P<exam_id>\d+)/$',
+        views.ProctoredExamReviewPolicyView.as_view(),
+        name='proctored_exam.review_policy'
+    ),
 
     # Unauthenticated callbacks from SoftwareSecure. Note we use other
     # security token measures to protect data

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -302,11 +302,26 @@ def get_visibility_check_date(course_schedule, usage_key):
     return visibility_check_date
 
 
-def get_exam_type(provider, attempt):
-    """ Helper that returns exam type string by backend provider and exam attempt params. """
-    return (
-        _('a timed exam') if not attempt['taking_as_proctored'] else
-        (_('a proctored exam') if not attempt['is_sample_attempt'] else
-         (_('an onboarding exam') if (provider and provider.supports_onboarding) else
-          _('a practice exam')))
-    )
+def get_exam_type(exam, provider):
+    """ Helper that returns exam type and humanized name by backend provider and exam params. """
+    is_practice_exam = exam['is_proctored'] and exam['is_practice_exam']
+    is_timed_exam = not exam['is_proctored'] and not exam['is_practice_exam']
+
+    if is_timed_exam:
+        exam_type = 'timed'
+        humanized_type = _('a timed exam')
+    elif is_practice_exam:
+        if provider and provider.supports_onboarding:
+            exam_type = 'onboarding'
+            humanized_type = _('an onboarding exam')
+        else:
+            exam_type = 'practice'
+            humanized_type = _('a practice exam')
+    else:
+        exam_type = 'proctored'
+        humanized_type = _('a proctored exam')
+
+    return {
+        'type': exam_type,
+        'humanized_type': humanized_type,
+    }

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -307,19 +307,15 @@ def get_exam_type(exam, provider):
     is_practice_exam = exam['is_proctored'] and exam['is_practice_exam']
     is_timed_exam = not exam['is_proctored'] and not exam['is_practice_exam']
 
+    exam_type, humanized_type = 'proctored', _('a proctored exam')
+
     if is_timed_exam:
-        exam_type = 'timed'
-        humanized_type = _('a timed exam')
+        exam_type, humanized_type = 'timed', _('a timed exam')
     elif is_practice_exam:
         if provider and provider.supports_onboarding:
-            exam_type = 'onboarding'
-            humanized_type = _('an onboarding exam')
+            exam_type, humanized_type = 'onboarding', _('an onboarding exam')
         else:
-            exam_type = 'practice'
-            humanized_type = _('a practice exam')
-    else:
-        exam_type = 'proctored'
-        humanized_type = _('a proctored exam')
+            exam_type, humanized_type = 'practice', _('a practice exam')
 
     return {
         'type': exam_type,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -43,6 +43,7 @@ from edx_proctoring.api import (
     get_exam_by_id,
     get_last_verified_onboarding_attempts_per_user,
     get_proctoring_settings_by_exam_id,
+    get_review_policy_by_exam_id,
     get_user_attempts_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
@@ -61,6 +62,7 @@ from edx_proctoring.exceptions import (
     ProctoredExamNotFoundException,
     ProctoredExamPermissionDenied,
     ProctoredExamReviewAlreadyExists,
+    ProctoredExamReviewPolicyNotFoundException,
     StudentExamAttemptDoesNotExistsException
 )
 from edx_proctoring.models import (
@@ -264,6 +266,33 @@ class ProctoredSettingsView(ProctoredAPIView):
         response_dict = get_proctoring_settings_by_exam_id(exam_id)
 
         return Response(data=response_dict, status=status.HTTP_200_OK)
+
+
+class ProctoredExamReviewPolicyView(ProctoredAPIView):
+    """
+    Endpoint for getting review policy for proctored exam.
+
+    edx_proctoring/v1/proctored_exam/review_policy/exam_id/{exam_id}
+
+    Supports:
+        HTTP GET:
+            ** Scenarios **
+            Returns review policy for proctored exam
+            {
+                "review_policy": "Example review policy."
+            }
+
+    """
+    def get(self, request, exam_id):
+        """
+        HTTP GET handler. Returns review policy for proctored exam.
+        """
+        try:
+            review_policy = get_review_policy_by_exam_id(exam_id)['review_policy']
+        except ProctoredExamReviewPolicyNotFoundException as exc:
+            LOG.warning(str(exc))
+            review_policy = None
+        return Response(data=dict(review_policy=review_policy), status=status.HTTP_200_OK)
 
 
 class ProctoredExamView(ProctoredAPIView):

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -28,6 +28,7 @@ from django.utils.translation import ugettext as _
 from edx_proctoring import constants
 from edx_proctoring.api import (
     add_allowance_for_user,
+    check_prerequisites,
     create_exam,
     create_exam_attempt,
     get_active_exams_for_user,
@@ -229,6 +230,9 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
+                # exam hasn't started yet and is proctored so check if prerequisites are satisfied
+                elif exam['is_proctored']:
+                    exam = check_prerequisites(exam, request.user.id)
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:
                 exam = {}

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -85,6 +85,7 @@ from edx_proctoring.statuses import (
 )
 from edx_proctoring.utils import (
     AuthenticatedAPIView,
+    get_exam_type,
     get_time_remaining_for_attempt,
     get_visibility_check_date,
     humanized_time,
@@ -238,7 +239,9 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:
                 exam = {}
-
+        if exam:
+            provider = get_backend_provider(exam)
+            exam['type'] = get_exam_type(exam, provider)['type']
         response_dict = {
             'exam': exam,
             'active_attempt': active_attempt_data,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -230,8 +230,10 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
-                # exam hasn't started yet and is proctored so check if prerequisites are satisfied
-                elif exam['is_proctored']:
+                # Exam hasn't started yet and is proctored so check if prerequisites are satisfied.
+                # We only do this for proctored exam hence additional check 'not exam['is_practice_exam']',
+                # meaning we do not check prerequisites for practice or onboarding exams
+                elif exam['is_proctored'] and not exam['is_practice_exam']:
                     exam = check_prerequisites(exam, request.user.id)
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:


### PR DESCRIPTION
**Description:**

Extend proctoring settings API to return additional proctoring service data and also extend exam attempt API to return type of the exam.

NOTE: should be merged after #866 

**JIRA:**

[EDUCATOR-5808](https://openedx.atlassian.net/browse/EDUCATOR-5808)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.