### PR TITLE
Add Post Bulk Allowance Endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.15.0] - 2021-06-15
+~~~~~~~~~~~~~~~~~~~~~
+* Created a POST api endpoint to add allowances for multiple students and multiple exams at the same time.
+
 [3.14.0] - 2021-06-10
 ~~~~~~~~~~~~~~~~~~~~~
 * When an exam attempt is finished for the first time, mark all completable children in the exam as complete

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.14.0'
+__version__ = '3.15.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -7,7 +7,7 @@ API which is in the views.py file, per edX coding standards
 
 import logging
 import uuid
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 
 import pytz
 from opaque_keys import InvalidKeyError
@@ -519,8 +519,8 @@ def add_bulk_allowances(exam_ids, user_ids, allowance_type, value):
         ).format(value=value)
         try:
             multiplier = float(value) - 1
-        except ValueError:
-            raise AllowanceValueNotAllowedException(err_msg)
+        except ValueError as error:
+            raise AllowanceValueNotAllowedException(err_msg) from error
         if multiplier >= 0:
             for exam_id in exam_ids:
                 try:

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -503,7 +503,8 @@ def add_bulk_allowances(exam_ids, user_ids, allowance_type, value):
         for exam_id in exam_ids:
             time_allowed = str(round(get_exam_by_id(exam_id)["time_limit_mins"] * (float(value) - 1)))
             for user_id in user_ids:
-                add_allowance_for_user(exam_id, user_id, ProctoredExamStudentAllowance.ADDITIONAL_TIME_GRANTED, time_allowed)
+                add_allowance_for_user(exam_id, user_id, 
+                ProctoredExamStudentAllowance.ADDITIONAL_TIME_GRANTED, time_allowed)
     else:
         for exam_id in exam_ids:
             for user_id in user_ids:

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -531,7 +531,7 @@ def add_bulk_allowances(exam_ids, user_ids, allowance_type, value):
                     )
                     log.error(log_message)
                     continue
-                
+
                 exam_time = target_exam["time_limit_mins"]
                 added_time = round(exam_time * multiplier)
                 time_allowed = str(added_time)
@@ -555,8 +555,7 @@ def add_bulk_allowances(exam_ids, user_ids, allowance_type, value):
         err_msg = (
             u'allowance_value "{value}" should be non-negative integer value.'
         ).format(value=value)
-        if ProctoredExamStudentAllowance.is_allowance_value_valid(ProctoredExamStudentAllowance.ADDITIONAL_TIME_GRANTED,
-                                                                  value):
+        if value.isdigit():
             for exam_id in exam_ids:
                 try:
                     target_exam = get_exam_by_id(exam_id)
@@ -1664,7 +1663,7 @@ def reset_practice_exam(exam_id, user_id, requesting_user):
             user_id=user_id,
         )
     )
-    (log_msg)
+    log.info(log_msg)
 
     exam_attempt_obj = ProctoredExamStudentAttempt.objects.get_current_exam_attempt(exam_id, user_id)
     if exam_attempt_obj is None:

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -493,6 +493,25 @@ def remove_allowance_for_user(exam_id, user_id, key):
         emit_event(exam, 'allowance.deleted', override_data=data)
 
 
+def add_bulk_allowances(exam_ids, user_ids, allowance_type, value):
+    """
+    Adds (or updates) an allowance for multiple users and exams
+    """
+    exam_ids = set(exam_ids)
+    user_ids = set(user_ids)
+    if allowance_type == 'time_multiplier':
+        for exam_id in exam_ids:
+            time_allowed = str(round(get_exam_by_id(exam_id)["time_limit_mins"] * (float(value) - 1)))
+            for user_id in user_ids:
+                add_allowance_for_user(exam_id, user_id, ProctoredExamStudentAllowance.ADDITIONAL_TIME_GRANTED, time_allowed)
+    else:
+        for exam_id in exam_ids:
+            for user_id in user_ids:
+                add_allowance_for_user(exam_id, user_id, ProctoredExamStudentAllowance.ADDITIONAL_TIME_GRANTED, value)
+
+
+
+
 def _check_for_attempt_timeout(attempt):
     """
     Helper method to see if the status of an

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -74,4 +74,4 @@ CONTENT_VIEWABLE_PAST_DUE_DATE = getattr(settings, 'PROCTORED_EXAM_VIEWABLE_PAST
 
 TIME_MULTIPLIER = 'time_multiplier'
 
-ADDITIONAL_TIME = 'additional_time' 
+ADDITIONAL_TIME = 'additional_time'

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -71,3 +71,7 @@ PING_FAILURE_PASSTHROUGH_TEMPLATE = 'edx_proctoring.{}_ping_failure_passthrough'
 ONBOARDING_PROFILE_API = 'edx_proctoring.onboarding_profile_api'
 
 CONTENT_VIEWABLE_PAST_DUE_DATE = getattr(settings, 'PROCTORED_EXAM_VIEWABLE_PAST_DUE', False)
+
+TIME_MULTIPLIER = 'time_multiplier'
+
+ADDITIONAL_TIME = 'additional_time' 

--- a/edx_proctoring/exceptions.py
+++ b/edx_proctoring/exceptions.py
@@ -73,7 +73,7 @@ class UserNotFoundException(ProctoredBaseException):
 
 class AllowanceValueNotAllowedException(ProctoredBaseException):
     """
