### PR TITLE
fix: redact video url from raw data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.1.1] - 2021-10-05
+~~~~~~~~~~~~~~~~~~~~
+* Bug fix to redact video url from raw data in exam review
+
 [4.1.0] - 2021-09-28
 ~~~~~~~~~~~~~~~~~~~~
 * Add GH action for migrations tests.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/tests/test_reviews.py
+++ b/edx_proctoring/tests/test_reviews.py
@@ -145,6 +145,7 @@ class ReviewTests(LoggedInTestCase):
             self.assertTrue(review.encrypted_video_url)
 
             self.assertIsNotNone(review.raw_data)
+            self.assertIsNone(json.loads(review.raw_data).get('videoReviewLink'))
             self.assertIsNone(review.reviewed_by)
 
             # now check the comments that were stored

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -1788,7 +1788,6 @@ class BaseReviewCallback:
         review.review_status = SoftwareSecureReviewStatus.from_standard_status.get(backend_review['status'])
 
         review.attempt_code = attempt_code
-        review.raw_data = json.dumps(data)
         review.student_id = attempt['user']['id']
         review.exam_id = attempt['proctored_exam']['id']
 
@@ -1813,6 +1812,11 @@ class BaseReviewCallback:
             if aes_key_str:
                 aes_key = codecs.decode(aes_key_str, "hex")
                 review.encrypted_video_url = encrypt_and_encode(video_review_link.encode("utf-8"), aes_key)
+
+        # redact the video link from the raw data
+        if 'videoReviewLink' in data:
+            del data['videoReviewLink']
+        review.raw_data = json.dumps(data)
 
         review.save()
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Previously, the video url was deleted when the data dict was modified by the on_review_callback function. I didn't realize that this deletion affected the actual dict being passed in, as opposed to a copy of the dict. The video url should still be deleted after it is encrypted as to avoid saving it in the `raw_data` field.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.