### PR TITLE
fix: remove direct handler import in handler test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Handler test refactor
 
 [3.24.4] - 2021-09-02
 ~~~~~~~~~~~~~~~~~~~~~

--- a/edx_proctoring/tests/test_handlers.py
+++ b/edx_proctoring/tests/test_handlers.py
@@ -9,7 +9,6 @@ from httmock import HTTMock
 from django.db.models.signals import pre_delete, pre_save
 
 from edx_proctoring.api import update_attempt_status
-from edx_proctoring.handlers import on_attempt_changed
 from edx_proctoring.models import ProctoredExam, ProctoredExamStudentAttempt
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import MockInstructorService
@@ -34,9 +33,6 @@ class SignalTests(ProctoredExamTestCase):
             proctored_exam=self.proctored_exam, user=self.user, attempt_code='12345',
             external_id='abcde'
         )
-
-        pre_delete.connect(on_attempt_changed, sender=ProctoredExamStudentAttempt)
-        pre_save.connect(on_attempt_changed, sender=ProctoredExamStudentAttempt)
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
without this import the signal/handler test depends on the
load bearing unused import in apps.py and if that is broken fails

with this import, it works even with the apps.py connection is broken

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.