-    Raised when the allowance value is not an non-negative integer
+    Raised when the allowance value is not an non-negative integer or float
     """
 
 

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -64,6 +64,7 @@ from edx_proctoring.api import (
     update_exam_attempt,
     update_review_policy
 )
+from edx_proctoring.backends.tests.test_backend import TestBackendProvider
 from edx_proctoring.constants import ADDITIONAL_TIME, DEFAULT_CONTACT_EMAIL, TIME_MULTIPLIER
 from edx_proctoring.exceptions import (
     AllowanceValueNotAllowedException,

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -4721,7 +4721,7 @@ class ExamBulkAllowanceView(LoggedInTestCase):
             json.dumps(allowance_data),
             content_type='application/json'
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 207)
 
     @ddt.data(
         (
@@ -4768,7 +4768,7 @@ class ExamBulkAllowanceView(LoggedInTestCase):
             json.dumps(allowance_data),
             content_type='application/json'
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 207)
 
     @ddt.data(
         (
@@ -4813,6 +4813,84 @@ class ExamBulkAllowanceView(LoggedInTestCase):
             'user_ids': user_id_list,
             'allowance_type': allowance_type,
             'value': value
+        }
+        response = self.client.put(
+            reverse('edx_proctoring:proctored_exam.bulk_allowance'),
+            json.dumps(allowance_data),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_bulk_allowance_all_invalid_data(self):  # pylint: disable=invalid-name
+        """
+        Test to add bulk allowance with invalid exams and users
+        """
+        # Create exams.
+        user_id_list = ['invalid', 'invalid2', 'invalid3']
+        exam_list = [-99, -98]
+
+        allowance_data = {
+            'exam_ids': exam_list,
+            'user_ids': user_id_list,
+            'allowance_type': ADDITIONAL_TIME,
+            'value': '30'
+        }
+        response = self.client.put(
+            reverse('edx_proctoring:proctored_exam.bulk_allowance'),
+            json.dumps(allowance_data),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_bulk_allowance_no_users(self):  # pylint: disable=invalid-name
+        """
+        Test to add bulk allowance with no users
+        """
+        # Create exams.
+        user_id_list = []
+        exam1 = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            time_limit_mins=90,
+            is_active=True
+            )
+        exam2 = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content2',
+            exam_name='Test Exam2',
+            time_limit_mins=90,
+            is_active=True
+            )
+        exam_list = [exam1.id, exam2.id]
+
+        allowance_data = {
+            'exam_ids': exam_list,
+            'user_ids': user_id_list,
+            'allowance_type': ADDITIONAL_TIME,
+            'value': '30'
+        }
+        response = self.client.put(
+            reverse('edx_proctoring:proctored_exam.bulk_allowance'),
+            json.dumps(allowance_data),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_bulk_allowance_no_exams(self):  # pylint: disable=invalid-name
+        """
+        Test to add bulk allowance with no exams
+        """
+        # Create exams.
+        user_list = self.create_batch_users(3)
+        user_id_list = [user.email for user in user_list]
+        exam_list = []
+
+        allowance_data = {
+            'exam_ids': exam_list,
+            'user_ids': user_id_list,
+            'allowance_type': ADDITIONAL_TIME,
+            'value': '30'
         }
         response = self.client.put(
             reverse('edx_proctoring:proctored_exam.bulk_allowance'),

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -19,7 +19,6 @@ from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 
-from edx_proctoring.constants import ADDITIONAL_TIME, TIME_MULTIPLIER
 from edx_proctoring.api import (
     _calculate_allowed_mins,
     add_allowance_for_user,
@@ -33,6 +32,7 @@ from edx_proctoring.api import (
 from edx_proctoring.backends.tests.test_backend import TestBackendProvider
 from edx_proctoring.backends.tests.test_review_payload import create_test_review_payload
 from edx_proctoring.backends.tests.test_software_secure import mock_response_content
+from edx_proctoring.constants import ADDITIONAL_TIME, TIME_MULTIPLIER
 from edx_proctoring.exceptions import (
     BackendProviderOnboardingProfilesException,
     ProctoredExamIllegalStatusTransition,

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -23,6 +23,7 @@ from django.utils import timezone
 from edx_proctoring.api import (
     _calculate_allowed_mins,
     add_allowance_for_user,
+    add_bulk_allowances,
     create_exam,
     create_exam_attempt,
     get_backend_provider,
@@ -4569,7 +4570,102 @@ class TestExamAllowanceView(LoggedInTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+class ExamBulkAllowanceView(LoggedInTestCase):
+    """
 
