### PR TITLE
re-enable fail_ci_if_error setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         flags: unittests
-        fail_ci_if_error: false
+        fail_ci_if_error: true


### PR DESCRIPTION
**Description:**

Codecov was experiencing issues (see https://github.com/codecov/codecov-action/issues/330) so `fail_ci_if_error` was disabled to allow PRs to be merged. This setting should be re-enabled when codecov has resolved the problem.

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.