### PR TITLE
[BD-26] Extend exam attempt API to check if due date has passed and to return link to onboarding exam

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,12 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[3.14.0] - 2021-06-07
+[3.14.0] - 2021-06-09
 ~~~~~~~~~~~~~~~~~~~~~
-* Extend exam attempt API to return exam type and a link to the onboarding exam
-  in case user tries to take proctored exam when they haven't passed required
-  onboarding exam. Modify API to check if user has satisfied prerequisites
-  before taking proctored exam and if exam has passed due date.
+* Extend exam attempt API to return exam type, total time left in attempt,
+  and a link to the onboarding exam in case user tries to take proctored
+  exam when they haven't passed required onboarding exam.
+  Modify API to check if user has satisfied prerequisites before taking
+  proctored exam and if exam has passed due date.
 * Extend proctoring settings API to return additional data about proctoring
   provider.
 * Add API endpoint which provides exam review policy for specific exam.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-* Extend exam attempt API to return exam type and to check if
-  user has satisfied prerequisites before taking proctored exam.
+
+[3.14.0] - 2021-06-07
+~~~~~~~~~~~~~~~~~~~~~
+* Extend exam attempt API to return exam type and a link to the onboarding exam
+  in case user tries to take proctored exam when they haven't passed required
+  onboarding exam. Modify API to check if user has satisfied prerequisites
+  before taking proctored exam and if exam has passed due date.
 * Extend proctoring settings API to return additional data about proctoring
   provider.
 * Add API endpoint which provides exam review policy for specific exam.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.13.0'
+__version__ = '3.14.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -606,17 +606,18 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     low_threshold_pct = proctoring_settings.get('low_threshold_pct', .2)
     critically_low_threshold_pct = proctoring_settings.get('critically_low_threshold_pct', .05)
 
-    time_limit_mins = attempt.get('allowed_time_limit_mins') or 0
+    allowed_time_limit_mins = attempt.get('allowed_time_limit_mins') or 0
 
-    low_threshold = int(low_threshold_pct * float(time_limit_mins) * 60)
+    low_threshold = int(low_threshold_pct * float(allowed_time_limit_mins) * 60)
     critically_low_threshold = int(
-        critically_low_threshold_pct * float(time_limit_mins) * 60
+        critically_low_threshold_pct * float(allowed_time_limit_mins) * 60
     )
 
-    if not time_limit_mins or (attempt and attempt['status'] == ProctoredExamStudentAttemptStatus.ready_to_resume):
-        time_limit_mins = _calculate_allowed_mins(exam, attempt['user']['id'])
+    if (not allowed_time_limit_mins
+            or (attempt and attempt['status'] == ProctoredExamStudentAttemptStatus.ready_to_resume)):
+        allowed_time_limit_mins = _calculate_allowed_mins(exam, attempt['user']['id'])
 
-    total_time = humanized_time(time_limit_mins)
+    total_time = humanized_time(allowed_time_limit_mins)
 
     # resolve the LMS url, note we can't assume we're running in
     # a same process as the LMS

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta
 
 import pytz
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -65,6 +64,7 @@ from edx_proctoring.utils import (
     humanized_time,
     is_reattempting_exam,
     obscured_user_id,
+    resolve_exam_url_for_learning_mfe,
     verify_and_add_wait_deadline
 )
 
@@ -615,9 +615,7 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     # resolve the LMS url, note we can't assume we're running in
     # a same process as the LMS
     if is_learning_mfe:
-        course_key = CourseKey.from_string(exam['course_id'])
-        usage_key = UsageKey.from_string(exam['content_id'])
-        exam_url_path = '{}/course/{}/{}'.format(settings.LEARNING_MICROFRONTEND_URL, course_key, usage_key)
+        exam_url_path = resolve_exam_url_for_learning_mfe(exam['course_id'], exam['content_id'])
 
     else:
         exam_url_path = reverse('jump_to', args=[exam['course_id'], exam['content_id']])

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -3105,6 +3105,32 @@ class GetExamAttemptDataTests(ProctoredExamTestCase):
         # make sure we have the accessible human string
         self.assertEqual(data['accessibility_time_string'], 'you have 1 hour and 30 minutes remaining')
 
+    def test_get_exam_attempt_has_total_time_if_status_is_ready_to_resume(self):
+        """
+        Test Case that exam attempt data contains total_time when exam attempt is in ready_to_resume status.
+        """
+        proctored_exam = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            external_id='123aXqe3',
+            time_limit_mins=90,
+            is_proctored=True,
+        )
+
+        attempt = ProctoredExamStudentAttempt.objects.create(
+            proctored_exam=proctored_exam,
+            user=self.user,
+            allowed_time_limit_mins=90,
+            taking_as_proctored=True,
+            is_sample_attempt=False,
+            external_id=proctored_exam.external_id,
+            status=ProctoredExamStudentAttemptStatus.ready_to_resume
+        )
+
+        data = get_exam_attempt_data(proctored_exam.id, attempt.id)
+        self.assertEqual(data['total_time'], '1 hour and 30 minutes')
+
 
 @ddt.ddt
 class CheckPrerequisitesTests(ProctoredExamTestCase):

