### PR TITLE
docs: update release process in developer doc to match PR template

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -299,8 +299,8 @@ Release a new version of edx-proctoring
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Update the version in ``edx_proctoring/__init__.py`` and ``package.json``
+* Describe your changes in `CHANGELOG.rst`
 * Create a `new release on GitHub <https://github.com/edx/edx-proctoring/releases>`_ using the version number
-* Send an email to release-notifications@edx.org announcing the new version
 * Update edx-platform to use the new version
     * In edx-platform, create a branch and update the requirements/edx/base.in file to reflect the new tagged branch.
 * create a PR of this branch in edx-platform onto edx-platform:master

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -302,7 +302,7 @@ Release a new version of edx-proctoring
 * Describe your changes in `CHANGELOG.rst`
 * Create a `new release on GitHub <https://github.com/edx/edx-proctoring/releases>`_ using the version number
 * Update edx-platform to use the new version
-    * In edx-platform, create a branch and update the requirements/edx/base.in file to reflect the new tagged branch.
+    * In edx-platform, create a branch and update the requirements/edx/base.txt, development.txt, and testing.txt files to reflect the new tagged branch.
 * create a PR of this branch in edx-platform onto edx-platform:master
 * Once the PR onto edx-platform has been merged, the updated edx-proctoring will be live in production when the normally scheduled release completes.
 


### PR DESCRIPTION
Update the release process part of developer docs to match PR template and conversation.

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.