### PR TITLE
fix: Fix bug with user IDs returned by proctoring vendor for learners not enrolled in eligible mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.23.1] - 2021-08-06
+~~~~~~~~~~~~~~~~~~~~~
+* Fixes bug that occurs when a proctoring vendor returns onboarding information that includes user IDs that represent
+  learners that are not returned by the edX API as being enrolled in the course in a proctoring eligible mode.
+* Adds logging statement to enable further investigation.
 
 [3.23.0] - 2021-08-04
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.23.0'
+__version__ = '3.23.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

This pull request fixes a bug that occurs when a proctoring vendor returns onboarding information that includes user IDs that represent learners that are not returned by the edX API as being enrolled in the course in a proctoring eligible mode. It also adds a logging statement to enable further investigation.

**JIRA:**

None.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.