+    Tests for the ExamBulkAllowanceView
+    """
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.login_user(self.user)
+        self.student_taking_exam = User()
+        self.student_taking_exam.save()
+
+        set_runtime_service('instructor', MockInstructorService(is_user_course_staff=True))
+        
+    def test_add_bulk_time_allowances(self):
+        """
+        Add bulk time allowance for multiple users and exams
+        """
+        # Create an exam.
+        user_list = self.create_batch_users(3)
+        user_id_list = [user.email for user in user_list]
+        #pdb.set_trace()
+        exam_list = [
+            create_exam(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            time_limit_mins=90,
+            is_active=True
+            ),
+            create_exam(
+            course_id='a/b/c',
+            content_id='test_content2',
+            exam_name='Test Exam2',
+            time_limit_mins=90,
+            is_active=True
+            )]
+
+        allowance_data = {
+            'exam_ids': exam_list,
+            'user_ids': user_id_list,
+            'allowance_type': 'additional_time',
+            'value': '30'
+        }
+        response = self.client.put(
+            reverse('edx_proctoring:proctored_exam.bulk_allowance'),
+            json.dumps(allowance_data),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+    def test_add_allowance_non_staff_user(self):  # pylint: disable=invalid-name
+        """
+        Test to add bulk allowance with not staff/global user
+        returns forbidden response.
+        """
+        self.user.is_staff = False
+        self.user.save()
+        set_runtime_service('instructor', MockInstructorService(is_user_course_staff=False))
+        # Create exams.
+        user_list = self.create_batch_users(3)
+        user_id_list = [user.email for user in user_list]
+        exam1 = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content',
+            exam_name='Test Exam',
+            time_limit_mins=90,
+            is_active=True
+            )
+        exam2 = ProctoredExam.objects.create(
+            course_id='a/b/c',
+            content_id='test_content2',
+            exam_name='Test Exam2',
+            time_limit_mins=90,
+            is_active=True
+            )
+        exam_list = [exam1.id, exam2.id]
+
+        allowance_data = {
+            'exam_ids': exam_list,
+            'user_ids': user_id_list,
+            'allowance_type': 'additional_time',
+            'value': '30'
+        }
+        response = self.client.put(
+            reverse('edx_proctoring:proctored_exam.bulk_allowance', kwargs={'course_id': exam1.course_id}),
+            json.dumps(allowance_data),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 403)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['detail'], 'Must be a Staff User to Perform this request.')
+
+        
 class TestActiveExamsForUserView(LoggedInTestCase):
     """
     Tests for the ActiveExamsForUserView

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -23,7 +23,6 @@ from django.utils import timezone
 from edx_proctoring.api import (
     _calculate_allowed_mins,
     add_allowance_for_user,
-    add_bulk_allowances,
     create_exam,
     create_exam_attempt,
     get_backend_provider,
@@ -4584,7 +4583,7 @@ class ExamBulkAllowanceView(LoggedInTestCase):
         self.student_taking_exam.save()
 
         set_runtime_service('instructor', MockInstructorService(is_user_course_staff=True))
-        
+
     def test_add_bulk_time_allowances(self):
         """
         Add bulk time allowance for multiple users and exams
@@ -4665,7 +4664,7 @@ class ExamBulkAllowanceView(LoggedInTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response_data['detail'], 'Must be a Staff User to Perform this request.')
 
-        
+
 class TestActiveExamsForUserView(LoggedInTestCase):
     """
     Tests for the ActiveExamsForUserView

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -81,6 +81,16 @@ urlpatterns = [
         name='proctored_exam.allowance'
     ),
     url(
+        r'edx_proctoring/v1/proctored_exam/{}/bulk_allowance$'.format(settings.COURSE_ID_PATTERN),
+        views.ExamBulkAllowanceView.as_view(),
+        name='proctored_exam.bulk_allowance'
+    ),
+    url(
+        r'edx_proctoring/v1/proctored_exam/bulk_allowance$',
+        views.ExamBulkAllowanceView.as_view(),
+        name='proctored_exam.bulk_allowance'
+    ),
+    url(
         r'edx_proctoring/v1/proctored_exam/active_exams_for_user$',
         views.ActiveExamsForUserView.as_view(),
         name='proctored_exam.active_exams_for_user'

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1370,6 +1370,7 @@ class ExamAllowanceView(ProctoredAPIView):
             key=request.data.get('key', None)
         ))
 
