### PR TITLE
feat: smooth out install to test pathway

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 * Add simple history to proctored exam attempt, writing both old and new model for now. Includes admin view.
+* Update documentation and makefile targets for a clear path from clone to running tests.
 
 [3.22.1] - 2021-08-02
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help upgrade requirements clean quality requirements docs \
-	test test-all coverage pii_check \
+	requirements-test coverage pii_check \
 	compile_translations dummy_translations extract_translations \
 	fake_translations pull_translations push_translations test test-python \
 	test-js quality-python quality-js
@@ -58,6 +58,10 @@ requirements: ## install development environment requirements
 	pip install -qr requirements/dev.txt --exists-action w
 	pip-sync requirements/dev.txt requirements/base.txt requirements/private.*
 
+requirements-test: ## install requirements for running tests
+	npm install -g gulp-cli
+	pip install -qr requirements/test.txt --exists-action w
+
 install: requirements
 	./manage.py migrate --settings=test_settings
 	npm install
@@ -94,10 +98,6 @@ test-js:
 lint-js:
 	./node_modules/.bin/eslint --ignore-pattern 'edx_proctoring/static/index.js' --ext .js --ext .jsx .
 	./node_modules/.bin/eslint --config .eslintrc.worker.json 'edx_proctoring/static/index.js'
-
-test-all: ## run tests on every supported Python/Django combination
-	tox -e quality
-	tox
 
 diff_cover: test
 	diff-cover coverage.xml

--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,28 @@ Installation
 To install edx-proctoring:
 
     mkvirtualenv edx-proctoring
+
     make install
 
-To run the tests:
+If you want to run tests, first setup requirements. Note that JS tests
+require Node 10, nvm install v10 if you are on a different version so
+that gulp is installed for v10:
 
-    make test-all
+    nvm install v10
+
+    make requirements-test
+
+Run tests:
+
+    make test
+
+Run just python tests:
+
+    make test-python
+
+Run just JS tests:
+
+    make test-js
 
 For a full list of Make targets:
 


### PR DESCRIPTION
The original instructions were focused on make test-all which runs all
tox targets, including ones that do not work (CI doesn't run them
either) and ones that won't work on a laptop (translate does sudo
apt-get). No one wants to run all of those to start anyway.

New instructions are focused on the better make test command and
include the right targets and calls to get that running.


**JIRA:**

MST-908

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.