### PR TITLE
[MST-838] Disable IDV check if integrity signature is enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.12.0] - 2021-06-04
+~~~~~~~~~~~~~~~~~~~~~
+* If the `is_integrity_signature_enabled` waffle flag is turned on, do not render the ID verification
+  template for proctored exams.
+
 [3.11.6] - 2021-06-03
 ~~~~~~~~~~~~~~~~~~~~~
 * Add logging for attempt status transitions caused by a time out or reattempt

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.11.6'
+__version__ = '3.12.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -2491,8 +2491,12 @@ def _get_proctored_exam_view(exam, context, exam_id, user_id, course_id):
             return None
     elif attempt_status in [ProctoredExamStudentAttemptStatus.created,
                             ProctoredExamStudentAttemptStatus.download_software_clicked]:
-        if context.get('verification_status') is not APPROVED_STATUS:
-            # if the user has not id verified yet, show them the page that requires them to do so
+        if not (
+            context.get('is_integrity_signature_enabled')
+            or context.get('verification_status') is APPROVED_STATUS
+        ):
+            # if the user has not id verified yet, show them the page that requires them to do so,
+            # unless the integrity signature feature is enabled
             student_view_template = 'proctored_exam/id_verification.html'
         else:
             student_view_template = 'proctored_exam/instructions.html'

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -99,6 +99,7 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
             },
             'verification_status': 'approved',
             'verification_url': '/reverify',
+            'is_integrity_signature_enabled': False,
         }
         if context_overrides:
             context.update(context_overrides)
@@ -201,6 +202,18 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
             'verification_status': verification_status,
         })
         self.assertIn(expected_message, rendered_response)
+
+    def test_integrity_signature_enabled(self):
+        """
+        This test asserts that the ID verification message is not shown if the
+        integrity signature feature is enabled.
+        """
+        self._create_unstarted_exam_attempt()
+        rendered_response = self.render_proctored_exam({
+            'verification_status': None,
+            'is_integrity_signature_enabled': True,
+        })
+        self.assertIn(self.chose_proctored_exam_msg, rendered_response)
 
     def test_proctored_only_entrance(self):
         """

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.11.6",
+  "version": "3.12.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

If the integrity signature feature on edx-platform is enabled ([controlled by this waffle flag](https://github.com/edx/edx-platform/blob/f8fad40059097cb8f7bdb2226efddc09b615cd50/openedx/core/djangoapps/agreements/toggles.py#L7)), do not block the user from entering a proctored exam if they have not completed ID verification.

Related edx-platform PR: https://github.com/edx/edx-platform/pull/27831

**JIRA:**

[MST-838](https://openedx.atlassian.net/browse/MST-838)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.