### PR TITLE
[BB-4501] [HMS-730] ask confirmation before ending the exam

### DIFF
--- a/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
+++ b/edx_proctoring/static/proctoring/js/views/proctored_exam_view.js
@@ -124,20 +124,28 @@ edx = edx || {};
                     // Bind a click handler to the exam controls
                     self = this;
                     $('.exam-button-turn-in-exam').click(function() {
-                        $(window).unbind('beforeunload', self.unloadMessage);
+                        // ask learner for confirmation
+                        var confirmed = confirm(
+                            'Did you submit all the problems? You must select "Submit" ' +
+                            'for each problem before you end the exam.'
+                        );
 
-                        $.ajax({
-                            url: '/api/edx_proctoring/v1/proctored_exam/attempt/' + self.model.get('attempt_id'),
-                            type: 'PUT',
-                            data: {
-                                action: 'stop'
-                            },
-                            success: function() {
-                                // change the location of the page to the active exam page
-                                // which will reflect the new state of the attempt
-                                location.href = self.model.get('exam_url_path');
-                            }
-                        });
+                        if (confirmed) {
+                            $(window).unbind('beforeunload', self.unloadMessage);
+
+                            $.ajax({
+                                url: '/api/edx_proctoring/v1/proctored_exam/attempt/' + self.model.get('attempt_id'),
+                                type: 'PUT',
+                                data: {
+                                    action: 'stop'
+                                },
+                                success: function() {
+                                    // change the location of the page to the active exam page
+                                    // which will reflect the new state of the attempt
+                                    location.href = self.model.get('exam_url_path');
+                                }
+                            });
+                        }
                     });
                 } else {
                     // remove callback on scroll event


### PR DESCRIPTION
## Description

This PR adds a confirmation step before ending a timed exam.


## Supporting information

https://tasks.opencraft.com/browse/BB-4501

<img width="1423" alt="Screenshot 2021-10-12 at 8 09 02 AM" src="https://user-images.githubusercontent.com/1010244/136879861-e6e7e620-831f-4a58-bede-1463fb89fbdf.png">

## Testing instructions

1. Pull this PR in `src` directory of your local devstack
2. Open LMS Shell `make lms-shell`
3. Install `edx-proctoring` in LMS `pip install -e /edx/src/edx-proctoring`
4. Create a timed exam - https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/timed_exams.html
5. Go to live exam - change view as a learner instead of staff if you are logged in as super user.
6. Start the exam and use legacy view
7. Click `End My Exam` button
8. Verify a confirmation is shown.

## Deadline
None
