### PR TITLE
fix: if multiple attempts for a user exist, return attempt with non-reset status if possible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.0.1] - 2021-09-21
+~~~~~~~~~~~~~~~~~~~~~
+* Bug fix for student onboarding statuses by course. If learner has multiple attempts, return non-reset attempt status if possible.
+
 [4.0.0] - 2021-08-25
 ~~~~~~~~~~~~~~~~~~~~~
 **BREAKING CHANGES:**

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**
If a user has two or more active attempts, and one of them is has an `onboarding_reset` status, we should never return the `onboarding_reset` attempt if there is a more recently created attempt with a greater `id`. 

If we return an attempt with `onboarding_reset`, even though there are newer attempts, we risk showing incorrect information to the instructors. In this specific bug, if an attempt with an `onboarding_reset` status is considered the most recent (i.e. has a greater modified date than the attempt created after it, which is an edge case), an incorrect status will be shown on the instructor dashboard panel. 

To fix this, we should not return an attempt with an `onboarding_reset` status if there is a more recently created attempt, and instead return the more recently created attempt.

**JIRA:**

[MST-995](https://openedx.atlassian.net/browse/MST-995)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.