### PR TITLE
fix: get tag version and internal version in sync

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[3.20.3] - 2021-07-21
+[3.20.5] - 2021-07-21
+~~~~~~~~~~~~~~~~~~~~~
+* No changes, gets tag and internal version in sync
+
+[3.20.4] - 2021-07-21
 ~~~~~~~~~~~~~~~~~~~~~
 * Removed use of name field in proctored exam attempt.
 

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.20.3'
+__version__ = '3.20.5'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.20.3",
+  "version": "3.20.5",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
Tag got ahead of internal version in the miration release chain,
get them properly in sync by updating both.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.