### PR TITLE
fix: restore verified name waffle flag to proctoring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.24.3] - 2021-09-02
+~~~~~~~~~~~~~~~~~~~~~
+* Get verified name enabled from name affirmation service.
+
 [3.24.2] - 2021-09-01
 ~~~~~~~~~~~~~~~~~~~~~
 * Add exception handler and logging to proctored exam attempt emails. This prevents user errors

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.24.2'
+__version__ = '3.24.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1002,10 +1002,14 @@ def _register_proctored_exam_attempt(user_id, exam_id, exam, attempt_code, revie
 
 def _get_verified_name(user_id, name_affirmation_service):
     """
-    Get the user's verified name if it exists.
+    Get the user's verified name if name affirmation is enabled
+    and one exists.
 
     Returns a verified name object (or None)
     """
+    if not name_affirmation_service.is_verified_name_enabled():
+        return None
+
     verified_name = None
 
     user = USER_MODEL.objects.get(id=user_id)
@@ -1017,7 +1021,7 @@ def _get_verified_name(user_id, name_affirmation_service):
     return verified_name
 
 
-def create_exam_attempt(exam_id, user_id, taking_as_proctored=False, is_verified_name_enabled=False):
+def create_exam_attempt(exam_id, user_id, taking_as_proctored=False):
     """
     Creates an exam attempt for user_id against exam_id. There should only
     be one exam_attempt per user per exam, with one exception described below.
@@ -1079,7 +1083,7 @@ def create_exam_attempt(exam_id, user_id, taking_as_proctored=False, is_verified
 
     if taking_as_proctored:
         verified_name = None
-        if name_affirmation_service and is_verified_name_enabled:
+        if name_affirmation_service:
             verified_name = _get_verified_name(user_id, name_affirmation_service)
         external_id, force_status, full_name, profile_name = _register_proctored_exam_attempt(
             user_id, exam_id, exam, attempt_code, review_policy, verified_name,

--- a/edx_proctoring/tests/test_services.py
+++ b/edx_proctoring/tests/test_services.py
@@ -404,6 +404,11 @@ class MockNameAffirmationService:
     """Mock Name Affirmation Service"""
     def __init__(self):
         self.verified_name = None
+        self.enabled = False
+
+    def is_verified_name_enabled(self):
+        """ Return Mock Enabled Flag"""
+        return self.enabled
 
     def get_verified_name(self, user, is_verified=False):
         """ Return mock VerifiedName """

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.24.2",
+  "version": "3.24.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
This flag was read and passed from the front end but we've removed that. If verified names are in use we still want to pass them to the proctoring when available. So read the waffle flag during the POST.

This is the thing we should actually do to fix the apparently unused code instead of ripping it out like https://github.com/edx/edx-proctoring/pull/948

Edit: "just reading the waffle flag" is more complicated. Name affirmation 0.9.0 exposes the waffle flag for us to prevent cross-library waffle sharing which is not allowed at this brunch.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.