### PR TITLE
[DRAFT] feat: Use Verificient Onboarding API for instructor dashboard if waffle flag is enabled

### DIFF
--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -69,7 +69,6 @@ VERIFICATION_DAYS_VALID = 730
 PING_FAILURE_PASSTHROUGH_TEMPLATE = 'edx_proctoring.{}_ping_failure_passthrough'
 
 ONBOARDING_PROFILE_API = 'edx_proctoring.onboarding_profile_api'
-ONBOARDING_PROFILE_INSTRUCTOR_DASHBOARD_API = 'edx_proctoring.onboarding_profile_instructor_dashboard_api'
 
 ONBOARDING_PROFILE_INSTRUCTOR_DASHBOARD_API = 'edx_proctoring.onboarding_profile_instructor_dashboard_api'
 

--- a/edx_proctoring/constants.py
+++ b/edx_proctoring/constants.py
@@ -69,6 +69,7 @@ VERIFICATION_DAYS_VALID = 730
 PING_FAILURE_PASSTHROUGH_TEMPLATE = 'edx_proctoring.{}_ping_failure_passthrough'
 
 ONBOARDING_PROFILE_API = 'edx_proctoring.onboarding_profile_api'
+ONBOARDING_PROFILE_INSTRUCTOR_DASHBOARD_API = 'edx_proctoring.onboarding_profile_instructor_dashboard_api'
 
 ONBOARDING_PROFILE_INSTRUCTOR_DASHBOARD_API = 'edx_proctoring.onboarding_profile_instructor_dashboard_api'
 

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
@@ -3,7 +3,7 @@ edx = edx || {};
 (function(Backbone, $, _, gettext) {
     'use strict';
 
-    var viewHelper, onboardingStatuses, statusAndModeReadableFormat;
+    var viewHelper, onboardingStatuses, onboardingProfileAPIStatuses, statusAndModeReadableFormat;
     edx.instructor_dashboard = edx.instructor_dashboard || {};
     edx.instructor_dashboard.proctoring = edx.instructor_dashboard.proctoring || {};
     onboardingStatuses = [
@@ -16,6 +16,14 @@ edx = edx || {};
         'rejected',
         'error'
     ];
+    onboardingProfileAPIStatuses = [
+        'not_started',
+        'other_course_approved',
+        'submitted',
+        'verified',
+        'rejected',
+        'expired'
+    ];
     statusAndModeReadableFormat = {
         // Onboarding statuses
         not_started: gettext('Not Started'),
@@ -27,6 +35,7 @@ edx = edx || {};
         verified: gettext('Verified'),
         rejected: gettext('Rejected'),
         error: gettext('Error'),
+        expired: gettext('Expired'),
         // TODO: remove as part of MST-745
         onboarding_reset_past_due: gettext('Onboarding Reset Failed Due to Past Due Exam'),
         // Enrollment modes (Note: 'verified' is both a status and enrollment mode)
@@ -59,6 +68,7 @@ edx = edx || {};
             this.collection = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingCollection();
             this.templateUrl = '/static/proctoring/templates/student-onboarding-status.underscore';
             this.courseId = this.$el.data('course-id');
+            this.enableProctoringApi = this.$el.data('use-onboarding-api');
             this.template = null;
 
             this.initialUrl = this.collection.url;
@@ -202,14 +212,15 @@ edx = edx || {};
             this.hydrate();
         },
         render: function() {
-            var data, dataJson, html, startPage, endPage;
+            var data, dataJson, html, startPage, endPage, statuses;
+            statuses = this.enableProctoringApi ? onboardingProfileAPIStatuses : onboardingStatuses;
             if (this.template !== null) {
                 data = {
                     previousPage: null,
                     nextPage: null,
                     currentPage: 1,
                     onboardingItems: [],
-                    onboardingStatuses: onboardingStatuses,
+                    onboardingStatuses: statuses,
                     inSearchMode: this.inSearchMode,
                     searchText: this.searchText,
                     filters: this.filters,
@@ -239,7 +250,7 @@ edx = edx || {};
                         nextPage: dataJson.next,
                         currentPage: this.currentPage,
                         onboardingItems: dataJson.results,
-                        onboardingStatuses: onboardingStatuses,
+                        onboardingStatuses: statuses,
                         inSearchMode: this.inSearchMode,
                         searchText: this.searchText,
                         filters: this.filters,

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_onboarding_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_onboarding_spec.js
@@ -352,4 +352,38 @@ describe('ProctoredExamOnboardingView', function() {
         expect(this.proctored_exam_onboarding_view.$el.find('#onboarding-loading-indicator').hasClass('hidden'))
             .toEqual(true);
     });
+
+    it('Renders correct filters for onboarding API', function() {
+        setFixtures(
+            '<div class="student-onboarding-status-container" ' +
+            'data-course-id="test_course_id" data-use-onboarding-api="True">' +
+            '</div>'
+        );
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                200,
+                {
+                    'Content-Type': 'application/json'
+                },
+                JSON.stringify(expectedOnboardingDataJson)
+            ]
+        );
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+
+        this.server.respond();
+        this.server.respond();
+
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Not Started');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Submitted');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Verified');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Approved in Another Course');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .toContain('Rejected');
+        expect(this.proctored_exam_onboarding_view.$el.find('.status-checkboxes').html())
+            .not.toContain('Setup Started');
+    });
 });

