### PR TITLE
fix: Add log message for timed out attempt or re-attempt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.11.6] - 2021-06-03
+~~~~~~~~~~~~~~~~~~~~~
+* Add logging for attempt status transitions caused by a time out or reattempt
+
 [3.11.5] - 2021-06-01
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix a bug where we are to pass to vendor javascript a value in milliseconds, instead of just seconds

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.11.5'
+__version__ = '3.11.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1121,6 +1121,15 @@ def update_attempt_status(attempt_id, to_status,
 
     user_trying_to_reattempt = is_reattempting_exam(from_status, to_status)
     if treat_timeout_as_submitted or user_trying_to_reattempt:
+        detail = 'the attempt was timed out' if treat_timeout_as_submitted else 'the user reattempted the exam'
+        log_msg = (
+            'Attempt status for exam_id={exam_id} for user_id={user_id} will not be updated to '
+            '"{to_status}" because {submitted_message}. Instead the attempt '
+            'status will be updated to "submitted"'.format(
+                exam_id=exam_id, user_id=user_id, to_status=to_status, submitted_message=detail
+            )
+        )
+        log.info(log_msg)
         to_status = ProctoredExamStudentAttemptStatus.submitted
 
     exam = get_exam_by_id(exam_id)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.11.5",
+  "version": "3.11.6",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
## [MST-850](https://openedx.atlassian.net/browse/MST-850)

When an attempt is timed out or a user is reattempting an exam, their attempt will be marked as submitted. This status update is currently not captured in our logs, which makes the triggers for transitions to 'submitted' non-obvious in these cases.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.