### PR TITLE
[BD-26] Extend exam attempt API to check if user can continue exam if attempt is in ready_to_submit status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.13.3] - 2021-06-10
+~~~~~~~~~~~~~~~~~~~~~
+* Extend exam attempt API to check if user can continue
+  taking exam when attempt is in ready_to_submit status.
+
 [3.13.2] - 2021-06-09
 ~~~~~~~~~~~~~~~~~~~~~
 * Extend exam attempt API to return total time left in the attempt

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.13.2'
+__version__ = '3.13.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -649,9 +649,8 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     }
 
     if attempt['status'] == ProctoredExamStudentAttemptStatus.ready_to_submit:
-        can_continue = _does_time_remain(attempt)
-        if exam['is_proctored']:
-            can_continue = can_continue and provider and not provider.should_block_access_to_exam_material()
+        if (can_continue := _does_time_remain(attempt)) and exam['is_proctored']:
+            can_continue = provider and not provider.should_block_access_to_exam_material()
         attempt_data['can_continue'] = can_continue
 
     if provider:

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -623,7 +623,6 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     # a same process as the LMS
     if is_learning_mfe:
         exam_url_path = resolve_exam_url_for_learning_mfe(exam['course_id'], exam['content_id'])
-
     else:
         exam_url_path = reverse('jump_to', args=[exam['course_id'], exam['content_id']])
 
@@ -648,6 +647,12 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
             args=[attempt['id']]
         ),
     }
+
+    if attempt['status'] == ProctoredExamStudentAttemptStatus.ready_to_submit:
+        can_continue = _does_time_remain(attempt)
+        if exam['is_proctored']:
+            can_continue = can_continue and provider and not provider.should_block_access_to_exam_material()
+        attempt_data['can_continue'] = can_continue
 
     if provider:
         attempt_data.update({

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -3159,6 +3159,19 @@ class GetExamAttemptDataTests(ProctoredExamTestCase):
         data = get_exam_attempt_data(proctored_exam.id, attempt.id)
         self.assertEqual(data['total_time'], '1 hour and 30 minutes')
 
+    @ddt.data('timed_exam_id', 'proctored_exam_id')
+    def test_get_exam_attempt_checks_if_exam_can_be_continued_if_attempt_status_is_ready_to_submit(self, exam_id):
+        """
+        Tests that it is checked whether user can continue taking the exam
+        when attempt is in ready_to_submit status.
+        """
+        attempt = self._create_exam_attempt(
+            getattr(self, exam_id),
+            status=ProctoredExamStudentAttemptStatus.ready_to_submit,
+        )
+        data = get_exam_attempt_data(self.proctored_exam_id, attempt.id)
+        assert 'can_continue' in data
+
 
 @ddt.ddt
 class CheckPrerequisitesTests(ProctoredExamTestCase):

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Extend exam attempt API to check if user can continue taking exam when attempt is in ready_to_submit status.

**JIRA:**

[EDUCATOR-5827](https://openedx.atlassian.net/browse/EDUCATOR-5827)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.