### PR TITLE
Fix the make requirements Django incompatibility issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 
 requirements: ## install development environment requirements
 	pip install -qr requirements/dev.txt --exists-action w
-	pip-sync requirements/*.txt requirements/private.*
+	pip-sync requirements/dev.txt requirements/base.txt requirements/private.*
 
 install: requirements
 	./manage.py migrate --settings=test_settings

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,6 +28,7 @@ click-repl==0.2.0
     # via celery
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,4 +16,5 @@ jsonfield2==3.0.3
 
 # pinning it to latest release.
 celery==5.0.4
-
+# celery latest version requires click<8.0.0
+click<8.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,16 +14,15 @@ bleach==3.3.0
     # via readme-renderer
 certifi==2021.5.30
     # via requests
-cffi==1.14.5
-    # via cryptography
 chardet==4.0.0
     # via
     #   diff-cover
     #   requests
 click-log==0.3.2
     # via edx-lint
-click==8.0.1
+click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
@@ -32,8 +31,6 @@ code-annotations==1.1.2
     # via edx-lint
 colorama==0.4.4
     # via twine
-cryptography==3.4.7
-    # via secretstorage
 diff-cover==5.1.2
     # via -r requirements/dev.in
 distlib==0.3.2
@@ -72,10 +69,6 @@ isort==5.8.0
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.6.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2-pluralize==0.3.0
     # via diff-cover
 jinja2==3.0.1
@@ -119,8 +112,6 @@ py==1.10.0
     # via tox
 pycodestyle==2.7.0
     # via -r requirements/quality.in
-pycparser==2.20
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.9.0
@@ -163,8 +154,6 @@ rfc3986==1.5.0
     # via twine
 rstcheck==3.3.1
     # via -r requirements/quality.in
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,6 +36,7 @@ click-repl==0.2.0
     # via celery
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,14 +12,13 @@ bleach==3.3.0
     # via readme-renderer
 certifi==2021.5.30
     # via requests
-cffi==1.14.5
-    # via cryptography
 chardet==4.0.0
     # via requests
 click-log==0.3.2
     # via edx-lint
-click==8.0.1
+click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
@@ -27,8 +26,6 @@ code-annotations==1.1.2
     # via edx-lint
 colorama==0.4.4
     # via twine
-cryptography==3.4.7
-    # via secretstorage
 django==2.2.24
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -51,10 +48,6 @@ isort==5.8.0
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.6.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.1
     # via code-annotations
 keyring==23.0.1
@@ -73,8 +66,6 @@ pkginfo==1.7.0
     # via twine
 pycodestyle==2.7.0
     # via -r requirements/quality.in
-pycparser==2.20
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.9.0
@@ -113,8 +104,6 @@ rfc3986==1.5.0
     # via twine
 rstcheck==3.3.1
     # via -r requirements/quality.in
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,6 +28,7 @@ click-plugins==1.1.1
     # via celery
     # via celery
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins


### PR DESCRIPTION
## Description
- Running `make requirements` used to cause the following error
`Incompatible requirements found: django<3.0 (from -r requirements/constraints.txt (line 11)) and django==2.2.24 (from -r requirements/base.txt (line 24))`

## Fix
- pip-sync command had `requirements/*.txt` in it which also included `constraints.txt` file. This used to cause the error when running the `make requirements` command.

- changing the
    `pip-sync requirements/*.txt requirements/private.*`
  with
    `pip-sync requirements/dev.txt requirements/base.txt requirements/private.*`
  worked with the constraint Django<3.0 present in the constraints.
