### PR TITLE
[MST-806] Use verified name in exam attempt creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.22.0] - 2021-07-26
+~~~~~~~~~~~~~~~~~~~~~
+* If verified name functionality is enabled through the "name_affirmation" runtime service,
+  use it in proctored exam attempt creation. (see https://github.com/edx/edx-name-affirmation)
+* When updating a proctored exam attempt to "verified" status, update the user's verified
+  name status, if verified name functionality is enabled and they have one linked to that
+  exam attempt.
+
 [3.21.1] - 2021-07-26
 ~~~~~~~~~~~~~~~~~~~~~
 * Removed name field in proctored exam attempt from the DB.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.21.1'
+__version__ = '3.22.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/exam_action_handler.js
+++ b/edx_proctoring/static/proctoring/js/exam_action_handler.js
@@ -83,13 +83,14 @@ edx = edx || {};
     }
 
     // Update the state of the attempt
-    function updateExamAttemptStatusPromise(actionUrl, action) {
+    function updateExamAttemptStatusPromise(actionUrl, action, isVerifiedNameEnabled) {
         return function() {
             return Promise.resolve($.ajax({
                 url: actionUrl,
                 type: 'PUT',
                 data: {
-                    action: action
+                    action: action,
+                    is_verified_name_enabled: isVerifiedNameEnabled
                 }
             }));
         };
@@ -123,7 +124,12 @@ edx = edx || {};
         var $this = $(this);
         var actionUrl = $this.data('change-state-url');
         var action = $this.data('action');
-        updateExamAttemptStatusPromise(actionUrl, action)()
+
+        // Course waffle flag for verified name
+        var main = document.getElementById('main');
+        var isVerifiedNameEnabled = main.dataset.isVerifiedNameEnabled.toLowerCase() === 'true';
+
+        updateExamAttemptStatusPromise(actionUrl, action, isVerifiedNameEnabled)()
             .then(reloadPage)
             .catch(errorHandlerGivenMessage(
                 $this,

--- a/edx_proctoring/templates/practice_exam/entrance.html
+++ b/edx_proctoring/templates/practice_exam/entrance.html
@@ -32,7 +32,6 @@
 {% include 'proctored_exam/footer.html' %}
 
 <script type="text/javascript">
-
   var inProcess = false;
 
   var disableClickEvent = function () {
@@ -55,6 +54,10 @@
         var attempt_proctored = $(this).data('attempt-proctored');
         var start_immediately = $(this).data('start-immediately');
 
+        // Course waffle flag for verified name
+        var main = document.getElementById('main');
+        var isVerifiedNameEnabled = main.dataset.isVerifiedNameEnabled.toLowerCase() === 'true';
+
         if (typeof action_url === "undefined") {
           enableClickEvent();
           return false;
@@ -65,7 +68,8 @@
           {
             "exam_id": exam_id,
             "attempt_proctored": attempt_proctored,
-            "start_clock": start_immediately
+            "start_clock": start_immediately,
+            "is_verified_name_enabled": isVerifiedNameEnabled
           },
           function (data) {
             // reload the page, because we've unlocked it

--- a/edx_proctoring/templates/proctored_exam/footer.html
+++ b/edx_proctoring/templates/proctored_exam/footer.html
@@ -10,13 +10,18 @@
 </div>
 
 <script type="text/javascript">
+  // Course waffle flag for verified name
+  var main = document.getElementById('main');
+  var isVerifiedNameEnabled = main.dataset.isVerifiedNameEnabled.toLowerCase() === 'true';
+
   var startProctoredExam = function(selector, exam_id, action_url, start_immediately, attempt_proctored) {
     $.post(
       action_url,
       {
         "exam_id": exam_id,
         "attempt_proctored": attempt_proctored,
-        "start_clock": start_immediately
+        "start_clock": start_immediately,
+        "is_verified_name_enabled": isVerifiedNameEnabled
       },
       function(data) {
         // reload the page, because we've unlocked it

--- a/edx_proctoring/tests/test_api.py
+++ b/edx_proctoring/tests/test_api.py
@@ -101,7 +101,8 @@ from .test_services import (
     MockCreditServiceWithCourseEndDate,
     MockEnrollmentsService,
     MockGradesService,
-    MockInstructorService
+    MockInstructorService,
+    MockNameAffirmationService
 )
 from .utils import ProctoredExamTestCase
 
@@ -125,6 +126,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         self.disabled_exam_id = self._create_disabled_exam()
         set_runtime_service('certificates', MockCertificateService())
         set_runtime_service('instructor', MockInstructorService())
+        set_runtime_service('name_affirmation', MockNameAffirmationService())
 
     def tearDown(self):
         """
@@ -133,6 +135,7 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         super().tearDown()
         set_runtime_service('certificates', None)
         set_runtime_service('instructor', None)
+        set_runtime_service('name_affirmation', None)
 
     def _add_allowance_for_user(self):
         """
@@ -1272,6 +1275,26 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         )
         with self.assertRaises(ProctoredExamIllegalStatusTransition):
             reset_practice_exam(self.practice_exam_id, self.user_id, self.user)
+
+    @patch('edx_proctoring.api.create_exam_attempt')
+    def test_reset_exam_verified_name_enabled(self, create_exam_attempt_mock):
+        """
+        If verified name feature is enabled, account for that when creating a new
+        exam attempt as a result of resetting an exam.
+        """
+        self._create_exam_attempt(
+            self.practice_exam_id,
+            status=ProctoredExamStudentAttemptStatus.rejected,
+            is_practice_exam=True,
+        )
+        reset_practice_exam(self.practice_exam_id, self.user_id, self.user, True)
+
+        create_exam_attempt_mock.assert_called_once_with(
+            self.practice_exam_id,
+            self.user.id,
+            taking_as_proctored=True,
+            is_verified_name_enabled=True,
+        )
 
     def test_stop_a_non_started_exam(self):
         """
@@ -2477,6 +2500,29 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
         attempt = get_exam_attempt_by_id(exam_attempt.id)
         self.assertEqual(attempt['status'], ProctoredExamStudentAttemptStatus.resumed)
 
+    def test_update_exam_attempt_verified_name(self):
+        """
+        Test that updating a proctored exam attempt to a "verified" status will trigger an
+        update to the linked verified name entry, if one exists.
+        """
+        attempt_id = create_exam_attempt(
+            exam_id=self.proctored_exam_id,
+            user_id=self.user_id,
+            taking_as_proctored=True,
+            is_verified_name_enabled=True
+        )
+
+        # Check that a verified name was created with is_verified = False
+        name_affirmation_service = get_runtime_service('name_affirmation')
+        verified_name_obj = name_affirmation_service.get_verified_name(self.user)
+        self.assertFalse(verified_name_obj.is_verified)
+
+        update_attempt_status(attempt_id, ProctoredExamStudentAttemptStatus.verified)
+
+        # User's verified name has been updated to is_verified = True
+        verified_name_obj = name_affirmation_service.get_verified_name(self.user)
+        self.assertTrue(verified_name_obj.is_verified)
+
     @ddt.data(
         (
             ProctoredExamStudentAttemptStatus.started,
@@ -3143,6 +3189,99 @@ class ProctoredExamApiTests(ProctoredExamTestCase):
             })
         else:
             self.assertEqual(override, None)
+
+    def test_use_verified_name_in_attempt_creation(self):
+        """
+        If verified name feature is enabled, and the user has an existing verified
+        name, don't create a new one.
+        """
+        name_affirmation_service = get_runtime_service('name_affirmation')
+        name_affirmation_service.create_verified_name(
+            self.user,
+            verified_name='Jonathan Doe',
+            profile_name='Jon Doe',
+            verification_attempt_id=123,
+            is_verified=True
+        )
+
+        create_exam_attempt(
+            exam_id=self.proctored_exam_id,
+            user_id=self.user_id,
+            taking_as_proctored=True,
+            is_verified_name_enabled=True
+        )
+
+        # Assert that a new verified name was not created with the exam attempt ID
+        verified_name_obj = name_affirmation_service.get_verified_name(self.user)
+        self.assertIsNone(verified_name_obj.proctored_exam_attempt_id)
+
+    def test_create_verified_name_with_exam_attempt(self):
+        """
+        If verified name feature is enabled, create a verified name for a user during
+        proctored exam attempt creation if they don't already have one.
+        """
+        attempt_id = create_exam_attempt(
+            exam_id=self.proctored_exam_id,
+            user_id=self.user_id,
+            taking_as_proctored=True,
+            is_verified_name_enabled=True
+        )
+
+        credit_service = get_runtime_service('credit')
+        credit_status = credit_service.get_credit_state(self.user.id, self.course_id)
+        full_name = credit_status['profile_fullname']
+
+        name_affirmation_service = get_runtime_service('name_affirmation')
+        verified_name_obj = name_affirmation_service.get_verified_name(self.user)
+        self.assertEqual(verified_name_obj.verified_name, full_name)
+        self.assertEqual(verified_name_obj.profile_name, full_name)
+        self.assertEqual(verified_name_obj.proctored_exam_attempt_id, attempt_id)
+
+    def test_create_verified_name_with_exam_attempt_when_pending(self):
+        """
+        If verified name feature is enabled, create a verified name for a user during
+        proctored exam attempt creation if they have a pending verified name.
+        """
+        name_affirmation_service = get_runtime_service('name_affirmation')
+        name_affirmation_service.create_verified_name(
+            self.user, verified_name='John Doe', profile_name='Old Name', is_verified=False,
+        )
+
+        attempt_id = create_exam_attempt(
+            exam_id=self.proctored_exam_id,
+            user_id=self.user_id,
+            taking_as_proctored=True,
+            is_verified_name_enabled=True
+        )
+
+        credit_service = get_runtime_service('credit')
+        credit_status = credit_service.get_credit_state(self.user.id, self.course_id)
+        profile_name = credit_status['profile_fullname']
+
+        verified_name_obj = name_affirmation_service.get_verified_name(self.user)
+        self.assertEqual(attempt_id, verified_name_obj.proctored_exam_attempt_id)
+        self.assertEqual(profile_name, verified_name_obj.profile_name)
+
+    def test_create_exam_attempt_empty_string(self):
+        """
+        Assert that exam attempt creation does not fail if the user's profile name is an
+        empty string.
+        """
+        with patch(
+                'edx_proctoring.tests.test_services.MockCreditService.get_credit_state',
+                return_value={'profile_fullname': '', 'student_email': 'foo@bar'}
+        ):
+            attempt_id = create_exam_attempt(
+                exam_id=self.proctored_exam_id,
+                user_id=self.user_id,
+                taking_as_proctored=True,
+                is_verified_name_enabled=True
+            )
+
+            self.assertEqual(
+                get_exam_attempt_by_id(attempt_id)['status'],
+                ProctoredExamStudentAttemptStatus.created
+            )
 
 
 @ddt.ddt

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -384,3 +384,51 @@ class MockLearningSequencesService:
     def get_user_course_outline(self, course_key, user, at_time):
         """ Return mock UserCourseOutlineData """
         return MockUserCourseOutlineData(self.accessible_sequences)
+
+
+class MockVerifiedName:
+    """Mock VerifiedName object"""
+    def __init__(
+        self, user, verified_name, profile_name, verification_attempt_id=None,
+        proctored_exam_attempt_id=None, is_verified=False,
+    ):
+        self.user = user
+        self.verified_name = verified_name
+        self.profile_name = profile_name
+        self.verification_attempt_id = verification_attempt_id
+        self.proctored_exam_attempt_id = proctored_exam_attempt_id
+        self.is_verified = is_verified
+
+
+class MockNameAffirmationService:
+    """Mock Name Affirmation Service"""
+    def __init__(self):
+        self.verified_name = None
+
+    def get_verified_name(self, user, is_verified=False):
+        """ Return mock VerifiedName """
+        return self.verified_name
+
+    def create_verified_name(
+        self, user, verified_name, profile_name, verification_attempt_id=None,
+        proctored_exam_attempt_id=None, is_verified=False,
+    ):
+        """ Create mock VerifiedName """
+        self.verified_name = MockVerifiedName(
+            user,
+            verified_name,
+            profile_name,
+            verification_attempt_id,
+            proctored_exam_attempt_id,
+            is_verified,
+        )
+        return self.get_verified_name(user)
+
+    def update_is_verified_status(
+        self, user, is_verified, verification_attempt_id=None, proctored_exam_attempt_id=None,
+    ):
+        """ Update is_verified field on mock VerifiedName """
+        if self.verified_name:
+            self.verified_name.is_verified = is_verified
+        else:
+            raise Exception

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1124,6 +1124,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
         course_id = attempt['proctored_exam']['course_id']
         action = request.data.get('action')
         detail = request.data.get('detail')
+        is_verified_name_enabled = request.data.get('is_verified_name_enabled', False)
 
         err_msg = (
             'user_id={user_id} attempted to update attempt_id={attempt_id} in '
@@ -1173,6 +1174,7 @@ class StudentProctoredExamAttempt(ProctoredAPIView):
                 attempt['proctored_exam']['id'],
                 user_id,
                 requesting_user=request.user,
+                is_verified_name_enabled=is_verified_name_enabled
             )
         elif action == 'error':
             backend = attempt['proctored_exam']['backend']
@@ -1312,6 +1314,7 @@ class StudentProctoredExamAttemptCollection(ProctoredAPIView):
         start_immediately = request.data.get('start_clock', 'false').lower() == 'true'
         exam_id = request.data.get('exam_id', None)
         attempt_proctored = request.data.get('attempt_proctored', 'false').lower() == 'true'
+        is_verified_name_enabled = request.data.get('is_verified_name_enabled', False)
         user_id = request.user.id
         exam = get_exam_by_id(exam_id)
 
@@ -1330,7 +1333,8 @@ class StudentProctoredExamAttemptCollection(ProctoredAPIView):
         exam_attempt_id = create_exam_attempt(
             exam_id=exam_id,
             user_id=user_id,
-            taking_as_proctored=attempt_proctored
+            taking_as_proctored=attempt_proctored,
+            is_verified_name_enabled=is_verified_name_enabled,
         )
 
         # if use elected not to take as proctored exam, then

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.21.1",
+  "version": "3.22.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,4 +22,3 @@ edx-opaque-keys>=0.4
 edx-drf-extensions
 edx-rest-api-client>=1.9.2
 edx-when>=0.1.3
-


### PR DESCRIPTION
**Description:**

If the verified name feature is active through 1) runtime service and 2) course waffle flag (implemented in https://github.com/edx/edx-platform/pull/28187), the following features are added:

- During proctored exam attempt creation, check to see if the user has a valid verified name.
  - If they do, use that name for the backend provider's ID check.
  - If not, create a verified name for the user, linking the exam attempt ID.
- When a proctored exam attempt is verified, check to see if there is a linked verified name. If there is, flip the `is_verified` field to True.

**JIRA:**

[MST-806](https://openedx.atlassian.net/browse/MST-806)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.