### PR TITLE
[BD-26] Update onboarding links generation for learning mfe and remove old exam attempt url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.18.0] - 2021-07-15
+~~~~~~~~~~~~~~~~~~~~~
+* Remove old proctored exam attempt url.
+* Fix onboarding link generation in proctored exam attempt view when exam attempt is in
+  onboarding errors status, don't return the link to exams that are not accessible to user.
+* Update onboarding link url in student onboarding status view to link
+  to the learning mfe page instead of LMS.
+
 [3.17.3] - 2021-07-14
 ~~~~~~~~~~~~~~~~~~~~~
 * Add missing get_proctoring_config method to base backend provider class.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.17.3'
+__version__ = '3.18.0'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -105,20 +105,14 @@ def get_onboarding_exam_link(course_id, user, is_learning_mfe):
             course_key, user, pytz.utc.localize(datetime.now())
         )
         categorized_exams = categorize_inaccessible_exams_by_date(onboarding_exams, details)
-        (non_date_inaccessible_exams, future_exams, past_due_exams) = categorized_exams
+        non_date_inaccessible_exams = categorized_exams[0]
 
         # remove onboarding exams not accessible to learners
         for onboarding_exam in non_date_inaccessible_exams:
             onboarding_exams.remove(onboarding_exam)
 
-        currently_available_exams = [
-            onboarding_exam
-            for onboarding_exam in onboarding_exams
-            if onboarding_exam not in future_exams and onboarding_exam not in past_due_exams
-        ]
-
-        if currently_available_exams:
-            onboarding_exam = currently_available_exams[0]
+        if onboarding_exams:
+            onboarding_exam = onboarding_exams[0]
             if is_learning_mfe:
                 onboarding_link = resolve_exam_url_for_learning_mfe(
                     course_id, onboarding_exam.content_id

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -55,7 +55,7 @@ from edx_proctoring.statuses import (
 )
 from edx_proctoring.tests import mock_perm
 from edx_proctoring.urls import urlpatterns
-from edx_proctoring.utils import obscured_user_id
+from edx_proctoring.utils import obscured_user_id, resolve_exam_url_for_learning_mfe
 from edx_proctoring.views import require_course_or_global_staff, require_staff
 from mock_apps.models import Profile
 
@@ -550,6 +550,22 @@ class TestStudentOnboardingStatusView(ProctoredExamTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         message = 'There is no onboarding exam related to this course id.'
         self.assertEqual(response_data['detail'], message)
+
+    @override_settings(LEARNING_MICROFRONTEND_URL='https://learningmfe')
+    def test_onboarding_mfe_link(self):
+        """
+        Test that the request returns correct link to onboarding exam for learning mfe application.
+        """
+        response = self.client.get(
+            reverse('edx_proctoring:user_onboarding.status')
+            + '?course_id={}&is_learning_mfe=True'.format(self.course_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(
+            response_data['onboarding_link'],
+            resolve_exam_url_for_learning_mfe(self.course_id, self.onboarding_exam.content_id)
+        )
 
     def test_no_exam_attempts(self):
         """

--- a/edx_proctoring/urls.py
+++ b/edx_proctoring/urls.py
@@ -131,13 +131,6 @@ urlpatterns = [
         views.ProctoredExamAttemptView.as_view(),
         name='proctored_exam.exam_attempts'
     ),
-    # TODO: remove url after updating frontend-lib-special-exams
-    url(
-        r'edx_proctoring/v1/proctored_exam/attempt/course_id/{}/content_id/{}$'.format(
-            settings.COURSE_ID_PATTERN, CONTENT_ID_PATTERN),
-        views.ProctoredExamAttemptView.as_view(),
-        name='proctored_exam.exam_attempts_old'
-    ),
     url(
         r'edx_proctoring/v1/proctored_exam/settings/exam_id/(?P<exam_id>\d+)/$',
         views.ProctoredSettingsView.as_view(),

--- a/edx_proctoring/utils.py
+++ b/edx_proctoring/utils.py
@@ -13,6 +13,7 @@ from edx_when import api as when_api
 from eventtracking import tracker
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys.edx.locator import BlockUsageLocator
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
@@ -329,3 +330,49 @@ def resolve_exam_url_for_learning_mfe(course_id, content_id):
     usage_key = UsageKey.from_string(content_id)
     url = '{}/course/{}/{}'.format(settings.LEARNING_MICROFRONTEND_URL, course_key, usage_key)
     return url
+
+
+def categorize_inaccessible_exams_by_date(onboarding_exams, details):
+    """
+    Categorize a list of inaccessible onboarding exams based on whether they are
+    inaccessible because they are in the future, because they are in the past, or because
+    they are inaccessible for reason unrelated to the exam schedule (e.g. visibility settings,
+    content gating, etc.)
+
+    Parameters:
+    * onboarding_exams: a list of onboarding exams
+    * details: a UserCourseOutlineData returned by the learning sequences API
+
+    Returns: a tuple containing three lists
+    * non_date_inaccessible_exams: a list of onboarding exams not accessible to the learner for
+      reasons other than the exam schedule
+    * future_exams: a list of onboarding exams not accessible to the learner because the exams are released
+      in the future
+    * past_due_exams: a list of onboarding exams not accessible to the learner because the exams are past their
+      due date
+    """
+    non_date_inaccessible_exams = []
+    future_exams = []
+    past_due_exams = []
+
+    for onboarding_exam in onboarding_exams:
+        usage_key = BlockUsageLocator.from_string(onboarding_exam.content_id)
+        if usage_key not in details.outline.accessible_sequences:
+            sequence_schedule = details.schedule.sequences.get(usage_key)
+
+            if sequence_schedule:
+                effective_start = details.schedule.sequences.get(usage_key).effective_start
+                due_date = get_visibility_check_date(details.schedule, usage_key)
+
+                if effective_start and pytz.utc.localize(datetime.now()) < effective_start:
+                    future_exams.append(onboarding_exam)
+                elif due_date and pytz.utc.localize(datetime.now()) > due_date:
+                    past_due_exams.append(onboarding_exam)
+                else:
+                    non_date_inaccessible_exams.append(onboarding_exam)
+            else:
+                # if the sequence schedule is not available, then the sequence is not available
+                # to the learner
+                non_date_inaccessible_exams.append(onboarding_exam)
+
+    return non_date_inaccessible_exams, future_exams, past_due_exams

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/edx-proctoring",
   "//": "Be sure to update the version number in edx_proctoring/__init__.py",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.17.3",
+  "version": "3.18.0",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

The purpose of this PR is to handle following issues:

1) Fix onboarding link generation in proctored exam attempt view when exam attempt in in onboarding errors status, don't show the link if exam is not accessible to user
2) Update onboarding link url in student onboarding status view to link to the learning mfe page instead of LMS
3) Remove old proctored exam attempt url

**JIRA:**

 - [EDUCATOR-5828](https://openedx.atlassian.net/browse/EDUCATOR-5828)
 - [EDUCATOR-5842](https://openedx.atlassian.net/browse/EDUCATOR-5842)
 - [EDUCATOR-5892](https://openedx.atlassian.net/browse/EDUCATOR-5892)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.