### PR TITLE
[MST-1162] Catch all worker errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.7.3] - 2021-12-06
+~~~~~~~~~~~~~~~~~~~~
+* Catch errors from `onStartExamAttempt` and `onEndExamAttempt`.
+
 [4.7.2] - 2021-11-17
 ~~~~~~~~~~~~~~~~~~~~
 * Add SimpleHistory to proctoring_proctoredexam table

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.7.2'
+__version__ = '4.7.3'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -12,7 +12,7 @@ export const handlerWrapper = (Handler) => {
         if (handler.onStartExamAttempt) {
           handler.onStartExamAttempt()
             .then(() => self.postMessage({ type: 'examAttemptStarted' }))
-            .catch(() => self.postMessage({ type: 'examAttemptStartFailed' }));
+            .catch(error => self.postMessage({ type: 'examAttemptStartFailed', error }));
         }
         break;
       }
@@ -20,7 +20,7 @@ export const handlerWrapper = (Handler) => {
         if (handler.onEndExamAttempt) {
           handler.onEndExamAttempt()
             .then(() => self.postMessage({ type: 'examAttemptEnded' }))
-            .catch(() => self.postMessage({ type: 'examAttemptEndFailed' }));
+            .catch(error => self.postMessage({ type: 'examAttemptEndFailed', error }));
         }
         break;
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
**Description:**

Catch errors from `onStartExamAttempt` and `onEndExamAttempt`.

**JIRA:**

[MST-1162](https://openedx.atlassian.net/browse/MST-1162)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [x] Described your changes in `CHANGELOG.rst`
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.