### PR TITLE
fix: add interstitial for timed exams

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.7.1] - 2021-11-16
+~~~~~~~~~~~~~~~~~~~~
+* Assign interstitial to timed exam status
+
 [4.7.0] - 2021-11-08
 ~~~~~~~~~~~~~~~~~~~~
 * Convert onboarding profile API waffle flag to Django setting.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.7.0'
+__version__ = '4.7.1'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -2464,7 +2464,7 @@ def _get_timed_exam_view(exam, context, exam_id, user_id, course_id):
 
     attempt_status = attempt['status'] if attempt else None
     has_due_date = exam['due_date'] is not None
-    if not attempt_status:
+    if not attempt_status or attempt_status == ProctoredExamStudentAttemptStatus.created:
         if is_exam_passed_due(exam, user=user_id):
             student_view_template = 'timed_exam/expired.html'
         else:

--- a/edx_proctoring/tests/test_student_view.py
+++ b/edx_proctoring/tests/test_student_view.py
@@ -1439,6 +1439,27 @@ class ProctoredExamStudentViewTests(ProctoredExamTestCase):
         )
         self.assertIn(expected_content, rendered_response)
 
+    def test_get_studentview_created_timed_exam(self):
+        """
+        Test that get_student_view for a created timed exam returns interstitial
+        """
+        self._create_unstarted_exam_attempt(is_proctored=False)
+
+        rendered_response = get_student_view(
+            user_id=self.user_id,
+            course_id=self.course_id,
+            content_id=self.content_id_timed,
+            context={
+                'display_name': self.exam_name,
+            }
+        )
+        self.assertNotIn(
+            f'data-exam-id="{self.proctored_exam_id}"',
+            rendered_response
+        )
+        self.assertIn(self.timed_exam_msg.format(exam_name=self.exam_name), rendered_response)
+        self.assertNotIn(self.start_an_exam_msg, rendered_response)
+
     def test_expired_exam(self):
         """
         Test that an expired exam shows a difference message when the exam is expired just recently

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

We should assign created exams to an appropriate interstitial

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.