--- a/edx_proctoring/tests/test_mfe_views.py
+++ b/edx_proctoring/tests/test_mfe_views.py
@@ -256,6 +256,26 @@ class ProctoredExamAttemptsMFEViewTests(ProctoredExamTestCase):
         assert 'onboarding_link' in exam
         self.assertEqual(expected_exam_url, exam['onboarding_link'])
 
+    def test_exam_data_does_not_fail_if_onboarding_errors_and_no_onboarding_exam(self):
+        """
+        Tests the GET exam attempts data not contain link to onboarding exam if
+        when user tries to take proctored exam and has not yet completed required
+        onboarding exam and onboarding exam is not found.
+        """
+        self._create_exam_attempt(self.proctored_exam_id, status=ProctoredExamStudentAttemptStatus.onboarding_missing)
+        url = reverse(
+            'edx_proctoring:proctored_exam.exam_attempts',
+            kwargs={
+                'course_id': self.course_id,
+                'content_id': self.content_id
+            }
+        ) + '?is_learning_mfe=true'
+        with patch('edx_proctoring.models.ProctoredExam.objects.filter', return_value=ProctoredExam.objects.none()):
+            response = self.client.get(url)
+        response_data = json.loads(response.content.decode('utf-8'))
+        exam = response_data['exam']
+        assert 'onboarding_link' not in exam
+
 
 class ProctoredSettingsViewTests(ProctoredExamTestCase):
     """

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -12,7 +12,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_when import api as when_api
 from eventtracking import tracker
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
@@ -321,3 +321,11 @@ def get_exam_type(exam, provider):
         'type': exam_type,
         'humanized_type': humanized_type,
     }
+
+
+def resolve_exam_url_for_learning_mfe(course_id, content_id):
+    """ Helper that builds the url to the exam for the MFE app learning. """
+    course_key = CourseKey.from_string(course_id)
+    usage_key = UsageKey.from_string(content_id)
+    url = '{}/course/{}/{}'.format(settings.LEARNING_MICROFRONTEND_URL, course_key, usage_key)
+    return url

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -94,7 +94,8 @@ from edx_proctoring.utils import (
     get_visibility_check_date,
     humanized_time,
     locate_attempt_by_attempt_code,
-    obscured_user_id
+    obscured_user_id,
+    resolve_exam_url_for_learning_mfe
 )
 
 ATTEMPTS_PER_PAGE = 25
@@ -241,6 +242,23 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                 # prerequisites for practice or onboarding exams
                 elif exam['is_proctored'] and not exam['is_practice_exam']:
                     exam = check_prerequisites(exam, request.user.id)
+
+                # if user hasn't completed required onboarding exam before taking
+                # proctored exam we need to navigate them to it with a link
+                if (exam['is_proctored'] and attempt_data and
+                        attempt_data['attempt_status'] in ProctoredExamStudentAttemptStatus.onboarding_errors):
+                    onboarding_exam = ProctoredExam.objects.filter(course_id=course_id,
+                                                                   is_active=True,
+                                                                   is_practice_exam=True).first()
+                    if onboarding_exam.exists():
+                        if is_learning_mfe:
+                            onboarding_link = resolve_exam_url_for_learning_mfe(
+                                course_id,
+                                onboarding_exam.content_id
+                            )
+                        else:
+                            onboarding_link = reverse('jump_to', args=[course_id, onboarding_exam.content_id])
+                        exam['onboarding_link'] = onboarding_link
                 exam.update({'attempt': attempt_data})
             except ProctoredExamNotFoundException:
                 exam = {}

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -247,10 +247,10 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                 # proctored exam we need to navigate them to it with a link
                 if (exam['is_proctored'] and attempt_data and
                         attempt_data['attempt_status'] in ProctoredExamStudentAttemptStatus.onboarding_errors):
-                    onboarding_exam = ProctoredExam.objects.filter(course_id=course_id,
-                                                                   is_active=True,
-                                                                   is_practice_exam=True).first()
-                    if onboarding_exam.exists():
+                    onboarding_exam = ProctoredExam.objects.filter(
+                        course_id=course_id, is_active=True, is_practice_exam=True
+                    ).first()
+                    if onboarding_exam:
                         if is_learning_mfe:
                             onboarding_link = resolve_exam_url_for_learning_mfe(
                                 course_id,

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -247,6 +247,7 @@ class ProctoredExamAttemptView(ProctoredAPIView):
         if exam:
             provider = get_backend_provider(exam)
             exam['type'] = get_exam_type(exam, provider)['type']
+            exam['passed_due_date'] = is_exam_passed_due(exam, user=request.user.id)
         response_dict = {
             'exam': exam,
             'active_attempt': active_attempt_data,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

This PR further extends exam attempt API to check if exam has passed due date and to return total time remaining in attempt and a link to onboarding exam if user tries to take proctored exam when they haven't completed required onboarding exam.
Also added proctoring_escalation_email to proctoring settings API response data.

**JIRA:**

[EDUCATOR-5808](https://openedx.atlassian.net/browse/EDUCATOR-5808)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.