### PR TITLE
[BD-26] Fix a bug in exam attempt API where total time for the exam would not include allowance time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[3.15.1] - 2021-06-16
+~~~~~~~~~~~~~~~~~~~~~
+* Fix a bug in exam attempt API where total time allowed for the exam would not include allowance time.
 * Add `test_plan` document to describe key features and test cases
 
 [3.15.0] - 2021-06-15

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.15.0'
+__version__ = '3.15.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -81,6 +81,14 @@ REJECTED_GRADE_OVERRIDE_EARNED = 0.0
 USER_MODEL = get_user_model()
 
 
+def get_total_allowed_time_for_exam(exam, user_id):
+    """
+    Returns total allowed time in humanized form for exam including allowance time.
+    """
+    total_allowed_time = _calculate_allowed_mins(exam, user_id)
+    return humanized_time(total_allowed_time)
+
+
 def get_proctoring_settings_by_exam_id(exam_id):
     """
     Return proctoring settings and exam proctoring backend for proctored exam by exam_id.
@@ -744,7 +752,6 @@ def get_exam_attempt_data(exam_id, attempt_id, is_learning_mfe=False):
     # a same process as the LMS
     if is_learning_mfe:
         exam_url_path = resolve_exam_url_for_learning_mfe(exam['course_id'], exam['content_id'])
-
     else:
         exam_url_path = reverse('jump_to', args=[exam['course_id'], exam['content_id']])
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -48,6 +48,7 @@ from edx_proctoring.api import (
     get_onboarding_attempt_data_for_learner,
     get_proctoring_settings_by_exam_id,
     get_review_policy_by_exam_id,
+    get_total_allowed_time_for_exam,
     get_user_attempts_by_exam_id,
     is_exam_passed_due,
     mark_exam_attempt_as_ready,
@@ -238,12 +239,17 @@ class ProctoredExamAttemptView(ProctoredAPIView):
                         attempt.get('id'),
                         is_learning_mfe=is_learning_mfe
                     )
-                # Exam hasn't been started yet but it is proctored so needs to be checked
-                # if prerequisites are satisfied. We only do this for proctored exam hence
-                # additional check 'not exam['is_practice_exam']', meaning we do not check
-                # prerequisites for practice or onboarding exams
-                elif exam['is_proctored'] and not exam['is_practice_exam']:
-                    exam = check_prerequisites(exam, request.user.id)
+                else:
+                    # calculate total allowed time for the exam including
+                    # allowance time to show on the MFE entrance pages
+                    exam['total_time'] = get_total_allowed_time_for_exam(exam, request.user.id)
+
+                    # Exam hasn't been started yet but it is proctored so needs to be checked
+                    # if prerequisites are satisfied. We only do this for proctored exam hence
+                    # additional check 'not exam['is_practice_exam']', meaning we do not check
+                    # prerequisites for practice or onboarding exams
+                    if exam['is_proctored'] and not exam['is_practice_exam']:
+                        exam = check_prerequisites(exam, request.user.id)
 
                 # if user hasn't completed required onboarding exam before taking
                 # proctored exam we need to navigate them to it with a link

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Fix a bug in exam attempt API where total time allowed for the exam would not include allowance time.

**JIRA:**

[EDUCATOR-5838](https://openedx.atlassian.net/browse/EDUCATOR-5838)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.