### PR TITLE
[MST-761] Use Provider Onboarding Profile API for Course Onboarding API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.17.0] - 2021-06-23
+~~~~~~~~~~~~~~~~~~~~~
+* Replace internal logic for determing learners' onboarding statuses for the course onboarding API
+  with provider onboarding API.
+
 [3.16.0] - 2021-06-22
 ~~~~~~~~~~~~~~~~~~~~~
 * Created a GET api endpoint which groups course allowances by users.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.16.0'
+__version__ = '3.17.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -70,6 +70,8 @@ PING_FAILURE_PASSTHROUGH_TEMPLATE = 'edx_proctoring.{}_ping_failure_passthrough'
 
 ONBOARDING_PROFILE_API = 'edx_proctoring.onboarding_profile_api'
 
+ONBOARDING_PROFILE_INSTRUCTOR_DASHBOARD_API = 'edx_proctoring.onboarding_profile_instructor_dashboard_api'
+
 CONTENT_VIEWABLE_PAST_DUE_DATE = getattr(settings, 'PROCTORED_EXAM_VIEWABLE_PAST_DUE', False)
 
 TIME_MULTIPLIER = 'time_multiplier'

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
@@ -3,7 +3,7 @@ edx = edx || {};
 (function(Backbone, $, _, gettext) {
     'use strict';
 
-    var viewHelper, onboardingStatuses, statusAndModeReadableFormat;
+    var viewHelper, onboardingStatuses, onboardingProfileAPIStatuses, statusAndModeReadableFormat;
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
     onboardingStatuses = [
@@ -16,6 +16,14 @@ edx = edx || {};
         'rejected',
         'error'
     ];
+    onboardingProfileAPIStatuses = [
+        'not_started',
+        'other_course_approved',
+        'submitted',
+        'verified',
+        'rejected',
+        'expired'
+    ];
     statusAndModeReadableFormat = {
         // Onboarding statuses
         not_started: gettext('Not Started'),
@@ -27,6 +35,7 @@ edx = edx || {};
         verified: gettext('Verified'),
         rejected: gettext('Rejected'),
         error: gettext('Error'),
+        expired: gettext('Expired'),
         // TODO: remove as part of MST-745
         onboarding_reset_past_due: gettext('Onboarding Reset Failed Due to Past Due Exam'),
         // Enrollment modes (Note: 'verified' is both a status and enrollment mode)
@@ -186,11 +195,21 @@ edx = edx || {};
                     $searchIcon = $(document.getElementById('onboarding-search-indicator'));
                     $searchIcon.removeClass('hidden');
                 },
-                error: function() {
+                error: function(unused, response) {
+                    var data, $searchIcon, $spinner, $errorResponse, $onboardingPanel;
+
                     // in the case that there is no onboarding data, we
                     // still want the view to render
-                    var $searchIcon, $spinner;
                     self.render();
+
+                    data = $.parseJSON(response.responseText);
+                    if (data.detail) {
+                        $errorResponse = $('#error-response');
+                        $errorResponse.html(data.detail);
+                        $onboardingPanel = $('.onboarding-status-content');
+                        $onboardingPanel.hide();
+                    }
+
                     $spinner = $(document.getElementById('onboarding-loading-indicator'));
                     $spinner.addClass('hidden');
                     $searchIcon = $(document.getElementById('onboarding-search-indicator'));
@@ -202,7 +221,8 @@ edx = edx || {};
             this.hydrate();
         },
         render: function() {
-            var data, dataJson, html, startPage, endPage;
+            var data, dataJson, html, startPage, endPage, statuses;
+
             if (this.template !== null) {
                 data = {
                     previousPage: null,
@@ -234,12 +254,13 @@ edx = edx || {};
                         endPage = dataJson.num_pages;
                     }
 
+                    statuses = dataJson.use_onboarding_profile_api ? onboardingProfileAPIStatuses : onboardingStatuses;
                     data = {
                         previousPage: dataJson.previous,
                         nextPage: dataJson.next,
                         currentPage: this.currentPage,
                         onboardingItems: dataJson.results,
-                        onboardingStatuses: onboardingStatuses,
+                        onboardingStatuses: statuses,
                         inSearchMode: this.inSearchMode,
                         searchText: this.searchText,
                         filters: this.filters,

--- a/edx_proctoring/static/proctoring/templates/student-onboarding-status.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-onboarding-status.underscore
@@ -27,11 +27,12 @@
             margin-left: 10px;
         }
 
-        .no-onboarding-data {
+        .no-onboarding-data, .onboarding-error {
             margin: 20px;
             font-weight: bold;
         }
     </style>
+    <h3 class="error-response" id="error-response"></h3>
     <% var isOnboardingItems = onboardingItems.length !== 0 %>
         <div class="content onboarding-status-content">
             <div class="top-header">
@@ -45,8 +46,8 @@
                         <span class="icon fa fa-search" id="onboarding-search-indicator" aria-hidden="true"></span>
                         <div aria-live="polite" aria-relevant="all">
                             <div id="onboarding-loading-indicator" class="hidden">
-                              <span class="icon fa fa-spinner fa-pulse" aria-hidden="true"></span>
-                              <span class="sr"><%- gettext("Loading") %></span>
+                                <span class="icon fa fa-spinner fa-pulse" aria-hidden="true"></span>
+                                <span class="sr"><%- gettext("Loading") %></span>
                             </div>
                         </div>
                     </span>
@@ -78,13 +79,13 @@
                     <li class="disabled">
                     <a aria-label="Next">
                         <span aria-hidden="true">&raquo;</span>
-                      </a>
+                    </a>
                     </li>
                     <% } else { %>
                     <li>
                     <a class="target-link" href="#" aria-label="Next" data-page-number="<%= currentPage + 1 %>"
                     >
-                      <span aria-hidden="true">&raquo;</span>
+                        <span aria-hidden="true">&raquo;</span>
                     </a>
                     </li>
                     <% }%>
@@ -98,7 +99,7 @@
                             <input type="checkbox" id="<%= status %>" name="status-filters" value="<%= status %>"
                             <% if (filters.includes(status)) { %>checked="true"<% } %>>
                             <label for="<%= status %>">
-                                <%- interpolate(gettext(" %(onboardingStatus)s "), 
+                                <%- interpolate(gettext(" %(onboardingStatus)s "),
                                 { onboardingStatus: getReadableString(status) }, true) %>
                             </label>
                         </li>
@@ -126,11 +127,11 @@
                                 <%- interpolate(gettext(" %(username)s "), { username: item.username }, true) %>
                             </td>
                             <td>
-                                <%- interpolate(gettext(" %(enrollmentMode)s "), 
+                                <%- interpolate(gettext(" %(enrollmentMode)s "),
                                 { enrollmentMode: getReadableString(item.enrollment_mode) }, true) %>
                             </td>
                             <td>
-                                <%- interpolate(gettext(" %(onboardingStatus)s "), 
+                                <%- interpolate(gettext(" %(onboardingStatus)s "),
                                 { onboardingStatus: getReadableString(item.status) }, true) %>
                             </td>
                             <td><%= getDateFormat(item.modified) %></td>

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -251,6 +251,7 @@ class InstructorDashboardOnboardingAttemptStatus:
     rejected = 'rejected'
     verified = 'verified'
     error = 'error'
+    expired = 'expired'
 
     # The following status is not a true attempt status, but is used when the
     # user's onboarding profile is approved in a different course.
@@ -273,7 +274,8 @@ class InstructorDashboardOnboardingAttemptStatus:
         ProctoredExamStudentAttemptStatus.submitted: submitted,
         ProctoredExamStudentAttemptStatus.rejected: rejected,
         ProctoredExamStudentAttemptStatus.verified: verified,
-        ProctoredExamStudentAttemptStatus.error: error
+        ProctoredExamStudentAttemptStatus.error: error,
+        ProctoredExamStudentAttemptStatus.expired: expired
     }
 
     @classmethod
@@ -304,11 +306,20 @@ class VerificientOnboardingProfileStatus:
 
     profile_status_mapping = {
         no_profile: None,
-        approved: ProctoredExamStudentAttemptStatus.verified,
+        approved: InstructorDashboardOnboardingAttemptStatus.verified,
         other_course_approved: InstructorDashboardOnboardingAttemptStatus.other_course_approved,
-        rejected: ProctoredExamStudentAttemptStatus.rejected,
-        expired: ProctoredExamStudentAttemptStatus.expired,
-        pending: ProctoredExamStudentAttemptStatus.submitted
+        rejected: InstructorDashboardOnboardingAttemptStatus.rejected,
+        expired: InstructorDashboardOnboardingAttemptStatus.expired,
+        pending: InstructorDashboardOnboardingAttemptStatus.submitted
+    }
+
+    filter_status_mapping = {
+        InstructorDashboardOnboardingAttemptStatus.not_started: no_profile,
+        InstructorDashboardOnboardingAttemptStatus.submitted: pending,
+        InstructorDashboardOnboardingAttemptStatus.other_course_approved: other_course_approved,
+        InstructorDashboardOnboardingAttemptStatus.verified: approved,
+        InstructorDashboardOnboardingAttemptStatus: rejected,
+        InstructorDashboardOnboardingAttemptStatus.expired: expired
     }
 
     @classmethod
@@ -317,6 +328,28 @@ class VerificientOnboardingProfileStatus:
         Get the internal attempt status given a status from the onboarding api
 
         Parameters:
-            * status (str):
+            * status (str): status from Verficient's onboarding API endpoint
         """
         return cls.profile_status_mapping.get(api_status)
+
+    @classmethod
+    def get_profile_status_from_filter(cls, filter_status):
+        """
+        Get the verificient profile status given an edx status for filtering
+
+        Parameters:
+            * status (str): edX onboarding status
+        """
+        return cls.filter_status_mapping.get(filter_status)
+
+    @classmethod
+    def get_instructor_status_from_profile_status(cls, api_status):
+        """
+        Get the instructor onboarding status given a status from the onboarding api
+
+        Parameters:
+            * status (str): status from Verficient's onboarding API endpoint
+        """
+        if api_status == cls.no_profile:
+            return InstructorDashboardOnboardingAttemptStatus.not_started
+        return cls.get_edx_status_from_profile_status(api_status)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

This pull request makes a change to the method of determining learners' onboarding statuses in a course via the StudentOnboardingStatusByCourseView. Instead of using internal logic to determine onboarding statuses, the provider's onboarding API will be used instead.

**JIRA:**

[MST-761](https://openedx.atlassian.net/browse/MST-761)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.