### PR TITLE
Adjusted error location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.23.1] - 2021-08-06
+~~~~~~~~~~~~~~~~~~~~~
+* Update errors on the bulk allowance modal so they show under the associated field.
 
 [3.23.0] - 2021-08-04
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.23.1'
+__version__ = '3.23.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.23.0'
+__version__ = '3.23.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_add_bulk_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_add_bulk_allowance_view.js
@@ -201,7 +201,8 @@ edx = edx || {};
                     },
                     error: function(unused, response) {
                         var data = $.parseJSON(response.responseText);
-                        $errorResponse.html(gettext(data.detail));
+                        var errorField = data.field;
+                        self.showError(self, data.field, data.detail);
                     }
                 });
             }

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_add_bulk_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_add_bulk_allowance_view.js
@@ -201,7 +201,6 @@ edx = edx || {};
                     },
                     error: function(unused, response) {
                         var data = $.parseJSON(response.responseText);
-                        var errorField = data.field;
                         self.showError(self, data.field, data.detail);
                     }
                 });

--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_edit_allowance_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_edit_allowance_view.js
@@ -142,7 +142,7 @@ edx = edx || {};
                     },
                     error: function(unused, response) {
                         var data = $.parseJSON(response.responseText);
-                        $errorResponse.html(gettext(data.detail));
+                        self.showError(self, data.field, data.detail);
                     }
                 });
             }

--- a/edx_proctoring/tests/test_views.py
+++ b/edx_proctoring/tests/test_views.py
@@ -5167,6 +5167,9 @@ class ExamBulkAllowanceView(LoggedInTestCase):
             content_type='application/json'
         )
         self.assertEqual(response.status_code, 400)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_data['detail'], 'Enter a valid positive value number')
+        self.assertEqual(response_data['field'], 'allowance_value')
 
     def test_add_bulk_allowance_all_invalid_data(self):  # pylint: disable=invalid-name
         """

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1563,7 +1563,7 @@ class ExamBulkAllowanceView(ProctoredAPIView):
             if successes == 0:
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
-                    data={"detail": _("Enter a valid username or email")}
+                    data={"detail": _("Enter a valid username or email"), "field": _("user_info")}
                 )
             if failures > 0:
                 return Response(
@@ -1576,7 +1576,7 @@ class ExamBulkAllowanceView(ProctoredAPIView):
         except AllowanceValueNotAllowedException:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"detail": _("Enter a valid positive value number")}
+                data={"detail": _("Enter a valid positive value number"), "field": _("allowance_value")}
                 )
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Changed the way backend errors work so they display on the field they occur to. Screenshots of the updated errors are shown below:
<img width="492" alt="Screen Shot 2021-08-06 at 4 45 06 PM" src="https://user-images.githubusercontent.com/59623984/128569520-824d8473-3ff4-4e50-a50c-ddb38bf0a89a.png">
<img width="490" alt="Screen Shot 2021-08-06 at 4 45 21 PM" src="https://user-images.githubusercontent.com/59623984/128569540-3f951850-19b4-4ee4-a8b2-abafe3f4bb16.png">


**JIRA:**

[MST-948](https://openedx.atlassian.net/browse/MST-948)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.