+
 class ExamBulkAllowanceView(ProctoredAPIView):
     """
     Endpoint for the Exam Allowance
@@ -1390,7 +1391,7 @@ class ExamBulkAllowanceView(ProctoredAPIView):
     **PUT data Parameters**
         * exam_ids: The set of unique identifiers for the exams.
         * user_ids: The set of unique identifiers for the students.
-        * allowance_type: key for the allowance entry, either 'additional_time' or 'time_multiplier'
+        * allowance_type: key for the allowance entry, either ADDITIONAL_TIME or TIME_MULTIPLIER
         * value: value for the allowance entry.
 
     **Response Values**
@@ -1408,6 +1409,7 @@ class ExamBulkAllowanceView(ProctoredAPIView):
             allowance_type=request.data.get('allowance_type', None),
             value=request.data.get('value', None)
         ))
+
 
 class ActiveExamsForUserView(ProctoredAPIView):
     """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -29,6 +29,7 @@ from django.utils.translation import ugettext as _
 from edx_proctoring import constants
 from edx_proctoring.api import (
     add_allowance_for_user,
+    add_bulk_allowances,
     check_prerequisites,
     create_exam,
     create_exam_attempt,
@@ -1369,6 +1370,44 @@ class ExamAllowanceView(ProctoredAPIView):
             key=request.data.get('key', None)
         ))
 
+class ExamBulkAllowanceView(ProctoredAPIView):
+    """
+    Endpoint for the Exam Allowance
+    /edx_proctoring/v1/proctored_exam/bulk_allowance
+
+    Supports:
+        HTTP PUT: Creates or Updates the allowances for multiple users and multiple exams.
+
+    HTTP PUT
+    Adds or updates multiple exam and student allowances.
+    PUT data : {
+        "exam_ids": [1, 2, 3],
+        "user_ids": [1, 2],
+        "allowance_type": 'extra_time',
+        "value": '10'
+    }
+
+    **PUT data Parameters**
+        * exam_ids: The set of unique identifiers for the exams.
+        * user_ids: The set of unique identifiers for the students.
+        * allowance_type: key for the allowance entry, either 'additional_time' or 'time_multiplier'
+        * value: value for the allowance entry.
+
+    **Response Values**
+        * returns Nothing. Add or update the allowances for the users and exams.
+    """
+
+    @method_decorator(require_course_or_global_staff)
+    def put(self, request):
+        """
+        HTTP PUT handler. Adds or updates Allowances for many exams and students
+        """
+        return Response(add_bulk_allowances(
+            exam_ids=request.data.get('exam_ids', None),
+            user_ids=request.data.get('user_ids', None),
+            allowance_type=request.data.get('allowance_type', None),
+            value=request.data.get('value', None)
+        ))
 
 class ActiveExamsForUserView(ProctoredAPIView):
     """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1424,13 +1424,13 @@ class ExamBulkAllowanceView(ProctoredAPIView):
         HTTP PUT handler. Adds or updates Allowances for many exams and students
         """
         try:
-            data, succesess, failures = add_bulk_allowances(
+            data, successes, failures = add_bulk_allowances(
                 exam_ids=request.data.get('exam_ids', None),
                 user_ids=request.data.get('user_ids', None),
                 allowance_type=request.data.get('allowance_type', None),
                 value=request.data.get('value', None)
             )
-            if succesess == 0:
+            if successes == 0:
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
                     data=data

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
Implement the bulk allowance post endpoint. Had some questions regarding the implementation. I was wondering what the expected behavior should be if one of the exams or users passed were to be invalid? Should we add the allowances for all the other users and return a 200 response? Or should we not add any of the allowances and return a 400 error?

**Description:**

Adds a post endpoint for bulk allowances, adds functions to the views.py and api.py files.

**JIRA:**

[MST-809](https://openedx.atlassian.net/browse/MST-809)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.