### PR TITLE
fix: only request backend status update to started once

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,17 +13,22 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[3.13.1] - 2021-06-08
+~~~~~~~~~~~~~~~~~~~~~
+* If an attempt transitions from `ready_to_submit` back to `started`, the proctoring provider
+  backend function `start_exam_attempt` will not be called.
+
+[3.13.0] - 2021-06-07
+~~~~~~~~~~~~~~~~~~~~~
+* If the Django setting `PROCTORED_EXAM_VIEWABLE_PAST_DUE` is false, exam content will not be viewable past
+  an exam's due date, even if a learner has acknowledged their status.
 * Extend exam attempt API to return exam type and to check if
   user has satisfied prerequisites before taking proctored exam.
 * Extend proctoring settings API to return additional data about proctoring
   provider.
 * Add API endpoint which provides exam review policy for specific exam.
   Usage case is to provide required data for the learning app MFE.
-
-[3.13.0] - 2021-06-07
-~~~~~~~~~~~~~~~~~~~~~
-* If the Django setting `PROCTORED_EXAM_VIEWABLE_PAST_DUE` is false, exam content will not be viewable past
-  an exam's due date, even if a learner has acknowledged their status.
 
 [3.12.0] - 2021-06-04
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.13.0'
+__version__ = '3.13.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1404,7 +1404,11 @@ def update_attempt_status(attempt_id, to_status,
         # only proctored/practice exams have a backend
         # timed exams have no backend
         backend_method = None
-        if to_status == ProctoredExamStudentAttemptStatus.started:
+
+        # add_start_time will only have a value of true if this is the first time an
+        # attempt is transitioning to started. We only want to notify the backend
+        # for the first time an attempt is transitioned to a started status (MST-862).
+        if to_status == ProctoredExamStudentAttemptStatus.started and add_start_time:
             backend_method = backend.start_exam_attempt
         elif to_status == ProctoredExamStudentAttemptStatus.submitted:
             backend_method = backend.stop_exam_attempt

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

If a user is on the ready to submit panel, but chooses to continue in the exam, their attempt status will be updated to started. Each time an attempt status is updated to started, we previously would make a call to the proctoring provider backend to let them know that the attempt has started. Verificient uses the most recent status update to started to calculate how long a learner’s attempt is, resulting in different attempt durations shown to instructors on the edX attempt panel versus on the Proctortrack review dashboard. 

With these changes, we will only make a call to the proctoring provider backend when an exam attempt is updated to `started` if it is the first time that attempt is transitioning to `started`.


**JIRA:**

[MST-862](https://openedx.atlassian.net/browse/MST-862)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.