### PR TITLE
fix: remove student name reference from ProctoredExamStudentAttemptAdmin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.20.6] - 2021-07-22
+~~~~~~~~~~~~~~~~~~~~~
+* Removed use of name field in proctored exam attempt admin.
+
 [3.20.5] - 2021-07-21
 ~~~~~~~~~~~~~~~~~~~~~
 * No changes, gets tag and internal version in sync

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.20.5'
+__version__ = '3.20.6'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/admin.py
+++ b/edx_proctoring/admin.py
@@ -433,7 +433,6 @@ class ProctoredExamStudentAttemptAdmin(admin.ModelAdmin):
         'allowed_time_limit_mins',
         'taking_as_proctored',
         'is_sample_attempt',
-        'student_name',
         'review_policy_id',
         'is_status_acknowledged',
         'time_remaining_seconds'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.20.5",
+  "version": "3.20.6",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
edx-proctoring tests did not catch that admin still had a reference to
the removed student_name field.  Test updates to come but will take
longer than I am comfortable leaving the release broken.

MST-872

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.