### PR TITLE
fix: timeout value passed to handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.8.2] - 2021-12-21
+~~~~~~~~~~~~~~~~~~~~
+* Fix timeout value not getting passed to worker handler
+
 [4.8.1] - 2021-12-07
 ~~~~~~~~~~~~~~~~~~~~
 * Remove older exam attempt history table.

--- a/edx_proctoring/__init__.py
+++ b/edx_proctoring/__init__.py
@@ -3,6 +3,6 @@ The exam proctoring subsystem for the Open edX platform.
 """
 
 # Be sure to update the version number in edx_proctoring/package.json
-__version__ = '4.8.1'
+__version__ = '4.8.2'
 
 default_app_config = 'edx_proctoring.apps.EdxProctoringConfig'  # pylint: disable=invalid-name

--- a/edx_proctoring/static/index.js
+++ b/edx_proctoring/static/index.js
@@ -10,7 +10,7 @@ export const handlerWrapper = (Handler) => {
       }
       case 'startExamAttempt': {
         if (handler.onStartExamAttempt) {
-          handler.onStartExamAttempt()
+          handler.onStartExamAttempt(message.data.timeout)
             .then(() => self.postMessage({ type: 'examAttemptStarted' }))
             .catch(error => self.postMessage({ type: 'examAttemptStartFailed', error }));
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edx/edx-proctoring",
   "//": "Note that the version format is slightly different than that of the Python version when using prereleases.",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "main": "edx_proctoring/static/index.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:**

This timeout value represents how long the Proctortrack code is allowed to retry before reporting an error back to the edx courseware/mfe. This interface glues the API call to the Proctortrack code however the timeout value was getting dropped here causing Proctortrack to default to 2 minutes. https://github.com/anupdhabarde/edx-proctoring-proctortrack/blob/master/edx_proctoring_proctortrack/static/proctortrack_custom.js#L27

The learning mfe also needs to be updated to pass along a more appropriate value, PR to follow

**JIRA:**

[MST-1252](https://openedx.atlassian.net/browse/MST-1252)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_proctoring/__init__.py` and `package.json` if these changes are to be released.
- [ ] Described your changes in `CHANGELOG.rst`
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.