--- a/edx_proctoring/static/proctoring/templates/student-onboarding-status.underscore
+++ b/edx_proctoring/static/proctoring/templates/student-onboarding-status.underscore
@@ -98,7 +98,7 @@
                             <input type="checkbox" id="<%= status %>" name="status-filters" value="<%= status %>"
                             <% if (filters.includes(status)) { %>checked="true"<% } %>>
                             <label for="<%= status %>">
-                                <%- interpolate(gettext(" %(onboardingStatus)s "), 
+                                <%- interpolate(gettext(" %(onboardingStatus)s "),
                                 { onboardingStatus: getReadableString(status) }, true) %>
                             </label>
                         </li>
@@ -126,11 +126,11 @@
                                 <%- interpolate(gettext(" %(username)s "), { username: item.username }, true) %>
                             </td>
                             <td>
-                                <%- interpolate(gettext(" %(enrollmentMode)s "), 
+                                <%- interpolate(gettext(" %(enrollmentMode)s "),
                                 { enrollmentMode: getReadableString(item.enrollment_mode) }, true) %>
                             </td>
                             <td>
-                                <%- interpolate(gettext(" %(onboardingStatus)s "), 
+                                <%- interpolate(gettext(" %(onboardingStatus)s "),
                                 { onboardingStatus: getReadableString(item.status) }, true) %>
                             </td>
                             <td><%= getDateFormat(item.modified) %></td>

--- a/edx_proctoring/statuses.py
+++ b/edx_proctoring/statuses.py
@@ -251,6 +251,7 @@ class InstructorDashboardOnboardingAttemptStatus:
     rejected = 'rejected'
     verified = 'verified'
     error = 'error'
+    expired = 'expired'
 
     # The following status is not a true attempt status, but is used when the
     # user's onboarding profile is approved in a different course.
@@ -273,7 +274,8 @@ class InstructorDashboardOnboardingAttemptStatus:
         ProctoredExamStudentAttemptStatus.submitted: submitted,
         ProctoredExamStudentAttemptStatus.rejected: rejected,
         ProctoredExamStudentAttemptStatus.verified: verified,
-        ProctoredExamStudentAttemptStatus.error: error
+        ProctoredExamStudentAttemptStatus.error: error,
+        ProctoredExamStudentAttemptStatus.expired: expired
     }
 
     @classmethod
@@ -304,11 +306,20 @@ class VerificientOnboardingProfileStatus:
 
     profile_status_mapping = {
         no_profile: None,
-        approved: ProctoredExamStudentAttemptStatus.verified,
+        approved: InstructorDashboardOnboardingAttemptStatus.verified,
         other_course_approved: InstructorDashboardOnboardingAttemptStatus.other_course_approved,
-        rejected: ProctoredExamStudentAttemptStatus.rejected,
-        expired: ProctoredExamStudentAttemptStatus.expired,
-        pending: ProctoredExamStudentAttemptStatus.submitted
+        rejected: InstructorDashboardOnboardingAttemptStatus.rejected,
+        expired: InstructorDashboardOnboardingAttemptStatus.expired,
+        pending: InstructorDashboardOnboardingAttemptStatus.submitted
+    }
+
+    filter_status_mapping = {
+        InstructorDashboardOnboardingAttemptStatus.not_started: no_profile,
+        InstructorDashboardOnboardingAttemptStatus.submitted: pending,
+        InstructorDashboardOnboardingAttemptStatus.other_course_approved: other_course_approved,
+        InstructorDashboardOnboardingAttemptStatus.verified: approved,
+        InstructorDashboardOnboardingAttemptStatus: rejected,
+        InstructorDashboardOnboardingAttemptStatus.expired: expired
     }
 
     @classmethod
@@ -317,6 +328,28 @@ class VerificientOnboardingProfileStatus:
         Get the internal attempt status given a status from the onboarding api
 
         Parameters:
-            * status (str):
+            * status (str): status from Verficient's onboarding API endpoint
         """
         return cls.profile_status_mapping.get(api_status)
+
+    @classmethod
+    def get_profile_status_from_filter(cls, filter_status):
+        """
+        Get the verificient profile status given an edx status for filtering
+
+        Parameters:
+            * status (str): edX onboarding status
+        """
+        return cls.filter_status_mapping.get(filter_status)
+
+    @classmethod
+    def get_instructor_status_from_profile_status(cls, api_status):
+        """
+        Get the instructor onboarding status given a status from the onboarding api
+
+        Parameters:
+            * status (str): status from Verficient's onboarding API endpoint
+        """
+        if api_status == cls.no_profile:
+            return InstructorDashboardOnboardingAttemptStatus.not_started
+        return cls.get_edx_status_from_profile_status(api_status)


### PR DESCRIPTION
* Basic testing for use of onboarding API
* Added function to gather all paginated data from proctoring provider onboarding endpoint
* Updated frontend to only use specific filters if onboarding API is being used