### PR TITLE
fix: add email back for exam registration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.24.1] - 2021-08-30
+~~~~~~~~~~~~~~~~~~~~~
+* Bug fix for exam registration
+
 [3.24.0] - 2021-08-25
 ~~~~~~~~~~~~~~~~~~~~~
 * Re-added code for using a verified name for a proctored exam attempt that had been reverted.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.24.0'
+__version__ = '3.24.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -919,6 +919,7 @@ def _register_proctored_exam_attempt(user_id, exam_id, exam, attempt_code, revie
             profile_name = credit_state['profile_fullname']
             if not verified_name:
                 full_name = profile_name
+            email = credit_state['student_email']
 
     context = {
         'lms_host': lms_host,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
This line was accidentally removed in https://github.com/edx/edx-proctoring/pull/938, need to add email back in.