### PR TITLE
fix: catch except on failed email

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.24.2] - 2021-09-01
+~~~~~~~~~~~~~~~~~~~~~
+* Add exception handler and logging to proctored exam attempt emails. This prevents user errors
+  if the email is not able to be sent.
+
 [3.24.1] - 2021-08-30
 ~~~~~~~~~~~~~~~~~~~~~
 * Bug fix for exam registration

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '3.24.1'
+__version__ = '3.24.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1592,7 +1592,17 @@ def update_attempt_status(attempt_id, to_status,
             exam['course_id']
         )
         if email:
-            email.send()
+            try:
+                email.send()
+            except Exception as err:
+                log.exception(
+                    'Exception occurred while trying to send proctoring attempt '
+                    'status email for user_id={user_id} in course_id={course_id} -- {err}'.format(
+                        user_id=exam_attempt_obj.user_id,
+                        course_id=exam_attempt_obj.proctored_exam.course_id,
+                        err=err,
+                    )
+                )
 
     # emit an anlytics event based on the state transition
     # we re-read this from the database in case fields got updated

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1594,7 +1594,7 @@ def update_attempt_status(attempt_id, to_status,
         if email:
             try:
                 email.send()
-            except Exception as err:
+            except Exception as err:  # pylint: disable=broad-except
                 log.exception(
                     'Exception occurred while trying to send proctoring attempt '
                     'status email for user_id={user_id} in course_id={course_id} -- {err}'.format(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "3.24.1",
+  "version": "3.24.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Wrap email delivery in try/except, we don't want to block exam submission for a failure here.

**JIRA:**

[MST-1030](https://openedx.atlassian.net/browse/MST-1030)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.