### PR TITLE
docs: replace out of date config info with pointer to better info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,51 +52,12 @@ For a full list of Make targets:
 
     make help
 
-Configuration
+Developing
 -------------
 
-In order to use edx-proctoring, you must obtain an account (and secret
-configuration - see below) with SoftwareSecure, which provides the proctoring
-review services that edx-proctoring integrates with.
+See the `developer guide`_ for configuration, devstack and sandbox setup, and other developer concerns.
 
-You will need to turn on the ENABLE_SPECIAL_EXAMS in lms.env.json and
-cms.env.json FEATURES dictionary::
-
-    "FEATURES": {
-        :
-        "ENABLE_SPECIAL_EXAMS": true,
-        :
-    }
-
-Also in your lms.env.json and cms.env.json file please add the following::
-
-
-    "PROCTORING_SETTINGS": {
-        "LINK_URLS": {
-            "contact_us": "{add link here}",
-            "faq": "{add link here}",
-            "online_proctoring_rules": "{add link here}",
-            "tech_requirements": "{add link here}"
-        }
-    },
-
-In your lms.auth.json file, please add the following *secure* information::
-
-    "PROCTORING_BACKENDS": {
-        "software_secure": {
-            "crypto_key": "{add SoftwareSecure crypto key here}",
-            "exam_register_endpoint": "{add endpoint to SoftwareSecure}",
-            "exam_sponsor": "{add SoftwareSecure sponsor}",
-            "organization": "{add SoftwareSecure organization}",
-            "secret_key": "{add SoftwareSecure secret key}",
-            "secret_key_id": "{add SoftwareSecure secret key id}",
-            "software_download_url": "{add SoftwareSecure download url}"
-        },
-        'DEFAULT': 'software_secure'
-    },
-
-You will need to restart services after these configuration changes for them to
-take effect.
+.. _developer guide: ./docs/developing.rst
 
 Email Templates
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -59,24 +59,6 @@ See the `developer guide`_ for configuration, devstack and sandbox setup, and ot
 
 .. _developer guide: ./docs/developing.rst
 
-Email Templates
----------------
-
-edx-proctoring provides generic base email templates that are rendered and sent to learners based
-on changes to the status of a proctored exam attempt. They have been designed such that you may leverage Django template
-inheritance to customize their content to the proctoring backend. Because proctoring backend plugins are installed in edx-platform,
-you must create an overriding template in the edx-platform repository. The template path should be ``emails/proctoring/{backend}/{template_name}``.
-Note that your template can either completely override the base template in edx-proctoring, or it can extend the base template in order to leverage
-the existing content of the blocks within the base template, particularly if you only need to change a portion of the template.
-
-Debugging
-------------
-
-To debug with PDB, run ``pytest`` with the ``-n0`` flag. This restricts the number
-of processes in a way that is compatible with ``pytest``
-
-    pytest -n0 [file-path]
-
 License
 -------
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -214,7 +214,7 @@ plays, you can add the following to a sandbox's
     ...
 
 Placing these configurations here (rather than the more generic
-locations mentioned in `the README`_) will allow us to leverage the
+locations mentioned in this document) will allow us to leverage the
 power of the ansible plays used to construct and administer
 sandboxes, e.g. those run via the ``/edx/bin/update`` script.
 `More on that here.`_
@@ -252,7 +252,6 @@ a user which PT can authenticate as.
 
 .. _our spec: ./backends.rst
 .. _system overview: ./system-overview.rst
-.. _the README: https://github.com/edx/edx-proctoring
 .. _generate a public JWK keypair: https://mkjwk.org/
 .. _More on that here.: https://openedx.atlassian.net/wiki/spaces/EdxOps/pages/13960183/Sandboxes#Sandboxes-Updatingcode
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -95,6 +95,26 @@ How does the proctoring system work?
 
 See `system overview`_ for a description of the proctoring system and it's components.
 
+
+Email Templates
+---------------
+
+edx-proctoring provides generic base email templates that are rendered and sent to learners based
+on changes to the status of a proctored exam attempt. They have been designed such that you may leverage Django template
+inheritance to customize their content to the proctoring backend. Because proctoring backend plugins are installed in edx-platform,
+you must create an overriding template in the edx-platform repository. The template path should be ``emails/proctoring/{backend}/{template_name}``.
+Note that your template can either completely override the base template in edx-proctoring, or it can extend the base template in order to leverage
+the existing content of the blocks within the base template, particularly if you only need to change a portion of the template.
+
+Debugging
+------------
+
+To debug with PDB, run ``pytest`` with the ``-n0`` flag. This restricts the number
+of processes in a way that is compatible with ``pytest``
+
+    pytest -n0 [file-path]
+
+
 Using mockprock as a backend
 ----------------------------
 


### PR DESCRIPTION
The JSON file instructions were out of date, and it was better to point at developing.rst than duplicate the better instructions. The email and debugging info also seemed more suited to the developer docs.