### PR TITLE
fix: Fix JSON Parse Error for Error Responses without JSON Parseable Text

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.17.1] - 2021-06-25
+~~~~~~~~~~~~~~~~~~~~~
+* Fix JSON parse failure when error response from course onboarding status endpoint does not
+  return valid JSON.
+
 [3.17.0] - 2021-06-23
 ~~~~~~~~~~~~~~~~~~~~~
 * Replace internal logic for determing learners' onboarding statuses for the course onboarding API

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.17.0'
+__version__ = '3.17.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_onboarding_view.js
@@ -202,7 +202,14 @@ edx = edx || {};
                     // still want the view to render
                     self.render();
 
-                    data = $.parseJSON(response.responseText);
+                    try {
+                        data = $.parseJSON(response.responseText);
+                    } catch (error) {
+                        data = {
+                            detail: 'An unexpected error occured. Please try again later.'
+                        };
+                    }
+
                     if (data.detail) {
                         $errorResponse = $('#error-response');
                         $errorResponse.html(data.detail);

--- a/edx_proctoring/static/proctoring/spec/proctored_exam_onboarding_spec.js
+++ b/edx_proctoring/static/proctoring/spec/proctored_exam_onboarding_spec.js
@@ -445,4 +445,28 @@ describe('ProctoredExamOnboardingView', function() {
         expect(errorMessage).toBeVisible();
         expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-status-content')).not.toBeVisible();
     });
+
+    it('renders correctly with non-JSON parseable error message response', function() {
+        var errorMessage;
+
+        this.server.respondWith('GET', '/api/edx_proctoring/v1/user_onboarding/status/course_id/test_course_id',
+            [
+                500,
+                {
+                    'Content-Type': 'application/json'
+                },
+                ''
+            ]
+        );
+
+        this.proctored_exam_onboarding_view = new edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView();
+
+        this.server.respond();
+        this.server.respond();
+
+        errorMessage = this.proctored_exam_onboarding_view.$el.find('.error-response');
+        expect(errorMessage.html()).toContain('An unexpected error occured. Please try again later.');
+        expect(errorMessage).toBeVisible();
+        expect(this.proctored_exam_onboarding_view.$el.find('.onboarding-status-content')).not.toBeVisible();
+    });
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

In pull #879 (https://github.com/edx/edx-proctoring/pull/879), error handling was added to the Javascript that renders the Student Onboarding Status panel in the Instructor Dashboard. This error handling parsed the JSON returned by the response from the StudentOnboardingStatusByCourseView endpoint. However, this fails if the data returned in the response is not valid JSON. The changes in this commit address this bug by adding error handling to the call to parse the JSON response. If the JSON is not valid JSON, then a generic error message is returned and displayed by the frontend.

**JIRA:**

[MST-761](https://openedx.atlassian.net/browse/MST-761)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.